### PR TITLE
schema generators now output entities with all their optional keys

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/ctim "0.1.5-SNAPSHOT"
+(defproject threatgrid/ctim "0.1.5"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatbrain/ctim"
   :license {:name "Eclipse Public License"

--- a/src/ctim/generators/common.clj
+++ b/src/ctim/generators/common.clj
@@ -1,8 +1,9 @@
 (ns ctim.generators.common
   (:require [clojure.test.check.generators :as gen]
             [ctim.lib.time :as time]
-            [schema.experimental.complete :as sec]
-            [schema.experimental.generators :as seg]))
+            [schema-generators.complete :as sec]
+            [schema-generators.generators :as seg]
+            [schema.core :as s]))
 
 (defn maybe [gen]
   (gen/frequency [[1 (gen/return nil)]
@@ -19,10 +20,8 @@
                                     (gen/choose 97 122)))
 
 (def leaf-generators
-  {java.util.Date
-   ;; very simplistic randomized date
-   (gen/fmap #(time/plus-n-weeks (time/now) %)
-             gen/int)})
+  {java.util.Date (gen/fmap #(time/plus-n-weeks (time/now) %)
+                            gen/int)})
 
 (defn generate-entity [schema]
   (seg/generator schema leaf-generators))
@@ -31,7 +30,5 @@
   (sec/complete m schema {} leaf-generators))
 
 (def gen-valid-time-tuple
-  (gen/tuple (maybe (gen/fmap time/format-date-time
-                              (get leaf-generators java.util.Date)))
-             (maybe (gen/fmap time/format-date-time
-                              (get leaf-generators java.util.Date)))))
+  (gen/tuple (maybe (get leaf-generators s/Inst))
+             (maybe (get leaf-generators s/Inst))))

--- a/src/ctim/generators/schemas/actor_generators.clj
+++ b/src/ctim/generators/schemas/actor_generators.clj
@@ -13,7 +13,7 @@
 (def gen-actor
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredActor)
               (gen-id/gen-short-id-of-type :actor))))
 

--- a/src/ctim/generators/schemas/campaign_generators.clj
+++ b/src/ctim/generators/schemas/campaign_generators.clj
@@ -13,7 +13,7 @@
 (def gen-campaign
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredCampaign) (gen-id/gen-short-id-of-type :campaign))))
 
 (def gen-new-campaign

--- a/src/ctim/generators/schemas/coa_generators.clj
+++ b/src/ctim/generators/schemas/coa_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.coa-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [coa :refer [NewCOA StoredCOA]]
@@ -11,28 +12,20 @@
 
 (def gen-coa
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredCOA
-      {:id id}))
-   (gen-id/gen-short-id-of-type :coa)))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredCOA)
+              (gen-id/gen-short-id-of-type :coa))))
 
 (def gen-new-coa
   (gen/fmap
-   (fn [[id
-         [start-time end-time]]]
-     (complete
-      NewCOA
-      (cond-> {}
-        id
-        (assoc :id id)
-
-        start-time
-        (assoc-in [:valid_time :start_time] start-time)
-
-        end-time
-        (assoc-in [:valid_time :end_time] end-time))))
+   (fn [[s id [start-time end-time]]]
+     (cond-> (dissoc s :id :valid_time :type)
+       id (assoc :id id)
+       start-time (assoc-in [:valid_time :start_time] start-time)
+       end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
+    (seg/generator NewCOA)
     (maybe (gen-id/gen-short-id-of-type :coa))
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))

--- a/src/ctim/generators/schemas/coa_generators.clj
+++ b/src/ctim/generators/schemas/coa_generators.clj
@@ -13,7 +13,7 @@
 (def gen-coa
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredCOA)
               (gen-id/gen-short-id-of-type :coa))))
 

--- a/src/ctim/generators/schemas/exploit_target_generators.clj
+++ b/src/ctim/generators/schemas/exploit_target_generators.clj
@@ -13,7 +13,7 @@
 (def gen-exploit-target
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredExploitTarget)
               (gen-id/gen-short-id-of-type :exploit-target))))
 

