### PR TITLE
Flanders schema gen reimplementation

### DIFF
--- a/src/ctim/generators/schemas/indicator_generators.cljc
+++ b/src/ctim/generators/schemas/indicator_generators.cljc
@@ -17,8 +17,7 @@
   (gen/fmap
    (fn [[s id]]
      (assoc s :id id))
-   (gen/tuple (seg/generator (fs/get-schema
-                              (fs/replace-either-with-any csi/StoredIndicator)))
+   (gen/tuple (seg/generator (fs/get-schema csi/StoredIndicator))
               gen-short-id)))
 
 (defn gen-new-indicator_ [gen-id]
@@ -29,8 +28,7 @@
        start-time (assoc-in [:valid_time :start_time] start-time)
        end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
-    (seg/generator (fs/get-schema
-                    (fs/replace-either-with-any csi/NewIndicator)))
+    (seg/generator (fs/get-schema csi/NewIndicator))
     gen-id
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))

--- a/src/ctim/generators/schemas/indicator_generators.cljc
+++ b/src/ctim/generators/schemas/indicator_generators.cljc
@@ -17,7 +17,8 @@
   (gen/fmap
    (fn [[s id]]
      (assoc s :id id))
-   (gen/tuple (seg/generator (fs/get-schema csi/StoredIndicator))
+   (gen/tuple (seg/generator (fs/get-schema
+                              (fs/replace-either-with-any csi/StoredIndicator)))
               gen-short-id)))
 
 (defn gen-new-indicator_ [gen-id]
@@ -28,7 +29,8 @@
        start-time (assoc-in [:valid_time :start_time] start-time)
        end-time (assoc-in [:valid_time :end_time] end-time)))
    (gen/tuple
-    (seg/generator (fs/get-schema csi/NewIndicator))
+    (seg/generator (fs/get-schema
+                    (fs/replace-either-with-any csi/NewIndicator)))
     gen-id
     ;; complete doesn't seem to generate :valid_time values, so do it manually
     common/gen-valid-time-tuple)))

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -57,6 +57,11 @@
      (merge opts
             {:type t}))))
 
+(defn set-of [t & {:as opts}]
+  (ft/map->SetOfType
+   (merge opts
+          {:type t})))
+
 (defn conditional [& pred+types]
   (assert (even? (count pred+types)) "pred and types must be even")
   (assert (seq pred+types) "must provide pred and types")

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -135,7 +135,8 @@
     (str "<a name=\"" anchor "\"/>\n"
          (->leaf-header this loc)
          "  * Details: [" text "](#" jump-anchor ")\n"))
-  (->short-description [{:keys [text]}] text)
+  (->short-description [{:keys [text]}]
+    text)
 
   MapEntry
   (->markdown-part [{:keys [key required?] :as this} loc]
@@ -162,7 +163,7 @@
   SetOfType
   (->markdown-part [{:keys [description]} loc]
     nil)
-  (->short-description [{:keys [description]} loc]
+  (->short-description [{:keys [description]}]
     (str "#{" (->short-description type) "}"))
 
   EitherType

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -62,7 +62,7 @@
 (defn- ->entry-header [{:keys [key type]} loc]
   (->header loc
             " MapEntry "
-            (let [key-schema (fs/->schema key (z/down loc))]
+            (let [key-schema (fs/->schema (fs/key key))]
               (if (keyword? key-schema)
                 key-schema
                 (->short-description key)))
@@ -76,7 +76,7 @@
       (str "* " type-str " Value\n"))))
 
 (defn- ->schema-str [this loc]
-  (let [schema (pr-str (fs/->schema this loc))
+  (let [schema (pr-str (fs/->schema this))
         schema (cond
                  (str/starts-with? schema "(enum") "(enum ...)"
                  (= "java.lang.String" schema) "Str"

--- a/src/flanders/predicates.cljc
+++ b/src/flanders/predicates.cljc
@@ -4,9 +4,10 @@
             [flanders.protocols :as prots]
             #?(:clj  [flanders.types]
                :cljs [flanders.types
-                      :refer [EitherType MapEntry MapType SequenceOfType]]))
+                      :refer [EitherType KeywordType MapEntry MapType
+                              SequenceOfType]]))
   (:import #?(:clj [flanders.types
-                    EitherType MapEntry MapType SequenceOfType])))
+                    EitherType KeywordType MapEntry MapType SequenceOfType])))
 
 ;; ----------------------------------------------------------------------
 ;; about nodes

