### PR TITLE
Fixed gen-new-sighting-with-indicator 

### DIFF
--- a/src/ctim/generators/schemas.clj
+++ b/src/ctim/generators/schemas.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas
   (:require [clojure.test.check.generators :as gen]
+            [ctim.domain.id :as id]
             [ctim.schemas
              [common :refer [Observable]]
              [feedback :refer [Feedback]]
@@ -17,27 +18,14 @@
              [sighting-generators :as sg]
              [ttp-generators :as tg]]))
 
-(def gen-new-indicator-with-new-sightings
-  (gen/fmap
-   (fn [[indicator sightings]]
-     [indicator
-      (map (fn [sighting]
-             (assoc sighting :indicators
-                    [{:indicator_id (:id indicator)}]))
-           sightings)])
-   (gen/tuple ng/gen-new-indicator-with-id
-              (gen/vector sg/gen-new-sighting 1 10))))
-
-(def gen-indicator-with-sightings
-  (gen/fmap
-   (fn [[indicator sightings]]
-     [indicator
-      (map (fn [sighting]
-             (assoc sighting :indicators
-                    [{:indicator_id (:id indicator)}]))
-           sightings)])
-   (gen/tuple ng/gen-indicator
-              (gen/vector sg/gen-sighting 1 10))))
+(defn gen-new-indicator-with-new-sightings [url-params-fn]
+  (gen/let [{id :id :as indicator} ng/gen-new-indicator-with-id
+            sightings (gen/vector
+                       (sg/gen-new-sighting-with-indicator
+                        (id/short-id->long-id id url-params-fn))
+                       1
+                       10)]
+    [indicator sightings]))
 
 (def kw->generator
   {:actor          ag/gen-actor

--- a/src/ctim/generators/schemas/indicator_generators.clj
+++ b/src/ctim/generators/schemas/indicator_generators.clj
@@ -9,13 +9,16 @@
              :as common]
             [ctim.generators.id :as gen-id]))
 
+(def gen-short-id
+  (gen-id/gen-short-id-of-type :indicator))
+
 (def gen-indicator
   (gen/fmap
    (fn [id]
      (complete
       StoredIndicator
       {:id id}))
-   (gen-id/gen-short-id-of-type :indicator)))
+   gen-short-id))
 
 (defn gen-new-indicator_ [gen-id]
   (gen/fmap
@@ -39,8 +42,8 @@
 
 (def gen-new-indicator
   (gen-new-indicator_
-   (maybe (gen-id/gen-short-id-of-type :indicator))))
+   (maybe gen-short-id)))
 
 (def gen-new-indicator-with-id
   (gen-new-indicator_
-   (gen-id/gen-short-id-of-type :indicator)))
+   gen-short-id))

--- a/src/ctim/generators/schemas/sighting_generators.clj
+++ b/src/ctim/generators/schemas/sighting_generators.clj
@@ -17,6 +17,11 @@
    StoredSighting
    m))
 
+(defn complete-new [m]
+  (common/complete
+   NewSighting
+   m))
+
 (def gen-sighting
   (gen/fmap
    (fn [id]
@@ -30,6 +35,14 @@
      (complete
       {:id id
        :observables observables}))
+   gen-short-id))
+
+(defn gen-new-sighting-with-indicator [indicator-long-id]
+  (gen/fmap
+   (fn [id]
+     (complete-new
+      {:id id
+       :indicators [{:indicator_id indicator-long-id}]}))
    gen-short-id))
 
 (def gen-new-sighting

--- a/test/ctim/domain/id_test.clj
+++ b/test/ctim/domain/id_test.clj
@@ -71,3 +71,11 @@
   (is (true?  (id/valid-short-id? "bar-9baa492f-8ac8-463c-b193-f2d3cc429e3d")))
   (is (false? (id/valid-short-id? "9baa492f-8ac8-463c-b193-f2d3cc429e3d")))
   (is (false? (id/valid-short-id? "foo-123-7d24c22a-96e3-40fb-81d3-eae158f0770c"))))
+
+(deftest test-short-id->long-id
+  (is (= "http://ctia.com/bar/ctia/sighting/sighting-1aa088c0-e2af-4ec2-91ee-bbec4f93267c"
+         (id/short-id->long-id "sighting-1aa088c0-e2af-4ec2-91ee-bbec4f93267c"
+                               (constantly
+                                {:protocol "http"
+                                 :hostname "ctia.com"
+                                 :path-prefix "/bar"})))))


### PR DESCRIPTION
So that it generates long IDs in indicator references.

Closes #17 