--- a/src/ctim/generators/schemas/exploit_target_generators.clj
+++ b/src/ctim/generators/schemas/exploit_target_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.exploit-target-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [exploit-target :refer [NewExploitTarget StoredExploitTarget]]
@@ -11,28 +12,20 @@
 
 (def gen-exploit-target
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredExploitTarget
-      {:id id}))
-   (gen-id/gen-short-id-of-type :exploit-target)))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredExploitTarget)
+              (gen-id/gen-short-id-of-type :exploit-target))))
 
 (def gen-new-exploit-target
   (gen/fmap
-   (fn [[id
-         [start-time end-time]]]
-     (complete
-      NewExploitTarget
-      (cond-> {}
-        id
-        (assoc :id id)
-
-        start-time
-        (assoc-in [:valid_time :start_time] start-time)
-
-        end-time
-        (assoc-in [:valid_time :end_time] end-time))))
+   (fn [[s id [start-time end-time]]]
+     (cond-> (dissoc s :id :valid_time)
+       id (assoc :id id)
+       start-time (assoc-in [:valid_time :start_time] start-time)
+       end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
+    (seg/generator NewExploitTarget)
     (maybe (gen-id/gen-short-id-of-type :exploit-target))
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))

--- a/src/ctim/generators/schemas/feedback_generators.clj
+++ b/src/ctim/generators/schemas/feedback_generators.clj
@@ -13,7 +13,7 @@
 (def gen-feedback
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredFeedback)
               (gen-id/gen-short-id-of-type :feedback))))
 

--- a/src/ctim/generators/schemas/feedback_generators.clj
+++ b/src/ctim/generators/schemas/feedback_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.feedback-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [feedback :refer [NewFeedback StoredFeedback]]
@@ -11,20 +12,18 @@
 
 (def gen-feedback
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredFeedback
-      {:id id}))
-   (gen-id/gen-short-id-of-type :feedback)))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredFeedback)
+              (gen-id/gen-short-id-of-type :feedback))))
 
 (def gen-new-feedback
   (gen/fmap
-   (fn [[id entity-id]]
-     (complete
-      NewFeedback
-      (cond-> {}
-        id (assoc :id id)
-        entity-id (assoc :entity_id entity-id))))
+   (fn [[s id e-id [start-time end-time]]]
+     (cond-> (dissoc s :id :judgement_id)
+       id (assoc :id id)
+       e-id (assoc :entity_id e-id)))
    (gen/tuple
+    (seg/generator NewFeedback)
     (gen-id/gen-short-id-of-type :feedback)
     (gen-id/gen-short-id-of-type :judgement))))

--- a/src/ctim/generators/schemas/incident_generators.clj
+++ b/src/ctim/generators/schemas/incident_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.incident-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [common :as schemas-common]
@@ -11,28 +12,23 @@
 
 (def gen-incident
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredIncident
-      {:id id}))
-   (gen-id/gen-short-id-of-type :incident)))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredIncident)
+              (gen-id/gen-short-id-of-type :incident))))
+
 
 (def gen-new-incident
   (gen/fmap
-   (fn [[id
-         [start-time end-time]]]
-     (complete
-      NewIncident
-      (cond-> {}
-        id
-        (assoc :id id)
-
-        start-time
-        (assoc-in [:valid_time :start_time] start-time)
-
-        end-time
-        (assoc-in [:valid_time :end_time] end-time))))
+   (fn [[s id [start-time end-time]]]
+     (cond-> (dissoc s :id :valid_time)
+       id (assoc :id id)
+       start-time (assoc-in [:valid_time :start_time] start-time)
+       end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
+    (seg/generator NewIncident)
     (maybe (gen-id/gen-short-id-of-type :incident))
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))
+
+

--- a/src/ctim/generators/schemas/incident_generators.clj
+++ b/src/ctim/generators/schemas/incident_generators.clj
@@ -13,7 +13,7 @@
 (def gen-incident
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredIncident)
               (gen-id/gen-short-id-of-type :incident))))
 

