### PR TITLE
Refactor schema, using a BaseEntity

### DIFF
--- a/doc/data_structures.md
+++ b/doc/data_structures.md
@@ -481,6 +481,7 @@ One of the following structures:
 | --- | --- | --- |
 | description         | (string, ...)                    | &#10003;   |
 | timestamp           | [Time](#time)                    | &#10003;   |
+| observed_time       | [ValidTime](#valid_time)         | &#10003;   |
 | tlp                 | [TLP](#tlp)                      | &#10003;   |
 | version             | string                           | &#10003;   |
 | source              | [Source](#source)                |            |
@@ -488,6 +489,7 @@ One of the following structures:
 | source_device       | [Sensor](#sensor)                |            |
 | reference           | [URI](#uri)                      |            |
 | confidence          | [HighMedLow](#high_med_low)      |            |
+| count               | integer - defaults to 1          |            |
 | observables         | ([Observable](#observable), ...) |            |
 | indicators          | ([RelatedIndicator](#related_indicator), ...) |            |
 | relations           | ([ObservedRelation](#observed_relation), ...) |            |

--- a/project.clj
+++ b/project.clj
@@ -5,23 +5,20 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  ;; what compojure-api 1.0.0 wants
-                 [prismatic/schema "1.0.4"]
+                 [prismatic/schema "1.1.1"]
                  ;; for describe
                  [metosin/ring-swagger "0.22.4"]
                  ;; for merge and such
-                 [metosin/schema-tools "0.7.0"]
+                 [metosin/schema-tools "0.9.0"]
                  ;; for generators
                  [org.clojure/test.check "0.9.0"]
                  [com.gfredericks/test.chuck "0.2.6"]
-                 [prismatic/schema-generators "0.1.0"]]
+                 [prismatic/schema-generators "0.1.0"
+                  :exclusions [prismatic/schema]]]
   :uberjar-name "ctim.jar"
   :resource-paths ["doc"]
   :profiles {:dev {:dependencies [[cheshire "5.5.0"]
-                                  [com.h2database/h2 "1.4.191"]
-                                  [org.clojure/test.check "0.9.0"]
-                                  [com.gfredericks/test.chuck "0.2.6"]
-                                  [prismatic/schema-generators "0.1.0"
-                                   :exclusions [prismatic/schema]]]
+                                  [com.h2database/h2 "1.4.191"]]
                    :resource-paths ["model"
                                     "test/resources"]}
              :test {:dependencies [[cheshire "5.5.0"]

--- a/src/ctim/events/schemas.clj
+++ b/src/ctim/events/schemas.clj
@@ -16,8 +16,7 @@
 (s/defschema CreateEvent
   (st/merge
    ModelEventBase
-   {:type (s/eq CreateEventType)
-    :entity {s/Any s/Any}}))
+   {:type (s/eq CreateEventType)}))
 
 (def UpdateEventType "UpdatedModel")
 
@@ -47,6 +46,9 @@
    {:type (s/eq VerdictChangeEventType)
     :judgement_id s/Str
     :verdict v/Verdict}))
+
+(def event-types
+  ["CreatedModel" "UpdatedModel" "DeletedModel" "VerdictChange"])
 
 (s/defschema Event
   (s/conditional

--- a/src/ctim/generators/events.clj
+++ b/src/ctim/generators/events.clj
@@ -1,0 +1,25 @@
+(ns ctim.generators.events
+  (:require [clojure.test.check.generators :as gen]
+            [ctim.events.schemas :as es]
+            [ctim.generators.common :as c]
+            [ctim.generators.schemas :as gs]))
+
+;; This is a work in progress
+
+(def gen-event-type
+  (gen/elements es/event-types))
+
+(defn gen-event-of-type [event-type]
+  (gen/fmap (fn [entity]
+              (c/complete es/Event
+                          {:entity entity
+                           :type event-type
+                           :id (:id entity)}))
+            (gen/let [entity-type (gen/elements gs/entity-types)
+                      entity (gs/gen-entity entity-type)]
+              entity)))
+
+(def gen-event
+  (gen/let [event-type gen-event-type
+            event      (gen-event-of-type event-type)]
+    event))

--- a/src/ctim/generators/schemas.clj
+++ b/src/ctim/generators/schemas.clj
@@ -51,6 +51,9 @@
    :new-ttp        tg/gen-new-ttp
    :verdict        (generate-entity Verdict)})
 
+(def entity-types [:actor :campaign :coa :exploit-target :feedback :incident
+                   :indicator :judgement :sighting :ttp])
+
 (defn gen-entity [schema-kw]
   (get kw->generator schema-kw))
 

--- a/src/ctim/generators/schemas/feedback_generators.clj
+++ b/src/ctim/generators/schemas/feedback_generators.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test.check.generators :as gen]
             [ctim.lib.time :as time]
             [ctim.schemas
-             [feedback :refer [NewFeedback Feedback]]
+             [feedback :refer [NewFeedback StoredFeedback]]
              [common :as schemas-common]]
             [ctim.generators.common
              :refer [complete leaf-generators maybe]
@@ -13,7 +13,7 @@
   (gen/fmap
    (fn [id]
      (complete
-      Feedback
+      StoredFeedback
       {:id id}))
    (gen-id/gen-short-id-of-type :feedback)))
 

--- a/src/ctim/schemas/actor.clj
+++ b/src/ctim/schemas/actor.clj
@@ -5,16 +5,20 @@
             [schema.core :as s]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "actor"))
+
 (s/defschema Actor
   "http://stixproject.github.io/data-model/1.2/ta/ThreatActorType/"
   (st/merge
-   c/GenericStixIdentifiers
-   {:valid_time c/ValidTime
-    :actor_type v/ThreatActorType
-    :tlp c/TLP}
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :valid_time c/ValidTime
+    :actor_type v/ThreatActorType}
    (st/optional-keys
-    {:source s/Str
-     :identity c/Identity
+    {:identity c/Identity
      :motivation v/Motivation
      :sophistication v/Sophistication
      :intended_effect v/IntendedEffect
@@ -27,18 +31,13 @@
      ;; Not provided: related_packages (deprecated)
      })))
 
-(s/defschema Type
-  (s/enum "actor"))
-
 (s/defschema NewActor
   "Schema for submitting new Actors"
   (st/merge
    Actor
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
+    {:valid_time c/ValidTime})))
 
 (s/defschema StoredActor
   "An actor as stored in the data store"

--- a/src/ctim/schemas/campaign.clj
+++ b/src/ctim/schemas/campaign.clj
@@ -7,19 +7,26 @@
             [schema.core :as s]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "campaign"))
+
+
+
 (s/defschema Campaign
   "See http://stixproject.github.io/data-model/1.2/campaign/CampaignType/"
   (st/merge
-   c/GenericStixIdentifiers
-   {:valid_time (describe
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :valid_time (describe
                  c/ValidTime
                  "timestamp for the definition of a specific version of a Campaign")
     ;; Extension fields:
-    :campaign_type  s/Str
-    :indicators rel/RelatedIndicators
-    :tlp c/TLP}
+    :campaign_type  s/Str}
    (st/optional-keys
     {:names (describe [s/Str] "Names used to identify this Campaign")
+     :indicators rel/RelatedIndicators
      :intended_effect (describe
                        [v/IntendedEffect]
                        (str "characterizes the intended effect of"
@@ -46,24 +53,17 @@
                                 " the characterization of this Campaign"))
      :activity (describe c/Activity
                          "actions taken in regards to this Campaign")
-     :source (describe s/Str "source of this Campaign")
      ;; Not provided: Handling
      ;; Not provided: related_packages (deprecated)
      })))
-
-(s/defschema Type
-  (s/enum "campaign"))
 
 (s/defschema NewCampaign
   "Schema for submitting new Campaigns"
   (st/merge
    Campaign
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
-
+    {:valid_time c/ValidTime})))
 
 (s/defschema StoredCampaign
   "An campaign as stored in the data store"

--- a/src/ctim/schemas/coa.clj
+++ b/src/ctim/schemas/coa.clj
@@ -6,11 +6,15 @@
             [ring.swagger.schema :refer [describe]]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "coa"))
+
 (s/defschema COA
-  (merge
-   c/GenericStixIdentifiers
-   {:valid_time c/ValidTime
-    :tlp c/TLP}
+  (st/merge
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:valid_time c/ValidTime}
    (st/optional-keys
     {:stage (describe
              v/COAStage
@@ -29,7 +33,6 @@
      :efficacy (describe v/HighMedLow
                          (str "effectiveness of this Course Of Action"
                               " in achieving its targeted Objective"))
-     :source (describe s/Str "Source of this Course Of Action")
      :related_COAs (describe
                     rel/RelatedCOAs
                     (str "identifies or characterizes relationships to"
@@ -43,11 +46,9 @@
   "Schema for submitting new COAs"
   (st/merge
    COA
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type (s/enum "COA")
-     :tlp c/TLP})))
+    {:valid_time c/ValidTime})))
 
 (s/defschema StoredCOA
   "An coa as stored in the data store"

--- a/src/ctim/schemas/common.clj
+++ b/src/ctim/schemas/common.clj
@@ -22,6 +22,9 @@
   "Schema definition for all date or timestamp values in GUNDAM."
   s/Inst)
 
+(def Markdown
+  "Markdown text"
+  s/Str)
 
 (s/defschema TLP
   "TLP Stand for Traffic Light Protocol (https://www.us-cert.gov/tlp).
@@ -55,9 +58,10 @@
 
 (s/defschema DescribableEntity
   "These fields for decribable entities"
-  {:title s/Str
-   :description s/Str
-   (s/optional-key :short_description) s/Str})
+  (st/optional-keys
+    {:title s/Str
+     :description Markdown
+     :short_description s/Str}))
 
 (s/defschema SourcedObject
   "An object that must have a source"

--- a/src/ctim/schemas/common.clj
+++ b/src/ctim/schemas/common.clj
@@ -4,7 +4,7 @@
             [ring.swagger.schema :refer [describe]]
             [schema-tools.core :as st]))
 
-(def ctim-schema-version "0.1.3ß")
+(def ctim-schema-version "0.1.4")
 
 (def Reference
   "An entity ID, or a URI referring to a remote one."
@@ -22,12 +22,6 @@
   "Schema definition for all date or timestamp values in GUNDAM."
   s/Inst)
 
-(s/defschema VersionInfo
-  {:base URI
-   :version s/Str
-   :build s/Str
-   :beta s/Bool
-   :supported_features [s/Str]})
 
 (s/defschema TLP
   "TLP Stand for Traffic Light Protocol (https://www.us-cert.gov/tlp).
@@ -37,6 +31,54 @@
 
 (def default-tlp "green")
 
+(s/defschema BaseEntity
+  {;; :id and :idref must be implemented exclusively
+   :id ID
+   :type s/Str
+   :schema_version (describe s/Str "CTIM schema version for this entity")
+   (s/optional-key :uri) URI
+   (s/optional-key :revision) s/Int
+   (s/optional-key :external_ids) [s/Str]
+   (s/optional-key :timestamp) Time
+   (s/optional-key :language) s/Str
+   (s/optional-key :tlp) TLP
+   })
+
+(s/defschema NewBaseEntity
+  "Base for New Entities, optionalizes ID and type and schema_version"
+  (st/merge
+   BaseEntity
+   (st/optional-keys
+    {:id ID
+     :type (describe s/Str "A valid entity type identifer")
+     :schema_version (describe s/Str "CTIM schema version for this entity")})))
+
+(s/defschema DescribableEntity
+  "These fields for decribable entities"
+  {:title s/Str
+   :description s/Str
+   (s/optional-key :short_description) s/Str})
+
+(s/defschema SourcedObject
+  "An object that must have a source"
+  {:source s/Str
+   (s/optional-key :source_uri) URI})
+
+(s/defschema SourcableObject
+  "An object that MAY have a source"
+  {(s/optional-key :source) s/Str
+   (s/optional-key :source_uri) URI})
+
+;; this is CTIA specific, should be moved there
+(s/defschema VersionInfo
+  "Version information for a specific instance of CTIA"
+  {:base URI
+   :version s/Str
+   :build s/Str
+   :beta s/Bool
+   :supported_features [s/Str]})
+
+;; this is CTIA specific, should be moved there
 (s/defschema CTIAFeature
   (s/enum "Judgements"
           "Verdicts"
@@ -56,17 +98,8 @@
           "Snort"
           "OpenIOC"))
 
-(s/defschema MinimalStixIdentifiers
-  {;; :id and :idref must be implemented exclusively
-   :id ID})
 
-(s/defschema GenericStixIdentifiers
-  "These fields are common in STIX data models"
-  (st/merge
-   MinimalStixIdentifiers
-   {:title s/Str
-    :description s/Str
-    (s/optional-key :short_description) s/Str}))
+
 
 (s/defschema Tool
   "See http://stixproject.github.io/data-model/1.2/cyboxCommon/ToolInformationType/"
@@ -129,7 +162,7 @@
   classic 'indicator' which might appear in a data feed of bad IPs, or
   bad Domains."
   {:value s/Str
-   :type v/ObservableType})
+   :type v/ObservableTypeIdentifier})
 
 (s/defschema ValidTime
   "See http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/"
@@ -140,6 +173,16 @@
    (s/optional-key :end_time)
    (describe Time
              "If not present, the valid time position of the indicator does not have an upper bound")})