--- a/src/flanders/predicates.cljc
+++ b/src/flanders/predicates.cljc
@@ -5,9 +5,10 @@
             #?(:clj  [flanders.types]
                :cljs [flanders.types
                       :refer [EitherType KeywordType MapEntry MapType
-                              SequenceOfType]]))
+                              SequenceOfType SetOfType]]))
   (:import #?(:clj [flanders.types
-                    EitherType KeywordType MapEntry MapType SequenceOfType])))
+                    EitherType KeywordType MapEntry MapType SequenceOfType
+                    SetOfType])))
 
 ;; ----------------------------------------------------------------------
 ;; about nodes
@@ -24,6 +25,8 @@
 (def leaf? (complement branch?))
 
 (def sequence-of? (partial instance? SequenceOfType))
+
+(def set-of? (partial instance? SetOfType))
 
 
 ;; ----------------------------------------------------------------------

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -127,7 +127,7 @@
 
 (defn ->schema-tree
   "Get the Plumatic schema for a DDL node"
-  [{:keys [description] :as ddl}]
+  [ddl]
   (->schema ddl
             ->schema-tree))
 

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -34,6 +34,11 @@
 
   ;; Branches
 
+  EitherType
+  (->schema [{:keys [choices tests]} f]
+    (let [choice-schemas (map f choices)]
+      (apply s/conditional (mapcat vector tests choice-schemas))))
+
   MapEntry
   (->schema [{:keys [key type required?] :as entry} f]
     [((if (not required?)

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -46,6 +46,18 @@
     (merge this
            (SequenceOfType. new-type description reference comment usage))))
 
+(defrecord SetOfType [type :- (s/protocol TreeNode)
+                      description :- (s/maybe s/Str)
+                      reference :- (s/maybe s/Str)
+                      comment :- (s/maybe s/Str)
+                      usage :- (s/maybe s/Str)]
+  TreeNode
+  (branch? [_] true)
+  (node-children [_] (list type))
+  (make-node [this [new-type]]
+    (merge this
+           (SetOfType. new-type description reference comment usage))))
+
 (defrecord EitherType [choices :- [(s/protocol TreeNode)]
                        tests :- (s/maybe [s/Any])
                        description :- (s/maybe s/Str)

--- a/test/ctim/schemas/indicator_test.cljc
+++ b/test/ctim/schemas/indicator_test.cljc
@@ -12,7 +12,8 @@
 (deftest test-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree i/Indicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/Indicator))
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -70,7 +71,8 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree i/Indicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/Indicator))
          {:id "indicator-123"
           :type "indicator"
           :producer "producer"
@@ -80,7 +82,8 @@
 (deftest test-new-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree i/NewIndicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/NewIndicator))
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -138,13 +141,15 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree i/NewIndicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/NewIndicator))
          {:producer "prod"}))))
 
 (deftest test-stored-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree i/StoredIndicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/StoredIndicator))
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -205,7 +210,8 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree i/StoredIndicator)
+         (fs/->schema-tree
+          (fs/replace-either-with-any i/StoredIndicator))
          {:id "indicator-123"
           :type "indicator"
           :producer "producer"

--- a/test/ctim/schemas/indicator_test.cljc
+++ b/test/ctim/schemas/indicator_test.cljc
@@ -12,8 +12,7 @@
 (deftest test-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/Indicator))
+         (fs/->schema-tree i/Indicator)
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -62,7 +61,65 @@
                           :COA_id "coa-123"}]
           :kill_chain_phases ["foo" "bar"]
           :test_mechanisms ["spam" "eggs"]