--- a/src/ctim/generators/schemas/indicator_generators.clj
+++ b/src/ctim/generators/schemas/indicator_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.indicator-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [common :as schemas-common]
@@ -14,28 +15,20 @@
 
 (def gen-indicator
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredIndicator
-      {:id id}))
-   gen-short-id))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredIndicator)
+              gen-short-id)))
 
 (defn gen-new-indicator_ [gen-id]
   (gen/fmap
-   (fn [[id
-         [start-time end-time]]]
-     (complete
-      NewIndicator
-      (cond-> {}
-        id
-        (assoc :id id)
-
-        start-time
-        (assoc-in [:valid_time :start_time] start-time)
-
-        end-time
-        (assoc-in [:valid_time :end_time] end-time))))
+   (fn [[s id [start-time end-time]]]
+     (cond-> (dissoc s :id :valid_time)
+       id (assoc :id id)
+       start-time (assoc-in [:valid_time :start_time] start-time)
+       end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
+    (seg/generator NewIndicator)
     gen-id
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))

--- a/src/ctim/generators/schemas/indicator_generators.clj
+++ b/src/ctim/generators/schemas/indicator_generators.clj
@@ -16,7 +16,7 @@
 (def gen-indicator
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredIndicator)
               gen-short-id)))
 

--- a/src/ctim/generators/schemas/judgement_generators.clj
+++ b/src/ctim/generators/schemas/judgement_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.judgement-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [common :as schemas-common]
@@ -11,40 +12,31 @@
 
 (def gen-judgement
   (gen/fmap
-   (fn [[id disp]]
-     (complete
-      StoredJudgement
-      {:id id
-       :disposition disp
-       :disposition_name (get schemas-common/disposition-map disp)}))
-   (gen/tuple
-    (gen-id/gen-short-id-of-type :judgement)
-    (gen/choose 1 5))))
+   (fn [[s id disp]]
+     (into s {:id id
+              :disposition disp
+              :disposition_name (get schemas-common/disposition-map disp)}))
+   (gen/tuple (seg/generator StoredJudgement leaf-generators)
+              (gen-id/gen-short-id-of-type :judgement)
+              (gen/choose 1 5))))
 
 (defn gen-new-judgement_ [gen-id]
   (gen/fmap
-   (fn [[id
-        [disp-num disp-num? disp-name?]
-        [start-time end-time]]]
-     (complete
-      NewJudgement
-      (cond-> {}
-        id
-        (assoc :id id)
+   (fn [[s id [disp-num disp-num? disp-name?] [start-time end-time]]]
+     (cond-> (dissoc s :id :disposition :disposition_name :valid_time)
+       id (assoc :id id)
 
-        disp-num?
-        (assoc :disposition disp-num)
+       disp-num?
+       (assoc :disposition disp-num)
 
-        disp-name?
-        (assoc :disposition_name
-               (get schemas-common/disposition-map disp-num))
+       disp-name?
+       (assoc :disposition_name
+              (get schemas-common/disposition-map disp-num))
 
-        start-time
-        (assoc-in [:valid_time :start_time] start-time)
-
-        end-time
-        (assoc-in [:valid_time :end_time] end-time))))
+       start-time (assoc-in [:valid_time :start_time] start-time)
+       end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
+    (seg/generator NewJudgement leaf-generators)
     gen-id
     (gen/tuple (gen/choose 1 5)
                gen/boolean

--- a/src/ctim/generators/schemas/judgement_generators.clj
+++ b/src/ctim/generators/schemas/judgement_generators.clj
@@ -13,9 +13,10 @@
 (def gen-judgement
   (gen/fmap
    (fn [[s id disp]]
-     (into s {:id id
-              :disposition disp
-              :disposition_name (get schemas-common/disposition-map disp)}))
+     (assoc s
+            :id id
+            :disposition disp
+            :disposition_name (get schemas-common/disposition-map disp)))
    (gen/tuple (seg/generator StoredJudgement leaf-generators)
               (gen-id/gen-short-id-of-type :judgement)
               (gen/choose 1 5))))

--- a/src/ctim/generators/schemas/sighting_generators.clj
+++ b/src/ctim/generators/schemas/sighting_generators.clj
@@ -16,7 +16,7 @@
 (def gen-sighting
   (gen/fmap
    (fn [[s id]]
-     (into (dissoc s :relations) {:id id}))
+     (assoc (dissoc s :relations) :id id))
    (gen/tuple (seg/generator StoredSighting leaf-generators)
               gen-short-id)))
 

--- a/src/ctim/generators/schemas/sighting_generators.clj
+++ b/src/ctim/generators/schemas/sighting_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.sighting-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [common :as schemas-common]
@@ -12,44 +13,38 @@
 (def gen-short-id
   (gen-id/gen-short-id-of-type :sighting))
 
-(defn complete [m]
-  (common/complete
-   StoredSighting
-   m))
-
-(defn complete-new [m]
-  (common/complete
-   NewSighting
-   m))
-
 (def gen-sighting
   (gen/fmap
-   (fn [id]
-     (complete
-      {:id id}))
-   gen-short-id))
+   (fn [[s id]]
+     (into (dissoc s :relations) {:id id}))
+   (gen/tuple (seg/generator StoredSighting leaf-generators)
+              gen-short-id)))
 
 (defn gen-sighting-with-observables [observables]
   (gen/fmap
-   (fn [id]
-     (complete
-      {:id id
-       :observables observables}))
-   gen-short-id))
+   (fn [[s id]]
+     (into (dissoc s :relations) {:id id
+                                  :observables observables}))
+   (gen/tuple (seg/generator StoredSighting leaf-generators)
+              gen-short-id)))
 
 (defn gen-new-sighting-with-indicator [indicator-long-id]
   (gen/fmap
-   (fn [id]
-     (complete-new
-      {:id id
-       :indicators [{:indicator_id indicator-long-id}]}))
-   gen-short-id))
+   (fn [[s id]]
+     (into (dissoc s :relations)
+           {:id id
+            :indicators [{:indicator_id indicator-long-id}]}))
+   (gen/tuple (seg/generator NewSighting leaf-generators)
+              gen-short-id)))
 
 (def gen-new-sighting
   (gen/fmap
-   (fn [id]
-     (common/complete
-      NewSighting
-      (cond-> {}
-        id (assoc :id id))))
-   (maybe gen-short-id)))
+   (fn [[s id]]
+     (if id
+       (assoc s :id id)
+       (dissoc s :id)))
+   (gen/tuple
+    (seg/generator NewSighting)
+    (maybe gen-short-id))))
+
+