+
+(s/defschema ObservedTime
+  "See http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/"
+  {:start_time
+   (describe Time
+             "Time of the observation.  If the observation was made over a period of time, than this ield indicated the start of that period")
+   
+   (s/optional-key :end_time)
+   (describe Time
+             "If the observation was made over a period of time, than this field indicates the end of that period")})
 
 ;;Allowed disposition values are:
 (def disposition-map
@@ -167,7 +210,7 @@
 
 ;; ## Relations
 
-(def relations-map
+(def observable-relations-map
   {"Allocated" "Specifies that this object allocated the related object."
    "Allocated_By" "Specifies that this object was allocated by the related object."
    "Bound" "Specifies that this object bound the related object."
@@ -305,22 +348,22 @@
    "Wrote_To" "Specifies that this object wrote to the related object."
    "Created" "Specifies that this object created the related object."})
 
-(s/defschema RelationType
-  (apply s/enum (keys relations-map)))
+(s/defschema ObservableRelationType
+  (apply s/enum (keys observable-relations-map)))
 
-(s/defschema Relation
+(s/defschema ObservableRelation
   {:id s/Num
    :timestamp Time
    :origin s/Str
    (s/optional-key :origin_uri) URI
-   :relation RelationType
+   :relation ObservableRelationType
    (s/optional-key :relation_info) {s/Keyword s/Any}
    :source Observable
    :related Observable})
 
 (s/defschema ObservedRelation
   "A relation inside a Sighting."
-  (dissoc Relation :id :timestamp))
+  (dissoc ObservableRelation :id :timestamp))
 
 ;; ## helper fns used by schemas
 
@@ -341,13 +384,14 @@
                      :judgement judgement}))))
 
 
