### PR TITLE
Use sets for Bundle containers, support for non CTIM data

### DIFF
--- a/src/ctim/generators/common.cljc
+++ b/src/ctim/generators/common.cljc
@@ -1,5 +1,5 @@
 (ns ctim.generators.common
-  (:refer-clojure :exclude [vector])
+  (:refer-clojure :exclude [vector set])
   (:require [clj-momo.lib.time :as time]
             [clojure.test.check.generators :as gen]
             [schema-generators.complete :as sec]
@@ -27,7 +27,30 @@
                     (min min- max-complexity)
                     (min max- max-complexity))))))
 
+(defn gen-set
+  "Build a set generator (like gen/set) that uses a
+   max-complexity to limit the size of the generated sequences.
+   Note that this overrides optional inputs like quantity or min/max
+   such that max-complexity is honored."
+  [max-complexity]
+  (let [orig-set gen/set]
+    (fn set
+      ([generator]
+       (gen/bind (gen/choose 1 max-complexity)
+                 (fn [mc]
+                   (orig-set generator {:min-elements 0
+                                        :max-elements mc}))))
+      ([generator quantity]
+       (orig-set generator {:num-elements (min quantity max-complexity)}))
+      ([generator min- max-]
+       (orig-set generator
+                 {:min-elements (min min- max-complexity)
+                  :max-elements (min max- max-complexity)})))))
+
+
 (def vector (gen-vector generator-complexity))
+(def set (gen-set generator-complexity))
+
 
 (defn generator
   "Alternative to schema-generators.generators/generator that limits

--- a/src/ctim/generators/common.cljc
+++ b/src/ctim/generators/common.cljc
@@ -6,7 +6,8 @@
             [schema-generators.generators :as seg]
             [schema.core :as s]))
 
-(def generator-complexity 6)
+(def generator-vec-complexity 6)
+(def generator-set-complexity 5)
 
 (defn gen-vector
   "Build a vector generator (like gen/vector) that uses a
@@ -48,8 +49,8 @@
                   :max-elements (min max- max-complexity)})))))
 
 
-(def vector (gen-vector generator-complexity))
-(def set (gen-set generator-complexity))
+(def vector (gen-vector generator-vec-complexity))
+(def set (gen-set generator-set-complexity))
 
 
 (defn generator

--- a/src/ctim/generators/schemas/bundle_generators.cljc
+++ b/src/ctim/generators/schemas/bundle_generators.cljc
@@ -61,32 +61,32 @@
    merge-entities
    (gen/tuple (seg/generator BaseStoredBundle leaf-generators)
               (gen-id/gen-short-id-of-type :bundle)
-              (maybe (common/vector gen-actor))
-              (maybe (common/vector gen-campaign))
-              (maybe (common/vector gen-coa))
-              (maybe (common/vector gen-exploit-target))
-              (maybe (common/vector gen-feedback))
-              (maybe (common/vector gen-incident))
-              (maybe (common/vector gen-indicator))
-              (maybe (common/vector gen-judgement))
-              (maybe (common/vector gen-sighting))
-              (maybe (common/vector gen-ttp)))))
+              (maybe (common/set gen-actor))
+              (maybe (common/set gen-campaign))
+              (maybe (common/set gen-coa))
+              (maybe (common/set gen-exploit-target))
+              (maybe (common/set gen-feedback))
+              (maybe (common/set gen-incident))
+              (maybe (common/set gen-indicator))
+              (maybe (common/set gen-judgement))
+              (maybe (common/set gen-sighting))
+              (maybe (common/set gen-ttp)))))
 
 (defn gen-new-bundle_ [gen-id]
   (gen/fmap
    merge-entities
    (gen/tuple (seg/generator BaseNewBundle leaf-generators)
               gen-id
-              (maybe (common/vector gen-actor))
-              (maybe (common/vector gen-campaign))
-              (maybe (common/vector gen-coa))
-              (maybe (common/vector gen-exploit-target))
-              (maybe (common/vector gen-feedback))
-              (maybe (common/vector gen-incident))
-              (maybe (common/vector gen-indicator))
-              (maybe (common/vector gen-judgement))
-              (maybe (common/vector gen-sighting))
-              (maybe (common/vector gen-ttp)))))
+              (maybe (common/set gen-actor))
+              (maybe (common/set gen-campaign))
+              (maybe (common/set gen-coa))
+              (maybe (common/set gen-exploit-target))
+              (maybe (common/set gen-feedback))
+              (maybe (common/set gen-incident))
+              (maybe (common/set gen-indicator))
+              (maybe (common/set gen-judgement))
+              (maybe (common/set gen-sighting))
+              (maybe (common/set gen-ttp)))))
 
 (def gen-new-bundle
   (gen-new-bundle_

--- a/src/ctim/generators/schemas/bundle_generators.cljc
+++ b/src/ctim/generators/schemas/bundle_generators.cljc
@@ -42,7 +42,7 @@
                        exploit-targets feedbacks
                        incidents indicators judgements
                        sightings ttps]]