--- a/src/ctim/generators/schemas/sighting_generators.clj
+++ b/src/ctim/generators/schemas/sighting_generators.clj
@@ -23,17 +23,18 @@
 (defn gen-sighting-with-observables [observables]
   (gen/fmap
    (fn [[s id]]
-     (into (dissoc s :relations) {:id id
-                                  :observables observables}))
+     (assoc (dissoc s :relations)
+            :id id
+            :observables observables))
    (gen/tuple (seg/generator StoredSighting leaf-generators)
               gen-short-id)))
 
 (defn gen-new-sighting-with-indicator [indicator-long-id]
   (gen/fmap
    (fn [[s id]]
-     (into (dissoc s :relations)
-           {:id id
-            :indicators [{:indicator_id indicator-long-id}]}))
+     (assoc (dissoc s :relations)
+            :id id
+            :indicators [{:indicator_id indicator-long-id}]))
    (gen/tuple (seg/generator NewSighting leaf-generators)
               gen-short-id)))
 

--- a/src/ctim/generators/schemas/ttp_generators.clj
+++ b/src/ctim/generators/schemas/ttp_generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.generators.schemas.ttp-generators
   (:require [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
             [ctim.lib.time :as time]
             [ctim.schemas
              [common :as schemas-common]
@@ -11,17 +12,16 @@
 
 (def gen-ttp
   (gen/fmap
-   (fn [id]
-     (complete
-      StoredTTP
-      {:id id}))
-   (gen-id/gen-short-id-of-type :ttp)))
+   (fn [[s id]]
+     (into s {:id id}))
+   (gen/tuple (seg/generator StoredTTP)
+              (gen-id/gen-short-id-of-type :ttp))))
 
 (def gen-new-ttp
   (gen/fmap
-   (fn [id]
-     (complete
-      NewTTP
-      (cond-> {}
-        id (assoc :id id))))
-   (maybe (gen-id/gen-short-id-of-type :ttp))))
+   (fn [[s id]]
+     (cond-> (dissoc s :id)
+       id (assoc :id id)))
+   (gen/tuple
+    (seg/generator NewTTP)
+    (gen-id/gen-short-id-of-type :ttp))))

