### PR TITLE
Datatable Base Entity

### DIFF
--- a/src/ctim/generators/schemas.cljc
+++ b/src/ctim/generators/schemas.cljc
@@ -16,6 +16,7 @@
             [ctim.generators.schemas.sighting-generators :as sg]
             [ctim.generators.schemas.ttp-generators :as tg]
             [ctim.generators.schemas.bundle-generators :as bu]
+            [ctim.generators.schemas.datatable-generators :as dg]
             [flanders.schema :as fs]))
 
 (defn gen-new-indicator-with-new-sightings [url-params-fn]
@@ -51,7 +52,8 @@
    :bundle         bu/gen-bundle
    :new-bundle     bu/gen-new-bundle
    :new-ttp        tg/gen-new-ttp
-   :verdict        (generate-entity (fs/get-schema Verdict))})
+   :verdict        (generate-entity (fs/get-schema Verdict))
+   :data-table      dg/gen-new-datatable})
 
 (def entity-types [:actor :campaign :coa :exploit-target :feedback :incident
                    :indicator :judgement :sighting :ttp :bundle])
@@ -62,9 +64,9 @@
 (def default-complexity 20)
 
 (defn sample-by-kw
+  "generate num records of a schema-kw"
   ([schema-kw]
    (sample-by-kw default-complexity schema-kw))
   ([num schema-kw]
-   "generate num records of a schema-kw"
-   (gen/sample (get kw->generator schema-kw)
-               num)))
+   (gen/sample (get kw->generator schema-kw) num)))
+

--- a/src/ctim/generators/schemas/datatable_generators.cljc
+++ b/src/ctim/generators/schemas/datatable_generators.cljc
@@ -21,7 +21,7 @@
   "a `StoredDatatable` stripped of the keys we need to fine tune"
   (st/dissoc
    (fs/get-schema csd/StoredDataTable)
-   :columns :rows :count))
+   :columns :rows :row_count))
 
 (s/defschema BaseNewDataTable
   (st/dissoc BaseDataTable :created :modified :owner))
@@ -59,7 +59,7 @@
    (fn [[s id columns c]]
      (cond-> s
        id (assoc :id id)
-       c (assoc :count c)
+       c (assoc :row_count c)
        columns (assoc :columns columns
                       :rows (make-rows columns c))))
 
@@ -74,7 +74,7 @@
    (fn [[s id columns c]]
      (cond-> s
        id (assoc :id id)
-       c (assoc :count c)
+       c (assoc :row_count c)
        columns (assoc :columns columns
                       :rows (make-rows columns c))))
 
@@ -82,3 +82,6 @@
               (gen-id/gen-short-id-of-type :data-table)
               (gen/such-that not-empty (common/vector (seg/generator (fs/get-schema csd/ColumnDefinition))))
               gen-rows-count)))
+
+(map csd/check-datatable  (gen/sample gen-new-datatable 10))
+