+(s/defschema BaseStoredEntity
+  {:owner s/Str
+   :created Time
+   (s/optional-key :modified) Time})
+
 
 (defn stored-schema
   "Given a schema X generate a StoredX schema"
   [type-name a-schema]
   (st/merge a-schema
-            {:type (s/enum type-name)
-             :owner s/Str
-             :created Time
-             :modified Time
-             :version (describe s/Str "CTIM schema version for this entity")}))
+            BaseStoredEntity))

--- a/src/ctim/schemas/exploit_target.clj
+++ b/src/ctim/schemas/exploit_target.clj
@@ -70,6 +70,7 @@
   (st/merge
    c/BaseEntity
    c/SourcableObject
+   c/DescribableEntity
    {:type TypeIdentifier
     :valid_time c/ValidTime}
    (st/optional-keys

--- a/src/ctim/schemas/exploit_target.clj
+++ b/src/ctim/schemas/exploit_target.clj
@@ -6,6 +6,9 @@
             [ring.swagger.schema :refer [describe]]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "exploit-target"))
+
 (s/defschema Vulnerability
   "See http://stixproject.github.io/data-model/1.2/et/VulnerabilityType/"
   (st/merge
@@ -65,9 +68,10 @@
 (s/defschema ExploitTarget
   "See http://stixproject.github.io/data-model/1.2/et/ExploitTargetType/"
   (st/merge
-   c/GenericStixIdentifiers
-   {:valid_time c/ValidTime
-    :tlp c/TLP}
+   c/BaseEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :valid_time c/ValidTime}
    (st/optional-keys
     {:vulnerability (describe
                      [Vulnerability]
@@ -85,7 +89,6 @@
                       rel/RelatedCOAs
                       (str "identifies and characterizes a Configuration as"
                            " a potential Exploit Target"))
-     :source (describe s/Str "ExploitTarget source")
      :related_exploit_targets (describe
                                rel/RelatedExploitTargets
                                (str "identifies and characterizes a Configuration"
@@ -94,18 +97,13 @@
      ;; Not provided: handling
      })))
 
-(s/defschema Type
-  (s/enum "exploit-target"))
-
 (s/defschema NewExploitTarget
   "Schema for submitting ExploitTargets"
   (st/merge
    ExploitTarget
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
+    {:valid_time c/ValidTime})))
 
 (s/defschema StoredExploitTarget
   "An exploit-target as stored in the data store"

--- a/src/ctim/schemas/feedback.clj
+++ b/src/ctim/schemas/feedback.clj
@@ -4,32 +4,28 @@
             [schema.core :as s]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "feedback"))
+
 (s/defschema Feedback
   "Feedback on any entity.  Is it wrong?  If so why?  Was
   it right-on, and worthy of confirmation?"
-  {:id c/ID
-   :entity_id c/Reference
-   (s/optional-key :source) s/Str
-   :feedback (s/enum -1 0 1)
-   :reason s/Str
-   :tlp c/TLP})
+  (st/merge
+   c/BaseEntity
+   c/SourcableObject
+   {:entity_id c/Reference
+    :feedback (s/enum -1 0 1)
+    :reason s/Str}))
 