--- a/src/ctim/generators/schemas/ttp_generators.clj
+++ b/src/ctim/generators/schemas/ttp_generators.clj
@@ -13,7 +13,7 @@
 (def gen-ttp
   (gen/fmap
    (fn [[s id]]
-     (into s {:id id}))
+     (assoc s :id id))
    (gen/tuple (seg/generator StoredTTP)
               (gen-id/gen-short-id-of-type :ttp))))
 

--- a/src/ctim/schemas/actor.clj
+++ b/src/ctim/schemas/actor.clj
@@ -37,7 +37,8 @@
    Actor
    c/NewBaseEntity
    (st/optional-keys
-    {:valid_time c/ValidTime})))
+    {:type TypeIdentifier
+     :valid_time c/ValidTime})))
 
 (s/defschema StoredActor
   "An actor as stored in the data store"

--- a/src/ctim/schemas/campaign.clj
+++ b/src/ctim/schemas/campaign.clj
@@ -10,8 +10,6 @@
 (s/defschema TypeIdentifier
   (s/enum "campaign"))
 
-
-
 (s/defschema Campaign
   "See http://stixproject.github.io/data-model/1.2/campaign/CampaignType/"
   (st/merge
@@ -63,7 +61,8 @@
    Campaign
    c/NewBaseEntity
    (st/optional-keys
-    {:valid_time c/ValidTime})))
+    {:type TypeIdentifier
+     :valid_time c/ValidTime})))
 
 (s/defschema StoredCampaign
   "An campaign as stored in the data store"

--- a/src/ctim/schemas/coa.clj
+++ b/src/ctim/schemas/coa.clj
@@ -14,6 +14,7 @@
    c/BaseEntity
    c/DescribableEntity
    c/SourcableObject
+   {:type TypeIdentifier}
    {:valid_time c/ValidTime}
    (st/optional-keys
     {:stage (describe
@@ -48,7 +49,8 @@
    COA
    c/NewBaseEntity
    (st/optional-keys
-    {:valid_time c/ValidTime})))
+    {:type TypeIdentifier
+     :valid_time c/ValidTime})))
 
 (s/defschema StoredCOA
   "An coa as stored in the data store"

--- a/src/ctim/schemas/common.clj
+++ b/src/ctim/schemas/common.clj
@@ -4,7 +4,7 @@
             [ring.swagger.schema :refer [describe]]
             [schema-tools.core :as st]))
 
-(def ctim-schema-version "0.1.4")
+(def ctim-schema-version "0.1.5")
 
 (def Reference
   "An entity ID, or a URI referring to a remote one."

--- a/src/ctim/schemas/common.clj
+++ b/src/ctim/schemas/common.clj
@@ -38,14 +38,13 @@
   {;; :id and :idref must be implemented exclusively
    :id ID
    :type s/Str
-   :schema_version (describe s/Str "CTIM schema version for this entity")
+   :schema_version (describe (s/enum ctim-schema-version) "CTIM schema version for this entity")
    (s/optional-key :uri) URI
    (s/optional-key :revision) s/Int
    (s/optional-key :external_ids) [s/Str]
    (s/optional-key :timestamp) Time
    (s/optional-key :language) s/Str
-   (s/optional-key :tlp) TLP
-   })
+   (s/optional-key :tlp) TLP})
 
 (s/defschema NewBaseEntity
   "Base for New Entities, optionalizes ID and type and schema_version"
@@ -54,7 +53,7 @@
    (st/optional-keys
     {:id ID
      :type (describe s/Str "A valid entity type identifer")
-     :schema_version (describe s/Str "CTIM schema version for this entity")})))
+     :schema_version (describe (s/enum ctim-schema-version) "CTIM schema version for this entity")})))
 
 (s/defschema DescribableEntity
   "These fields for decribable entities"

--- a/src/ctim/schemas/exploit_target.clj
+++ b/src/ctim/schemas/exploit_target.clj
@@ -104,7 +104,8 @@
    ExploitTarget
    c/NewBaseEntity
    (st/optional-keys
-    {:valid_time c/ValidTime})))
+    {:type TypeIdentifier
+     :valid_time c/ValidTime})))
 
 (s/defschema StoredExploitTarget
   "An exploit-target as stored in the data store"


### PR DESCRIPTION
closes #30 
- use generators instead of complete to generate full entity fixtures
- all dates are now uniform: generated without formatting them as string
- schema_version on schemas is the current defined version
- added missing "type" optional keys