### PR TITLE
issue-33: TTP intended effect changed to vector

### DIFF
--- a/src/ctim/schemas/ttp.clj
+++ b/src/ctim/schemas/ttp.clj
@@ -85,7 +85,7 @@
                  "a timestamp for the definition of a specific version of a TTP item")}
    (st/optional-keys
     {:intended_effect (describe
-                       v/IntendedEffect
+                       [v/IntendedEffect]
                        "the suspected intended effect for this TTP")
      :behavior (describe
                 Behavior


### PR DESCRIPTION
Allows us to have a vector of intended effect strings.

Closes #33