-(s/defschema Type
-  (s/enum "feedback"))
 
 (s/defschema NewFeedback
   "Schema for submitting new Feedback"
   (st/merge
    Feedback
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :type Type
-     :tlp c/TLP})))
+    {:type TypeIdentifier})))
 
 (s/defschema StoredFeedback
   "A feedback record at rest in the storage service"
-  (st/merge Feedback
-            {:type Type
-             :owner s/Str
-             :created c/Time
-             :version s/Str}))
+  (c/stored-schema "feedback" Feedback))

--- a/src/ctim/schemas/incident.clj
+++ b/src/ctim/schemas/incident.clj
@@ -182,17 +182,24 @@
                          " during the handling of the Incident")) ;; simplified
     }))
 
+
+(s/defschema TypeIdentifier
+  (s/enum "incident"))
+
+
 (s/defschema Incident
   "See http://stixproject.github.io/data-model/1.2/incident/IncidentType/"
   (st/merge
-   c/GenericStixIdentifiers
-   {:valid_time (describe
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :valid_time (describe
                  c/ValidTime
                  "timestamp for the definition of a specific version of an Incident")
     :confidence (describe
                  v/HighMedLow
-                 "level of confidence held in the characterization of this Incident")
-    :tlp c/TLP}
+                 "level of confidence held in the characterization of this Incident")}
    (st/optional-keys
     {:status (describe v/Status "current status of the incident")
      :incident_time (describe
@@ -214,7 +221,6 @@
      :impact_assessment (describe
                          ImpactAssessment
                          "a summary assessment of impact for this cyber threat Incident")
-     :source s/Str
      :security_compromise (describe
                            v/SecurityCompromise
                            (str "knowledge of whether the Incident involved a"
@@ -270,17 +276,13 @@
      ;; Not provided: related_packages (deprecated)
      })))
 
-(s/defschema Type
-  (s/enum "incident"))
-
 (s/defschema NewIncident
   (st/merge
    Incident
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
+    {:valid_time c/ValidTime
+     :type TypeIdentifier})))
 
 
 (s/defschema StoredIncident

--- a/src/ctim/schemas/indicator.clj
+++ b/src/ctim/schemas/indicator.clj
@@ -43,12 +43,17 @@
   {:operator (s/enum "and" "or" "not")
    :indicator_ids [rel/IndicatorReference]})
 
+(s/defschema TypeIdentifier
+  (s/enum "indicator"))
+
 (s/defschema Indicator
   "See http://stixproject.github.io/data-model/1.2/indicator/IndicatorType/"
   (st/merge
-   c/GenericStixIdentifiers
-   {:valid_time c/ValidTime
-    :tlp c/TLP}
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :valid_time c/ValidTime}
    (st/optional-keys
     {:alternate_ids (describe [s/Str] "alternative identifier (or alias)")
      :negate (describe s/Bool "specifies the absence of the pattern")
@@ -85,7 +90,6 @@
                        (str "Test Mechanisms effective at identifying the cyber"
                             " Observables specified in this"
                             " cyber threat Indicator")) ;; simplified
-     :source (describe s/Str "source of this Indicator")
      })
    ;; Extension fields:
    {:producer s/Str ;; TODO - Document what is supposed to be in this field!
@@ -99,17 +103,14 @@
     ;; Not provided: handling
     }))
 