--- a/src/ctim/generators/schemas/datatable_generators.cljc
+++ b/src/ctim/generators/schemas/datatable_generators.cljc
@@ -1,0 +1,84 @@
+(ns ctim.generators.schemas.datatable-generators
+  (:require [clj-momo.lib.time :as time]
+            [clojure.test.check.generators :as gen]
+            [schema-generators.generators :as seg]
+            [ctim.schemas.data-table :as dt]
+            [ctim.schemas.common :as schemas-common]
+            [ctim.generators.common
+             :refer [complete leaf-generators maybe]
+             :as common]
+            [ctim.generators.id :as gen-id]
+            [flanders.schema :as fs]
+            [schema.core :as s]
+            [schema-tools.core :as st]
+            [ctim.schemas.data-table :as csd]
+            [ctim.schemas.common :refer [Observable]]
+            [ctim.generators.id :as idgen]))
+
+(def max-rows 100)
+
+(s/defschema BaseDataTable
+  "a `StoredDatatable` stripped of the keys we need to fine tune"
+  (st/dissoc
+   (fs/get-schema csd/StoredDataTable)
+   :columns :rows :count))
+
+(s/defschema BaseNewDataTable
+  (st/dissoc BaseDataTable :created :modified :owner))
+
+(def gen-observable
+  (seg/generator (fs/get-schema Observable)))
+
+(def gen-url idgen/gen-url-id)
+
+(def gen-rows-count
+  (gen/such-that #(and (not (nil? %))
+                       (> max-rows % 1))
+                 gen/pos-int 500))
+
+(defn gen-column-rows [c-def c]
+  "given a column definition make c rows"
+  (->> (case (:type c-def)
+         "observable" (gen/sample (gen/such-that not-empty gen-observable) c)
+         "string" (gen/sample gen/string-ascii c)
+         "markdown" (gen/sample gen/string-ascii c)
+         "integer" (gen/sample gen/int c)
+         "number" (gen/sample gen/large-integer c)
+         "url" (gen/sample gen-url c))
+       (take c)
+       vec))
+
+(defn make-rows [columns c]
+  "given a columns config vector and a rows
+   count int make the rows for each column"
+  (map #(gen-column-rows % c) columns))
+
+(def gen-datatable
+  "generate an entity that satisfies `StoredDataTable` schema"
+  (gen/fmap
+   (fn [[s id columns c]]
+     (cond-> s
+       id (assoc :id id)
+       c (assoc :count c)
+       columns (assoc :columns columns
+                      :rows (make-rows columns c))))
+
+   (gen/tuple (seg/generator BaseDataTable)
+              (gen-id/gen-short-id-of-type :data-table)
+              (gen/such-that not-empty (common/vector (seg/generator (fs/get-schema csd/ColumnDefinition))))
+              gen-rows-count)))
+
+(def gen-new-datatable
+  "generate an entity that satisfies `NewDataTable` schema"
+  (gen/fmap
+   (fn [[s id columns c]]
+     (cond-> s
+       id (assoc :id id)
+       c (assoc :count c)
+       columns (assoc :columns columns
+                      :rows (make-rows columns c))))
+
+   (gen/tuple (seg/generator BaseNewDataTable)
+              (gen-id/gen-short-id-of-type :data-table)
+              (gen/such-that not-empty (common/vector (seg/generator (fs/get-schema csd/ColumnDefinition))))
+              gen-rows-count)))

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -4,7 +4,7 @@
             [clojure.set :refer [map-invert]]
             [schema.core :as s]))
 
-(def ctim-schema-version "0.1.8")
+(def ctim-schema-version "0.1.9")
 
 (def Reference
   (f/str :description "A URI leading to an entity"))
@@ -46,6 +46,7 @@
     (f/entry :timestamp Time)
     (f/entry :language f/any-str)
     (f/entry :tlp TLP))))