-          :specification {:type "Judgment"
+          :specification {:type "Judgement"
+                          :judgements ["judgement-123"]
+                          :required_judgements [{:judgement_id "judgement-123"
+                                                 :source "source"
+                                                 :relationship "relationship"
+                                                 :confidence "High"}]}})))
+
+  (testing "example with all possible fields and with replace-either-with-any"
+    (is (s/validate
+         (fs/->schema-tree (fs/replace-either-with-any i/Indicator))
+         {:id "indicator-123"
+          :type "indicator"
+          :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
+                         "http://ex.tld/ctia/indicator/indicator-345"]
+          :title "indicator-title"
+          :description "description"
+          :short_description "short desc"
+          :producer "producer"
+          :tlp "green"
+          :schema_version c/ctim-schema-version
+          :uri "http://example.com"
+          :source "source"
+          :source_uri "http://example.com"
+          :revision 1
+          :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+          :language "language"
+          :indicator_type ["C2" "IP Watchlist"]
+          :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
+                       :end_time #inst "2016-07-11T00:40:48.212-00:00"}
+          :alternate_ids ["foo" "bar"]
+          :negate false
+          :tags ["foo" "bar"]
+          :judgements [{:judgement_id "judgement-123"
+                        :confidence "High"
+                        :source "source"
+                        :relationship "rel"}]
+          :likely_impact "end of days"
+          :suggested_COAs [{:confidence "High"
+                            :source "source"
+                            :relationship "relationship"
+                            :COA_id "coa-123"}]
+          :confidence "High"
+          :related_indicators [{:indicator_id "indicator-123"
+                                :source "source"
+                                :relationship "relationship"
+                                :confidence "Low"}]
+          :related_campaigns [{:confidence "High"
+                               :source "source"
+                               :relationship "relationship"
+                               :campaign_id "campaign-123"}]
+          :composite_indicator_expression {:operator "and"
+                                           :indicator_ids ["test1" "test2"]}
+          :related_COAs [{:confidence "High"
+                          :source "source"
+                          :relationship "relationship"
+                          :COA_id "coa-123"}]
+          :kill_chain_phases ["foo" "bar"]
+          :test_mechanisms ["spam" "eggs"]
+          :specification {:type "Judgement"
                           :judgements ["judgement-123"]
                           :required_judgements [{:judgement_id "judgement-123"
                                                  :source "source"
@@ -71,8 +128,7 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/Indicator))
+         (fs/->schema-tree i/Indicator)
          {:id "indicator-123"
           :type "indicator"
           :producer "producer"
@@ -82,8 +138,7 @@
 (deftest test-new-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/NewIndicator))
+         (fs/->schema-tree i/NewIndicator)
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -132,7 +187,7 @@
                           :COA_id "coa-123"}]
           :kill_chain_phases ["foo" "bar"]
           :test_mechanisms ["spam" "eggs"]
-          :specification {:type "Judgment"
+          :specification {:type "Judgement"
                           :judgements ["judgement-123"]
                           :required_judgements [{:judgement_id "judgement-123"
                                                  :source "source"
@@ -141,15 +196,13 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/NewIndicator))
+         (fs/->schema-tree i/NewIndicator)
          {:producer "prod"}))))
 
 (deftest test-stored-indicator-schema
   (testing "example with all possible fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/StoredIndicator))
+         (fs/->schema-tree i/StoredIndicator)
          {:id "indicator-123"
           :type "indicator"
           :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
@@ -198,7 +251,7 @@
                           :COA_id "coa-123"}]
           :kill_chain_phases ["foo" "bar"]
           :test_mechanisms ["spam" "eggs"]
-          :specification {:type "Judgment"
+          :specification {:type "Judgement"
                           :judgements ["judgement-123"]
                           :required_judgements [{:judgement_id "judgement-123"
                                                  :source "source"
@@ -210,8 +263,7 @@
 
   (testing "example with only required fields"
     (is (s/validate
-         (fs/->schema-tree
-          (fs/replace-either-with-any i/StoredIndicator))
+         (fs/->schema-tree i/StoredIndicator)
          {:id "indicator-123"
           :type "indicator"
           :producer "producer"


### PR DESCRIPTION
Fixes it so that any node can be turned into a schema, properly supports conditional, and adds sets as value types.

Closes #78 and closes #72 