-(s/defschema Type
-  (s/enum "indicator"))
 
 (s/defschema NewIndicator
   (st/merge
    Indicator
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
+    {:valid_time c/ValidTime
+     :type TypeIdentifier})))
 
 (s/defschema StoredIndicator
   "An indicator as stored in the data store"

--- a/src/ctim/schemas/judgement.clj
+++ b/src/ctim/schemas/judgement.clj
@@ -15,6 +15,9 @@
   priority of 100, so that humans can always override machines."
   s/Int)
 
+(s/defschema TypeIdentifier
+  (s/enum "judgement"))
+
 (s/defschema Judgement
   "A judgement about the intent or nature of an Observable.  For
   example, is it malicious, meaning is is malware and subverts system
@@ -22,41 +25,32 @@
   trusted source.  It could also be common, something so widespread
   that it's not likely to be malicious."
   (st/merge
-   {:id c/ID
+   c/BaseEntity
+   c/SourcedObject
+   {:type TypeIdentifier
     :observable c/Observable
     :disposition c/DispositionNumber
     :disposition_name c/DispositionName
-    :source s/Str
     :priority Priority
     :confidence v/HighMedLow
     :severity Severity
-    :valid_time c/ValidTime
-    :tlp c/TLP}
+    :valid_time c/ValidTime}
    (st/optional-keys
     {:reason s/Str
-     :source_uri c/URI
      :reason_uri c/URI
      :indicators rel/RelatedIndicators})))