-  (cond-> (dissoc s :id)
+  (cond-> (dissoc s :id :others :other_refs)
     id (assoc :id id)
     actors (assoc :actors actors)
     campaigns (assoc :campaigns campaigns)

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -47,7 +47,7 @@
     :sighting_refs ReferenceSet
     :ttp_refs ReferenceSet
     :verdict_refs ReferenceSet
-    :other_refs #{s/Any}}))
+    :other_refs ReferenceSet}))
 
 (s/defschema Bundle
   (st/merge

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -17,35 +17,37 @@
 (s/defschema TypeIdentifier
   (s/enum "bundle"))
 
-(s/defschema ReferenceList [c/ID])
+(s/defschema ReferenceSet #{c/ID})
 
 (s/defschema Objects
   (st/optional-keys
-   {:actors [StoredActor]
-    :campaigns [StoredCampaign]
-    :coas [StoredCOA]
-    :exploit-targets [StoredExploitTarget]
-    :feedbacks [StoredFeedback]
-    :incidents [StoredIncident]
-    :indicators [StoredIndicator]
-    :judgements [StoredJudgement]
-    :sightings [StoredSighting]
-    :ttps [StoredTTP]
-    :verdicts [StoredVerdict]}))
+   {:actors #{StoredActor}
+    :campaigns #{StoredCampaign}
+    :coas #{StoredCOA}
+    :exploit-targets #{StoredExploitTarget}
+    :feedbacks #{StoredFeedback}
+    :incidents #{StoredIncident}
+    :indicators #{StoredIndicator}
+    :judgements #{StoredJudgement}
+    :sightings #{StoredSighting}
+    :ttps #{StoredTTP}
+    :verdicts #{StoredVerdict}
+    :others #{s/Any}}))
 
 (s/defschema References
   (st/optional-keys
-   {:actor_refs ReferenceList
-    :campaign_refs ReferenceList
-    :coa_refs ReferenceList
-    :exploit-target_refs ReferenceList
-    :feedback_refs ReferenceList
-    :incident_refs ReferenceList
-    :indicator_refs ReferenceList
-    :judgement_refs ReferenceList
-    :sighting_refs ReferenceList
-    :ttp_refs ReferenceList
-    :verdict_refs ReferenceList}))
+   {:actor_refs ReferenceSet
+    :campaign_refs ReferenceSet
+    :coa_refs ReferenceSet
+    :exploit-target_refs ReferenceSet
+    :feedback_refs ReferenceSet
+    :incident_refs ReferenceSet
+    :indicator_refs ReferenceSet
+    :judgement_refs ReferenceSet
+    :sighting_refs ReferenceSet
+    :ttp_refs ReferenceSet
+    :verdict_refs ReferenceSet
+    :other_refs #{s/Any}}))
 
 (s/defschema Bundle
   (st/merge

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -5,7 +5,7 @@
             [schema.core :as s]
             [clojure.set :refer [map-invert]]))
 
-(def ctim-schema-version "0.1.8")
+(def ctim-schema-version "0.1.10")
 
 (def Reference
   "An entity ID, or a URI referring to a remote one."

--- a/test/ctim/domain/id_test.cljc
+++ b/test/ctim/domain/id_test.cljc
@@ -90,7 +90,8 @@
   (testing "with hyphens in the entity type"
     (let [short-id "exploit-target-d51dfc7b-df40-46a4-9b06-c396e3dfdbcf"]
       (is (= #ctim.domain.id.CtiaId{:hostname "localhost",
-                                    :short-id short-id
+                                    :short-id
+                                    "exploit-target-d51dfc7b-df40-46a4-9b06-c396e3dfdbcf",
                                     :path-prefix nil,
                                     :port 3001,
                                     :protocol "http",


### PR DESCRIPTION
- Use sets instead of vector for entity containers, this eases entity deduping
- We need Bundles to support non CTIM schemas added :other and :other_refs in this regard
- Added a custom set generator like vector to handle max complexity