+
 
 (def base-new-entity-entries
   "Base for New Entities, optionalizes ID and type and schema_version"

--- a/src/ctim/schemas/data_table.cljc
+++ b/src/ctim/schemas/data_table.cljc
@@ -1,0 +1,84 @@
+(ns ctim.schemas.data-table
+  (:require [ctim.lib.schema :refer [describe]]
+            [ctim.schemas.common :as c]
+            [ctim.schemas.relationships :as rel]
+            [ctim.schemas.vocabularies :as v]
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+
+(def TypeIdentifier
+  (f/eq "data-table"))
+
+(def ColumnType
+  #{"observable"
+    "string"
+    "markdown"
+    "integer"
+    "number"
+    "url"})
+
+(def-map-type ColumnDefinition
+  (concat
+   (f/required-entries
+    (f/entry :name f/any-str)
+    (f/entry :type ColumnType))
+   (f/optional-entries
+    (f/entry :description c/Markdown)
+    (f/entry :required f/any-bool
+             :description "If true, the row entries for this column cannot contain nulls. Defaults to true")
+    (f/entry :short_description f/any-str))))
+
+(def Datum
+  "A generic data object, this is really limited to the types
+  defined in ColumnType"
+  f/any)
+
+(def-entity-type DataTable
+  "A generic table of data, consisting of types and documented
+  columns, and 1 or more rows of data."
+  c/base-entity-entries
+  c/describable-entity-entries
+  c/sourcable-object-entries
+  (f/required-entries
+   (f/entry :type TypeIdentifier)
+   (f/entry :columns (f/seq-of ColumnDefinition
+                               :description "an ordered list of column definitions"))
+   (f/entry :rows (f/seq-of (f/seq-of Datum)
+                            :description "an ordered list of column definitions")))
+
+  (f/optional-entries
+   (f/entry :valid_time c/ValidTime)
+   (f/entry :count f/any-int
+            :description "The number of rows in the data table.")))
+
+(def-entity-type NewDataTable
+  "Schema for submitting ExploitTargets"
+  (:entries DataTable)
+  c/base-new-entity-entries
+  (f/optional-entries
+   (f/entry :type TypeIdentifier)
+   (f/entry :valid_time c/ValidTime)))
+
+(def-entity-type StoredDataTable
+  "An exploit-target as stored in the data store"
+  (:entries DataTable)
+  c/base-stored-entity-entries)
+
+(defn check-datatable
+  "Check a datatable for potential Column definition mismatches"
+  [{:keys [rows columns] :as x}]
+  (assert (seq columns) "Empty columns")
+  (assert (seq rows) "Empty rows")
+
+  (assert (= (count columns)
+             (count rows))
+          "Columns spec/rows mismatch")
+
+  (doseq [column-rows rows]
+    (let [c (count column-rows)]
+      (when (and (:count x)
+                 (not= c (:count x)))
+        (throw (ex-info "Column row count mismatch"
+                        {:column column-rows
+                         :expected-count (:count x)
+                         :actual-count c}))))) x)

--- a/src/ctim/schemas/data_table.cljc
+++ b/src/ctim/schemas/data_table.cljc
@@ -48,11 +48,11 @@
 
   (f/optional-entries
    (f/entry :valid_time c/ValidTime)
-   (f/entry :count f/any-int
+   (f/entry :row_count f/any-int
             :description "The number of rows in the data table.")))
 
 (def-entity-type NewDataTable
-  "Schema for submitting ExploitTargets"
+  "Schema for submitting a NewDataTable record"
   (:entries DataTable)
   c/base-new-entity-entries
   (f/optional-entries
@@ -60,13 +60,13 @@
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredDataTable
-  "An exploit-target as stored in the data store"
+  "A DataTable as stored in the data store"
   (:entries DataTable)
   c/base-stored-entity-entries)
 
 (defn check-datatable
   "Check a datatable for potential Column definition mismatches"
-  [{:keys [rows columns] :as x}]
+  [{:keys [rows columns row_count] :as x}]
   (assert (seq columns) "Empty columns")
   (assert (seq rows) "Empty rows")
 
@@ -76,9 +76,9 @@
 
   (doseq [column-rows rows]
     (let [c (count column-rows)]
-      (when (and (:count x)
-                 (not= c (:count x)))
+      (when (and row_count
+                 (not= c row_count))
         (throw (ex-info "Column row count mismatch"
                         {:column column-rows
-                         :expected-count (:count x)
+                         :expected-count row_count
                          :actual-count c}))))) x)

--- a/test/ctim/runner.cljs
+++ b/test/ctim/runner.cljs
@@ -5,6 +5,7 @@
             [ctim.schemas.actor-test]
             [ctim.schemas.campaign-test]
             [ctim.schemas.coa-test]
+            [ctim.schemas.data-table-test]
             [ctim.schemas.exploit-target-test]
             [ctim.schemas.feedback-test]
             [ctim.schemas.incident-test]
@@ -20,6 +21,7 @@
            'ctim.schemas.actor-test
            'ctim.schemas.campaign-test
            'ctim.schemas.coa-test
+           'ctim.schemas.data-table-test
            'ctim.schemas.feedback-test
            'ctim.schemas.exploit-target-test
            'ctim.schemas.incident-test
@@ -29,3 +31,4 @@
            'ctim.schemas.sighting-test
            'ctim.schemas.ttp-test
            'ctim.schemas.verdict-test)
+

--- a/test/ctim/schemas/data_table_test.cljc
+++ b/test/ctim/schemas/data_table_test.cljc
@@ -1,0 +1,76 @@
+(ns ctim.schemas.data-table-test
+  (:require
+   [schema.core :as s]
+   [flanders.schema :as fs]
+   #?(:clj [clojure.test :refer [deftest testing is use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest testing is use-fixtures]])
+   [ctim.schemas.common :as c]
+   [ctim.schemas.data-table :as dt]))
+
+(use-fixtures :once (fn [t] (s/with-fn-validation (t))))
+
+(deftest test-datatable-schema
+  (testing "a valid datatable shall pass validation"
+    (let [t {:id "data-table-1"
+             :type "data-table"
+             :count 1
+             :schema_version c/ctim-schema-version
+             :columns [{:name "Column1"
+                        :type "string"}
+                       {:name "Column2"
+                        :type "string"}]
+             :rows [["foo"] ["bar"]]}]
+
+      (is (s/validate (fs/->schema-tree dt/DataTable) t))
+      (is (dt/check-datatable t))))
+
+  (testing "a datatable with mismatching column config shall throw"
+    (let [t {:id "data-table-1"
+             :type "data-table"
+             :schema_version c/ctim-schema-version
+             :count 1
+             :columns [{:name "Column1"
+                        :type "string"}]
+             :rows [["foo"] ["bar"]]}]
+      (is (s/validate (fs/->schema-tree dt/DataTable) t))
+      (is (= "Assert failed: Columns spec/rows mismatch\n(= (count columns) (count rows))"
+             (try (dt/check-datatable t)
+                  (catch java.lang.AssertionError e (.getMessage e)))))))
+
+  (testing "a datatable with empty rows shall fail validation"
+    (let [t {:id "data-table-1"
+             :type "data-table"
+             :schema_version c/ctim-schema-version
+             :count 0
+             :columns []
+             :rows []}]
+      (is (s/validate (fs/->schema-tree dt/DataTable) t))
+      (is (= "Assert failed: Empty columns\n(seq columns)"
+             (try (dt/check-datatable t)
+                  (catch java.lang.AssertionError e (.getMessage e)))))))
+
+  (testing "a datatable with no rows shall fail validation"
+    (let [t {:id "data-table-1"
+             :type "data-table"
+             :schema_version c/ctim-schema-version
+             :count 0
+             :columns [{:name "Column1"
+                        :type "string"}]
+             :rows []}]
+      (is (s/validate (fs/->schema-tree dt/DataTable) t))
+      (is (= "Assert failed: Empty rows\n(seq rows)"
+             (try (dt/check-datatable t)
+                  (catch java.lang.AssertionError e (.getMessage e)))))))
+
+  (testing "a datatable with mismatching row count shall fail validation"
+    (let [t {:id "data-table-1"
+             :type "data-table"
+             :schema_version c/ctim-schema-version
+             :count 2
+             :columns [{:name "Column1"
+                        :type "string"}]
+             :rows [["foo"]]}]
+      (is (s/validate (fs/->schema-tree dt/DataTable) t))
+      (is (= "Column row count mismatch"
+             (try (dt/check-datatable t)
+                  (catch clojure.lang.ExceptionInfo e (.getMessage e))))))))

--- a/test/ctim/schemas/data_table_test.cljc
+++ b/test/ctim/schemas/data_table_test.cljc
@@ -13,7 +13,7 @@
   (testing "a valid datatable shall pass validation"
     (let [t {:id "data-table-1"
              :type "data-table"
-             :count 1
+             :row_count 1
              :schema_version c/ctim-schema-version
              :columns [{:name "Column1"
                         :type "string"}
@@ -28,7 +28,7 @@
     (let [t {:id "data-table-1"
              :type "data-table"
              :schema_version c/ctim-schema-version
-             :count 1
+             :row_count 1
              :columns [{:name "Column1"
                         :type "string"}]
              :rows [["foo"] ["bar"]]}]
@@ -41,7 +41,7 @@
     (let [t {:id "data-table-1"
              :type "data-table"
              :schema_version c/ctim-schema-version
-             :count 0
+             :row_count 0
              :columns []
              :rows []}]
       (is (s/validate (fs/->schema-tree dt/DataTable) t))
@@ -53,7 +53,7 @@
     (let [t {:id "data-table-1"
              :type "data-table"
              :schema_version c/ctim-schema-version
-             :count 0
+             :row_count 0
              :columns [{:name "Column1"
                         :type "string"}]
              :rows []}]
@@ -62,11 +62,11 @@
              (try (dt/check-datatable t)
                   (catch java.lang.AssertionError e (.getMessage e)))))))
 
-  (testing "a datatable with mismatching row count shall fail validation"
+  (testing "a datatable with mismatching row row_count shall fail validation"
     (let [t {:id "data-table-1"
              :type "data-table"
              :schema_version c/ctim-schema-version
-             :count 2
+             :row_count 2
              :columns [{:name "Column1"
                         :type "string"}]
              :rows [["foo"]]}]


### PR DESCRIPTION
Add a base entity for representing typed tables of generic data.

- Included generators for NewDataTable and StoredDataTable schemas
- a fn that should be used to validate a DataTable record.