-
-(s/defschema Type
-  (s/enum "judgement"))
 
 (s/defschema NewJudgement
   "Schema for submitting new Judgements."
   (st/merge
    Judgement
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :disposition c/DispositionNumber
+    {:disposition c/DispositionNumber
      :disposition_name c/DispositionName
      :valid_time c/ValidTime
-     :type Type
-     :tlp c/TLP})))
+     :type TypeIdentifier})))
 
 (s/defschema StoredJudgement
   "A judgement as stored in the data store"
-  (st/merge Judgement
-            {:type Type
-             :owner s/Str
-             :created c/Time
-             :version s/Str}))
+  (c/stored-schema "judgement" Judgement))

--- a/src/ctim/schemas/sighting.clj
+++ b/src/ctim/schemas/sighting.clj
@@ -21,6 +21,7 @@
   (st/merge
    c/BaseEntity
    c/SourcableObject
+   c/DescribableEntity
    {:type TypeIdentifier
     :observed_time c/ObservedTime
     :confidence v/HighMedLow

--- a/src/ctim/schemas/sighting.clj
+++ b/src/ctim/schemas/sighting.clj
@@ -5,6 +5,9 @@
             [schema.core :as s]
             [schema-tools.core :as st]))
 
+(s/defschema TypeIdentifier
+  (s/enum "sighting"))
+
 (s/defschema Sighting
   "See http://stixproject.github.io/data-model/1.2/indicator/SightingType/"
   ;; Using s/pred break generative testing
@@ -16,22 +19,17 @@
   ;; --  #(not (and (empty? (:observables %))
   ;; --             (empty? (:indicators %)))))
   (st/merge
-   {:id c/ID
-    :timestamp c/Time
-    :description s/Str
-    ;; wether this Sighting is intended to be shared, replicated, copied...
-    ;; TLPValue is an enum "red", "yellow", "green", "white"  default green.
-    :tlp c/TLP}
+   c/BaseEntity
+   c/SourcableObject
+   {:type TypeIdentifier
+    :observed_time c/ObservedTime
+    :confidence v/HighMedLow
+    ;; how many times was it see
+    :count s/Int}
    (st/optional-keys
-    {:source s/Str
-     ;; if we have a source, we should have a source URI for more details
-     :source_uri c/URI
-     ;; The openC2 Actuator name that best fits the device that is
+    {;; The openC2 Actuator name that best fits the device that is
      ;; creating this sighting
-     :source_device v/Sensor ;; eg. "network.firewall"
-     ;; link to some random object
-     :reference c/URI
-     :confidence v/HighMedLow
+     :sensor v/Sensor ;; eg. "network.firewall"
      ;; The object(s) of interest.
      :observables [c/Observable]
      ;; the indicators we think we are seeing
@@ -42,16 +40,14 @@
      :relations [c/ObservedRelation]
      :incidents [rel/RelatedIncidents]})))
 
-(s/defschema Type
-  (s/enum "sighting"))
 
 (s/defschema NewSighting
   (st/merge
    Sighting
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :type Type
-     :tlp c/TLP})))
+    {:count s/Int
+     :confidence v/HighMedLow})))
 
 (s/defschema StoredSighting
   "A sighting as stored in the data store"

--- a/src/ctim/schemas/ttp.clj
+++ b/src/ctim/schemas/ttp.clj
@@ -70,11 +70,16 @@
                                     "a type of information that is targeted")
     :targeted_observables (describe [c/Observable] "targeted observables")})) ;; Was targeted_technical_details
 
+(s/defschema TypeIdentifier
+  (s/enum "ttp"))
+
 (s/defschema TTP
   "See http://stixproject.github.io/data-model/1.2/ttp/TTPType/"
   (merge
-   c/GenericStixIdentifiers
-   {:tlp c/TLP
+   c/BaseEntity
+   c/DescribableEntity
+   c/SourcableObject
+   {:type TypeIdentifier
     :valid_time (describe
                  c/ValidTime
                  "a timestamp for the definition of a specific version of a TTP item")}
@@ -114,11 +119,10 @@
 (s/defschema NewTTP
   (st/merge
    TTP
+   c/NewBaseEntity
    (st/optional-keys
-    {:id c/ID
-     :valid_time c/ValidTime
-     :type (s/enum "ttp")
-     :tlp c/TLP})))
+    {:type TypeIdentifier
+     :valid_time c/ValidTime})))
 
 (s/defschema StoredTTP
   "An ttp as stored in the data store"

--- a/src/ctim/schemas/verdict.clj
+++ b/src/ctim/schemas/verdict.clj
@@ -13,6 +13,9 @@ which have not yet expired.  The highest priority Judgement becomes
 the active verdict.  If there is more than one Judgement with that
 priority, then Clean disposition has priority over all others, then
 Malicious disposition, and so on down to Unknown.
+
+The ID of a verdict is a a str of the form
+\"observable.type:observable.value\" for example, \"ip:1.1.1.1\"
 "
   {:type Type
    :disposition c/DispositionNumber
@@ -22,9 +25,4 @@ Malicious disposition, and so on down to Unknown.
 
 (s/defschema StoredVerdict
   "A Verdict as stored in the data store"
-  (st/merge Verdict
-            {:id s/Str
-             :type Type
-             :owner s/Str
-             :created c/Time
-             :version s/Str}))
+  (c/stored-schema "verdict" Verdict))

--- a/src/ctim/schemas/verdict.clj
+++ b/src/ctim/schemas/verdict.clj
@@ -4,7 +4,7 @@
             [schema.core :as s]
             [schema-tools.core :as st]))
 
-(s/defschema Type
+(s/defschema TypeIdentifier
   (s/enum "verdict"))
 
 (s/defschema Verdict
@@ -17,7 +17,7 @@ Malicious disposition, and so on down to Unknown.
 The ID of a verdict is a a str of the form
 \"observable.type:observable.value\" for example, \"ip:1.1.1.1\"
 "
-  {:type Type
+  {:type TypeIdentifier
    :disposition c/DispositionNumber
    :observable c/Observable
    (s/optional-key :judgement_id) rel/JudgementReference
@@ -25,4 +25,9 @@ The ID of a verdict is a a str of the form
 
 (s/defschema StoredVerdict
   "A Verdict as stored in the data store"
-  (c/stored-schema "verdict" Verdict))
+  (st/merge
+   Verdict
+   {:id c/ID
+    :created c/Time
+    :schema_version s/Str
+    (s/optional-key :modified) c/Time}))

--- a/src/ctim/schemas/vocabularies.clj
+++ b/src/ctim/schemas/vocabularies.clj
@@ -255,7 +255,7 @@
           "Opportunistic"
           "Political"))
 
-(s/defschema ObservableType
+(s/defschema ObservableTypeIdentifier
   "Observable type names"
   (s/enum "ip"
           "ipv6"


### PR DESCRIPTION
The major changes of this PR are:

1. All entities derive from  BaseEntity
2. We define SourcableObject and SourcedObject mixins for objects with optional, or required source/source_uri fields.
3. We define DescribableEntity for entities which can have a title, and descriptions.
4. Refactor code to use these entities

BaseEntity is defined as:

````
   :id ID
   :type s/Str
   :schema_version (describe s/Str "CTIM schema version for this entity")
   (s/optional-key :uri) URI
   (s/optional-key :revision) s/Int
   (s/optional-key :external_ids) [s/Str]
   (s/optional-key :timestamp) Time
   (s/optional-key :language) s/Str
   (s/optional-key :tlp) TLP
````

This add the following new keys:

* URI - optional full URI referring to this object
* revision - an interger 0-N that is iterated each time the object is edited
* timestamp - a timetap for when the object was last touched, used to resolve conflicts.  This is NOT the same as the created/modified fields in the Stored version o the entity, which are imlementation specific.
* external_ids - a list of opaque strings which are identifiers o this object in other systems.  Intended to be used by other system maintaining mirrors of their data in an instance of CTIA
* langage - a string identifier for what human language the text in this object is written in.  Default is english.
* tlp - Traffic Light protocol indicating the sharing rules for this data
