### PR TITLE
Regenerated docs with duplication bug fixed

### DIFF
--- a/doc/structures/actor.md
+++ b/doc/structures/actor.md
@@ -5,180 +5,32 @@ Describes malicious actors (or adversaries) related to a cyber attack
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:source](#mapentry-source-string)|String|&#10003;|
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
-|[:actor_type](#mapentry-actor_type-string)|String|&#10003;|
-|[:identity](#mapentry-identity-identitymap)|*Identity* Map||
-|[:motivation](#mapentry-motivation-string)|String||
-|[:sophistication](#mapentry-sophistication-string)|String||
-|[:intended_effect](#mapentry-intended_effect-string)|String||
-|[:planning_and_operational_support](#mapentry-planning_and_operational_support-string)|String||
 |[:observed_TTPs](#mapentry-observed_ttps-relatedttpmap)|*RelatedTTP* Map||
+|[:motivation](#mapentry-motivation-string)|String||
+|[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
+|[:identity](#mapentry-identity-identitymap)|*Identity* Map||
+|[:sophistication](#mapentry-sophistication-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:planning_and_operational_support](#mapentry-planning_and_operational_support-string)|String||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String|&#10003;|
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:intended_effect](#mapentry-intended_effect-string)|String||
+|[:actor_type](#mapentry-actor_type-string)|String|&#10003;|
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String||
 |[:associated_campaigns](#mapentry-associated_campaigns-relatedcampaignmap)|*RelatedCampaign* Map||
 |[:associated_actors](#mapentry-associated_actors-relatedactormap)|*RelatedActor* Map||
-|[:confidence](#mapentry-confidence-string)|String||
 * Reference: [ThreatActorType](http://stixproject.github.io/data-model/1.2/ta/ThreatActorType/)
-
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :external_ids
-
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -192,81 +44,18 @@ CTIM schema version for this entity
   * Markdown text
   * Plumatic Schema: Str
 
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
+<a name="mapentry-observed_ttps-relatedttpmap"/>
+## MapEntry :observed_TTPs ∷ [*RelatedTTP* Map]
 
 * This entry is optional
+* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :short_description
+  * Plumatic Schema: :observed_TTPs
 
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "actor"
-
-<a name="mapentry-valid_time-validtimemap"/>
-## MapEntry :valid_time ∷ *ValidTime* Map
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :valid_time
-
-<a name="map1-ref"/>
-* *ValidTime* Map Value
-  * Details: [*ValidTime* Map](#map1)
-
-<a name="mapentry-actor_type-string"/>
-## MapEntry :actor_type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :actor_type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * Cyber Espionage Operations
-    * Disgruntled Customer / User
-    * Hacker
-    * Hacker - Black hat
-    * Hacker - Gray hat
-    * Hacker - White hat
-    * Hacktivist
-    * Insider Threat
-    * State Actor / Agency
-    * eCrime Actor - Credential Theft Botnet Operator
-    * eCrime Actor - Credential Theft Botnet Service
-    * eCrime Actor - Malware Developer
-    * eCrime Actor - Money Laundering Network
-    * eCrime Actor - Organized Crime Actor
-    * eCrime Actor - Spam Service
-    * eCrime Actor - Traffic Service
-    * eCrime Actor - Underground Call Service
-
-<a name="mapentry-identity-identitymap"/>
-## MapEntry :identity ∷ *Identity* Map
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :identity
-
-<a name="map2-ref"/>
-* *Identity* Map Value
-  * Details: [*Identity* Map](#map2)
+<a name="map3-ref"/>
+* *RelatedTTP* Map Value
+  * Details: [*RelatedTTP* Map](#map3)
 
 <a name="mapentry-motivation-string"/>
 ## MapEntry :motivation ∷ String
@@ -294,6 +83,30 @@ CTIM schema version for this entity
     * Opportunistic
     * Political
 
+<a name="mapentry-valid_time-validtimemap"/>
+## MapEntry :valid_time ∷ *ValidTime* Map
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :valid_time
+
+<a name="map1-ref"/>
+* *ValidTime* Map Value
+  * Details: [*ValidTime* Map](#map1)
+
+<a name="mapentry-identity-identitymap"/>
+## MapEntry :identity ∷ *Identity* Map
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :identity
+
+<a name="map2-ref"/>
+* *Identity* Map Value
+  * Details: [*Identity* Map](#map2)
+
 <a name="mapentry-sophistication-string"/>
 ## MapEntry :sophistication ∷ String
 
@@ -310,6 +123,111 @@ CTIM schema version for this entity
     * Innovator
     * Novice
     * Practitioner
+
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
+
+CTIM schema version for this entity
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :schema_version
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "0.3.1"
+
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :revision
+
+* Integer Value
+  * Plumatic Schema: Int
+
+<a name="mapentry-planning_and_operational_support-string"/>
+## MapEntry :planning_and_operational_support ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :planning_and_operational_support
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "actor"
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-intended_effect-string"/>
 ## MapEntry :intended_effect ∷ String
@@ -347,29 +265,117 @@ CTIM schema version for this entity
     * Traffic Diversion
     * Unauthorized Access
 
-<a name="mapentry-planning_and_operational_support-string"/>
-## MapEntry :planning_and_operational_support ∷ String
+<a name="mapentry-actor_type-string"/>
+## MapEntry :actor_type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :actor_type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * Cyber Espionage Operations
+    * Disgruntled Customer / User
+    * Hacker
+    * Hacker - Black hat
+    * Hacker - Gray hat
+    * Hacker - White hat
+    * Hacktivist
+    * Insider Threat
+    * State Actor / Agency
+    * eCrime Actor - Credential Theft Botnet Operator
+    * eCrime Actor - Credential Theft Botnet Service
+    * eCrime Actor - Malware Developer
+    * eCrime Actor - Money Laundering Network
+    * eCrime Actor - Organized Crime Actor
+    * eCrime Actor - Spam Service
+    * eCrime Actor - Traffic Service
+    * eCrime Actor - Underground Call Service
+
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :planning_and_operational_support
+  * Plumatic Schema: :language
 
 * String Value
   * Plumatic Schema: Str
 
-<a name="mapentry-observed_ttps-relatedttpmap"/>
-## MapEntry :observed_TTPs ∷ [*RelatedTTP* Map]
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
 
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
+* This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :observed_TTPs
+  * Plumatic Schema: :id
 
-<a name="map3-ref"/>
-* *RelatedTTP* Map Value
-  * Details: [*RelatedTTP* Map](#map3)
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-confidence-string"/>
+## MapEntry :confidence ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :confidence
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * High
+    * Low
+    * Medium
+    * None
+    * Unknown
+  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
 <a name="mapentry-associated_campaigns-relatedcampaignmap"/>
 ## MapEntry :associated_campaigns ∷ [*RelatedCampaign* Map]
@@ -396,24 +402,6 @@ CTIM schema version for this entity
 <a name="map5-ref"/>
 * *RelatedActor* Map Value
   * Details: [*RelatedActor* Map](#map5)
-
-<a name="mapentry-confidence-string"/>
-## MapEntry :confidence ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :confidence
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * High
-    * Low
-    * Medium
-    * None
-    * Unknown
-  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
 <a name="map1"/>
 # *ValidTime* Map

--- a/doc/structures/campaign.md
+++ b/doc/structures/campaign.md
@@ -5,158 +5,33 @@ TODO - Document Campaign
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
-|[:campaign_type](#mapentry-campaign_type-string)|String|&#10003;|
-|[:names](#mapentry-names-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
 |[:indicators](#mapentry-indicators-relatedindicatormap)|*RelatedIndicator* Map||
-|[:intended_effect](#mapentry-intended_effect-string)|String||
-|[:status](#mapentry-status-string)|String||
-|[:related_TTPs](#mapentry-related_ttps-relatedttpmap)|*RelatedTTP* Map||
-|[:related_incidents](#mapentry-related_incidents-relatedincidentmap)|*RelatedIncident* Map||
-|[:attribution](#mapentry-attribution-relatedactormap)|*RelatedActor* Map||
-|[:associated_campaigns](#mapentry-associated_campaigns-relatedcampaignmap)|*RelatedCampaign* Map||
-|[:confidence](#mapentry-confidence-string)|String||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:campaign_type](#mapentry-campaign_type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
 |[:activity](#mapentry-activity-activitymap)|*Activity* Map||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:intended_effect](#mapentry-intended_effect-string)|String||
+|[:related_TTPs](#mapentry-related_ttps-relatedttpmap)|*RelatedTTP* Map||
+|[:status](#mapentry-status-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:attribution](#mapentry-attribution-relatedactormap)|*RelatedActor* Map||
+|[:tlp](#mapentry-tlp-string)|String||
+|[:related_incidents](#mapentry-related_incidents-relatedincidentmap)|*RelatedIncident* Map||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String||
+|[:names](#mapentry-names-string)|String||
+|[:associated_campaigns](#mapentry-associated_campaigns-relatedcampaignmap)|*RelatedCampaign* Map||
 * Reference: [CampaignType](http://stixproject.github.io/data-model/1.2/campaign/CampaignType/)
-
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :external_ids
-
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -169,52 +44,6 @@ CTIM schema version for this entity
 * String Value
   * Markdown text
   * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "campaign"
 
 <a name="mapentry-valid_time-validtimemap"/>
 ## MapEntry :valid_time ∷ *ValidTime* Map
@@ -230,30 +59,30 @@ timestamp for the definition of a specific version of a Campaign
 * *ValidTime* Map Value
   * Details: [*ValidTime* Map](#map1)
 
-<a name="mapentry-campaign_type-string"/>
-## MapEntry :campaign_type ∷ String
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
+
+CTIM schema version for this entity
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :campaign_type
+  * Plumatic Schema: :schema_version
 
 * String Value
-  * Plumatic Schema: Str
+  * Plumatic Schema: (enum ...)
+  * Must equal: "0.3.1"
 
-<a name="mapentry-names-string"/>
-## MapEntry :names ∷ [String]
-
-Names used to identify this Campaign
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :names
+  * Plumatic Schema: :revision
 
-* String Value
-  * Plumatic Schema: [Str]
+* Integer Value
+  * Plumatic Schema: Int
 
 <a name="mapentry-indicators-relatedindicatormap"/>
 ## MapEntry :indicators ∷ [*RelatedIndicator* Map]
@@ -267,6 +96,100 @@ Names used to identify this Campaign
 <a name="map2-ref"/>
 * *RelatedIndicator* Map Value
   * Details: [*RelatedIndicator* Map](#map2)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "campaign"
+
+<a name="mapentry-campaign_type-string"/>
+## MapEntry :campaign_type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :campaign_type
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-activity-activitymap"/>
+## MapEntry :activity ∷ *Activity* Map
+
+actions taken in regards to this Campaign
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :activity
+
+<a name="map7-ref"/>
+* *Activity* Map Value
+  * Details: [*Activity* Map](#map7)
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-intended_effect-string"/>
 ## MapEntry :intended_effect ∷ [String]
@@ -307,6 +230,21 @@ characterizes the intended effect of this cyber threat Campaign
     * Traffic Diversion
     * Unauthorized Access
 
+<a name="mapentry-related_ttps-relatedttpmap"/>
+## MapEntry :related_TTPs ∷ [*RelatedTTP* Map]
+
+specifies TTPs asserted to be related to this cyber threat Campaign
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :related_TTPs
+
+<a name="map3-ref"/>
+* *RelatedTTP* Map Value
+  * Details: [*RelatedTTP* Map](#map3)
+
 <a name="mapentry-status-string"/>
 ## MapEntry :status ∷ String
 
@@ -324,35 +262,28 @@ status of this Campaign
     * Historic
     * Ongoing
 
-<a name="mapentry-related_ttps-relatedttpmap"/>
-## MapEntry :related_TTPs ∷ [*RelatedTTP* Map]
-
-specifies TTPs asserted to be related to this cyber threat Campaign
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :related_TTPs
+  * Plumatic Schema: :language
 
-<a name="map3-ref"/>
-* *RelatedTTP* Map Value
-  * Details: [*RelatedTTP* Map](#map3)
+* String Value
+  * Plumatic Schema: Str
 
-<a name="mapentry-related_incidents-relatedincidentmap"/>
-## MapEntry :related_incidents ∷ [*RelatedIncident* Map]
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
 
-identifies or characterizes one or more Incidents related to this cyber threat Campaign
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
+* This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :related_incidents
+  * Plumatic Schema: :id
 
-<a name="map4-ref"/>
-* *RelatedIncident* Map Value
-  * Details: [*RelatedIncident* Map](#map4)
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
 
 <a name="mapentry-attribution-relatedactormap"/>
 ## MapEntry :attribution ∷ [*RelatedActor* Map]
@@ -369,20 +300,62 @@ assertions of attibuted Threat Actors for this cyber threat Campaign
 * *RelatedActor* Map Value
   * Details: [*RelatedActor* Map](#map5)
 
-<a name="mapentry-associated_campaigns-relatedcampaignmap"/>
-## MapEntry :associated_campaigns ∷ [*RelatedCampaign* Map]
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
 
-other cyber threat Campaigns asserted to be associated with this cyber threat Campaign
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a name="mapentry-related_incidents-relatedincidentmap"/>
+## MapEntry :related_incidents ∷ [*RelatedIncident* Map]
+
+identifies or characterizes one or more Incidents related to this cyber threat Campaign
 
 * This entry is optional
 * This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :associated_campaigns
+  * Plumatic Schema: :related_incidents
 
-<a name="map6-ref"/>
-* *RelatedCampaign* Map Value
-  * Details: [*RelatedCampaign* Map](#map6)
+<a name="map4-ref"/>
+* *RelatedIncident* Map Value
+  * Details: [*RelatedIncident* Map](#map4)
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
 
 <a name="mapentry-confidence-string"/>
 ## MapEntry :confidence ∷ String
@@ -404,19 +377,34 @@ level of confidence held in the characterization of this Campaign
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
-<a name="mapentry-activity-activitymap"/>
-## MapEntry :activity ∷ *Activity* Map
+<a name="mapentry-names-string"/>
+## MapEntry :names ∷ [String]
 
-actions taken in regards to this Campaign
+Names used to identify this Campaign
 
 * This entry is optional
+* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :activity
+  * Plumatic Schema: :names
 
-<a name="map7-ref"/>
-* *Activity* Map Value
-  * Details: [*Activity* Map](#map7)
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-associated_campaigns-relatedcampaignmap"/>
+## MapEntry :associated_campaigns ∷ [*RelatedCampaign* Map]
+
+other cyber threat Campaigns asserted to be associated with this cyber threat Campaign
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :associated_campaigns
+
+<a name="map6-ref"/>
+* *RelatedCampaign* Map Value
+  * Details: [*RelatedCampaign* Map](#map6)
 
 <a name="map1"/>
 # *ValidTime* Map

--- a/doc/structures/coa.md
+++ b/doc/structures/coa.md
@@ -5,156 +5,31 @@ Corrective or preventative action to be taken in response to a threat
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
 |[:stage](#mapentry-stage-string)|String||
-|[:coa_type](#mapentry-coa_type-string)|String||
-|[:objective](#mapentry-objective-string)|String||
-|[:impact](#mapentry-impact-string)|String||
-|[:cost](#mapentry-cost-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
 |[:efficacy](#mapentry-efficacy-string)|String||
+|[:type](#mapentry-type-string)|String|&#10003;|
 |[:related_COAs](#mapentry-related_coas-relatedcoamap)|*RelatedCOA* Map||
-|[:structured_coa_type](#mapentry-structured_coa_type-string)|String||
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:coa_type](#mapentry-coa_type-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:objective](#mapentry-objective-string)|String||
+|[:cost](#mapentry-cost-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
 |[:open_c2_coa](#mapentry-open_c2_coa-openc2coamap)|*OpenC2COA* Map||
+|[:structured_coa_type](#mapentry-structured_coa_type-string)|String||
+|[:impact](#mapentry-impact-string)|String||
 * Reference: [CourseOfActionType](http://stixproject.github.io/data-model/1.2/coa/CourseOfActionType/)
-
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :external_ids
-
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -167,52 +42,6 @@ CTIM schema version for this entity
 * String Value
   * Markdown text
   * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "coa"
 
 <a name="mapentry-valid_time-validtimemap"/>
 ## MapEntry :valid_time ∷ *ValidTime* Map
@@ -242,6 +71,135 @@ specifies what stage in the cyber threat management lifecycle this Course Of Act
     * Remedy
     * Response
   * Reference: [COAStageVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/COAStageVocab-1.0/)
+
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
+
+CTIM schema version for this entity
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :schema_version
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "0.3.1"
+
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :revision
+
+* Integer Value
+  * Plumatic Schema: Int
+
+<a name="mapentry-efficacy-string"/>
+## MapEntry :efficacy ∷ String
+
+effectiveness of this Course Of Action in achieving its targeted Objective
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :efficacy
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * High
+    * Low
+    * Medium
+    * None
+    * Unknown
+  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "coa"
+
+<a name="mapentry-related_coas-relatedcoamap"/>
+## MapEntry :related_COAs ∷ [*RelatedCOA* Map]
+
+identifies or characterizes relationships to one or more related courses of action
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :related_COAs
+
+<a name="map2-ref"/>
+* *RelatedCOA* Map Value
+  * Details: [*RelatedCOA* Map](#map2)
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-coa_type-string"/>
 ## MapEntry :coa_type ∷ String
@@ -274,6 +232,47 @@ type of this COA
     * Training
   * Reference: [CourseOfActionTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/CourseOfActionTypeVocab-1.0/)
 
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :language
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
 <a name="mapentry-objective-string"/>
 ## MapEntry :objective ∷ [String]
 
@@ -288,19 +287,6 @@ characterizes the objective of this Course Of Action
 
 * String Value
   * Plumatic Schema: [Str]
-
-<a name="mapentry-impact-string"/>
-## MapEntry :impact ∷ String
-
-characterizes the estimated impact of applying this Course Of Action
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :impact
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-cost-string"/>
 ## MapEntry :cost ∷ String
@@ -322,40 +308,41 @@ characterizes the estimated cost for applying this Course Of Action
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
-<a name="mapentry-efficacy-string"/>
-## MapEntry :efficacy ∷ String
-
-effectiveness of this Course Of Action in achieving its targeted Objective
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :efficacy
+  * Plumatic Schema: :uri
 
 * String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * High
-    * Low
-    * Medium
-    * None
-    * Unknown
-  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+  * A URI
+  * Plumatic Schema: Str
 
-<a name="mapentry-related_coas-relatedcoamap"/>
-## MapEntry :related_COAs ∷ [*RelatedCOA* Map]
-
-identifies or characterizes relationships to one or more related courses of action
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :related_COAs
+  * Plumatic Schema: :timestamp
 
-<a name="map2-ref"/>
-* *RelatedCOA* Map Value
-  * Details: [*RelatedCOA* Map](#map2)
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-open_c2_coa-openc2coamap"/>
+## MapEntry :open_c2_coa ∷ *OpenC2COA* Map
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :open_c2_coa
+
+<a name="map3-ref"/>
+* *OpenC2COA* Map Value
+  * Details: [*OpenC2COA* Map](#map3)
 
 <a name="mapentry-structured_coa_type-string"/>
 ## MapEntry :structured_coa_type ∷ String
@@ -369,17 +356,18 @@ identifies or characterizes relationships to one or more related courses of acti
   * Plumatic Schema: (enum ...)
   * Must equal: "openc2"
 
-<a name="mapentry-open_c2_coa-openc2coamap"/>
-## MapEntry :open_c2_coa ∷ *OpenC2COA* Map
+<a name="mapentry-impact-string"/>
+## MapEntry :impact ∷ String
+
+characterizes the estimated impact of applying this Course Of Action
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :open_c2_coa
+  * Plumatic Schema: :impact
 
-<a name="map3-ref"/>
-* *OpenC2COA* Map Value
-  * Details: [*OpenC2COA* Map](#map3)
+* String Value
+  * Plumatic Schema: Str
 
 <a name="map1"/>
 # *ValidTime* Map
@@ -571,77 +559,19 @@ If not present, the valid time position of the indicator does not have an upper 
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:delay](#mapentry-delay-instdate)|Inst (Date)||
-|[:duration](#mapentry-duration-instdate)|Inst (Date)||
-|[:frequency](#mapentry-frequency-string)|String||
-|[:id](#mapentry-id-string)|String||
-|[:time](#mapentry-time-validtimemap)|*ValidTime* Map||
 |[:response](#mapentry-response-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:destination](#mapentry-destination-string)|String||
 |[:method](#mapentry-method-string)|String||
-|[:search](#mapentry-search-string)|String||
-|[:location](#mapentry-location-string)|String||
-|[:option](#mapentry-option-string)|String||
 |[:additional_properties](#mapentry-additional_properties-additionalpropertiesmap)|*AdditionalProperties* Map||
-
-<a name="mapentry-delay-instdate"/>
-## MapEntry :delay ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :delay
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-duration-instdate"/>
-## MapEntry :duration ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :duration
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-frequency-string"/>
-## MapEntry :frequency ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :frequency
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-time-validtimemap"/>
-## MapEntry :time ∷ *ValidTime* Map
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :time
-
-<a name="map8-ref"/>
-* *ValidTime* Map Value
-  * Details: [*ValidTime* Map](#map8)
+|[:time](#mapentry-time-validtimemap)|*ValidTime* Map||
+|[:frequency](#mapentry-frequency-string)|String||
+|[:duration](#mapentry-duration-instdate)|Inst (Date)||
+|[:source](#mapentry-source-string)|String||
+|[:search](#mapentry-search-string)|String||
+|[:option](#mapentry-option-string)|String||
+|[:id](#mapentry-id-string)|String||
+|[:location](#mapentry-location-string)|String||
+|[:delay](#mapentry-delay-instdate)|Inst (Date)||
+|[:destination](#mapentry-destination-string)|String||
 
 <a name="mapentry-response-string"/>
 ## MapEntry :response ∷ String
@@ -658,36 +588,6 @@ If not present, the valid time position of the indicator does not have an upper 
     * command-ref
     * query
     * status
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-destination-string"/>
-## MapEntry :destination ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :destination
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * copy-to
-    * modify-to
-    * move-to
-    * report-to
-    * restore-point
-    * save-to
-    * set-to
 
 <a name="mapentry-method-string"/>
 ## MapEntry :method ∷ [String]
@@ -715,6 +615,64 @@ If not present, the valid time position of the indicator does not have an upper 
     * unauthenticated
     * whitelist
 
+<a name="mapentry-additional_properties-additionalpropertiesmap"/>
+## MapEntry :additional_properties ∷ *AdditionalProperties* Map
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :additional_properties
+
+<a name="map9-ref"/>
+* *AdditionalProperties* Map Value
+  * Details: [*AdditionalProperties* Map](#map9)
+
+<a name="mapentry-time-validtimemap"/>
+## MapEntry :time ∷ *ValidTime* Map
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :time
+
+<a name="map8-ref"/>
+* *ValidTime* Map Value
+  * Details: [*ValidTime* Map](#map8)
+
+<a name="mapentry-frequency-string"/>
+## MapEntry :frequency ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :frequency
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-duration-instdate"/>
+## MapEntry :duration ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :duration
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
 <a name="mapentry-search-string"/>
 ## MapEntry :search ∷ String
 
@@ -731,6 +689,28 @@ If not present, the valid time position of the indicator does not have an upper 
     * signature
     * vendor_bulletin
 
+<a name="mapentry-option-string"/>
+## MapEntry :option ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :option
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * Plumatic Schema: Str
+
 <a name="mapentry-location-string"/>
 ## MapEntry :location ∷ String
 
@@ -745,28 +725,36 @@ If not present, the valid time position of the indicator does not have an upper 
     * internal
     * perimeter
 
-<a name="mapentry-option-string"/>
-## MapEntry :option ∷ String
+<a name="mapentry-delay-instdate"/>
+## MapEntry :delay ∷ Inst (Date)
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :option
+  * Plumatic Schema: :delay
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-destination-string"/>
+## MapEntry :destination ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :destination
 
 * String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-additional_properties-additionalpropertiesmap"/>
-## MapEntry :additional_properties ∷ *AdditionalProperties* Map
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :additional_properties
-
-<a name="map9-ref"/>
-* *AdditionalProperties* Map Value
-  * Details: [*AdditionalProperties* Map](#map9)
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * copy-to
+    * modify-to
+    * move-to
+    * report-to
+    * restore-point
+    * save-to
+    * set-to
 
 <a name="map9"/>
 # *AdditionalProperties* Map

--- a/doc/structures/exploit_target.md
+++ b/doc/structures/exploit_target.md
@@ -5,51 +5,51 @@
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
 |[:vulnerability](#mapentry-vulnerability-vulnerabilitymap)|*Vulnerability* Map||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
 |[:weakness](#mapentry-weakness-weaknessmap)|*Weakness* Map||
-|[:configuration](#mapentry-configuration-configurationmap)|*Configuration* Map||
 |[:potential_COAs](#mapentry-potential_coas-relatedcoamap)|*RelatedCOA* Map||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:configuration](#mapentry-configuration-configurationmap)|*Configuration* Map||
+|[:uri](#mapentry-uri-string)|String||
 |[:related_exploit_targets](#mapentry-related_exploit_targets-relatedexploittargetmap)|*RelatedExploitTarget* Map||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
 * Reference: [ExploitTargetType](http://stixproject.github.io/data-model/1.2/et/ExploitTargetType/)
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-description-string"/>
+## MapEntry :description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :description
+
+* String Value
+  * Markdown text
+  * Plumatic Schema: Str
+
+<a name="mapentry-valid_time-validtimemap"/>
+## MapEntry :valid_time ∷ *ValidTime* Map
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :id
+  * Plumatic Schema: :valid_time
 
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
+<a name="map1-ref"/>
+* *ValidTime* Map Value
+  * Details: [*ValidTime* Map](#map1)
 
 <a name="mapentry-schema_version-string"/>
 ## MapEntry :schema_version ∷ String
@@ -65,18 +65,6 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "0.3.1"
 
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-revision-integer"/>
 ## MapEntry :revision ∷ Integer
 
@@ -87,6 +75,44 @@ CTIM schema version for this entity
 
 * Integer Value
   * Plumatic Schema: Int
+
+<a name="mapentry-vulnerability-vulnerabilitymap"/>
+## MapEntry :vulnerability ∷ [*Vulnerability* Map]
+
+identifies and characterizes a Vulnerability as a potential Exploit Target
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :vulnerability
+
+<a name="map2-ref"/>
+* *Vulnerability* Map Value
+  * Details: [*Vulnerability* Map](#map2)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "exploit-target"
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-external_ids-string"/>
 ## MapEntry :external_ids ∷ [String]
@@ -100,17 +126,69 @@ CTIM schema version for this entity
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :timestamp
+  * Plumatic Schema: :short_description
 
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-weakness-weaknessmap"/>
+## MapEntry :weakness ∷ [*Weakness* Map]
+
+identifies and characterizes a Weakness as a potential Exploit Target
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :weakness
+
+<a name="map3-ref"/>
+* *Weakness* Map Value
+  * Details: [*Weakness* Map](#map3)
+
+<a name="mapentry-potential_coas-relatedcoamap"/>
+## MapEntry :potential_COAs ∷ [*RelatedCOA* Map]
+
+identifies and characterizes a Configuration as a potential Exploit Target
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :potential_COAs
+
+<a name="map5-ref"/>
+* *RelatedCOA* Map Value
+  * Details: [*RelatedCOA* Map](#map5)
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-language-string"/>
 ## MapEntry :language ∷ String
@@ -121,6 +199,18 @@ CTIM schema version for this entity
   * Plumatic Schema: :language
 
 * String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
   * Plumatic Schema: Str
 
 <a name="mapentry-tlp-string"/>
@@ -141,117 +231,6 @@ CTIM schema version for this entity
     * red
     * white
 
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-description-string"/>
-## MapEntry :description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :description
-
-* String Value
-  * Markdown text
-  * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "exploit-target"
-
-<a name="mapentry-valid_time-validtimemap"/>
-## MapEntry :valid_time ∷ *ValidTime* Map
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :valid_time
-
-<a name="map1-ref"/>
-* *ValidTime* Map Value
-  * Details: [*ValidTime* Map](#map1)
-
-<a name="mapentry-vulnerability-vulnerabilitymap"/>
-## MapEntry :vulnerability ∷ [*Vulnerability* Map]
-
-identifies and characterizes a Vulnerability as a potential Exploit Target
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :vulnerability
-
-<a name="map2-ref"/>
-* *Vulnerability* Map Value
-  * Details: [*Vulnerability* Map](#map2)
-
-<a name="mapentry-weakness-weaknessmap"/>
-## MapEntry :weakness ∷ [*Weakness* Map]
-
-identifies and characterizes a Weakness as a potential Exploit Target
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :weakness
-
-<a name="map3-ref"/>
-* *Weakness* Map Value
-  * Details: [*Weakness* Map](#map3)
-
 <a name="mapentry-configuration-configurationmap"/>
 ## MapEntry :configuration ∷ [*Configuration* Map]
 
@@ -267,20 +246,17 @@ identifies and characterizes a Configuration as a potential Exploit Target
 * *Configuration* Map Value
   * Details: [*Configuration* Map](#map4)
 
-<a name="mapentry-potential_coas-relatedcoamap"/>
-## MapEntry :potential_COAs ∷ [*RelatedCOA* Map]
-
-identifies and characterizes a Configuration as a potential Exploit Target
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :potential_COAs
+  * Plumatic Schema: :uri
 
-<a name="map5-ref"/>
-* *RelatedCOA* Map Value
-  * Details: [*RelatedCOA* Map](#map5)
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-related_exploit_targets-relatedexploittargetmap"/>
 ## MapEntry :related_exploit_targets ∷ [*RelatedExploitTarget* Map]
@@ -296,6 +272,18 @@ identifies and characterizes a Configuration as a potential Exploit Target
 <a name="map6-ref"/>
 * *RelatedExploitTarget* Map Value
   * Details: [*RelatedExploitTarget* Map](#map6)
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
 
 <a name="map1"/>
 # *ValidTime* Map
@@ -341,32 +329,19 @@ If not present, the valid time position of the indicator does not have an upper 
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:title](#mapentry-title-string)|String|&#10003;|
 |[:description](#mapentry-description-string)|String|&#10003;|
-|[:is_known](#mapentry-is_known-boolean)|Boolean||
 |[:is_public_acknowledged](#mapentry-is_public_acknowledged-boolean)|Boolean||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:cve_id](#mapentry-cve_id-string)|String||
-|[:osvdb_id](#mapentry-osvdb_id-integer)|Integer||
+|[:references](#mapentry-references-string)|String||
 |[:source](#mapentry-source-string)|String||
-|[:discovered_datetime](#mapentry-discovered_datetime-instdate)|Inst (Date)||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String|&#10003;|
 |[:published_datetime](#mapentry-published_datetime-instdate)|Inst (Date)||
 |[:affected_software](#mapentry-affected_software-string)|String||
-|[:references](#mapentry-references-string)|String||
+|[:cve_id](#mapentry-cve_id-string)|String||
+|[:discovered_datetime](#mapentry-discovered_datetime-instdate)|Inst (Date)||
+|[:is_known](#mapentry-is_known-boolean)|Boolean||
+|[:osvdb_id](#mapentry-osvdb_id-integer)|Integer||
 * Reference: [VulnerabilityType](http://stixproject.github.io/data-model/1.2/et/VulnerabilityType/)
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-title for this vulnerability
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -381,19 +356,6 @@ title for this vulnerability
 * String Value
   * Plumatic Schema: Str
 
-<a name="mapentry-is_known-boolean"/>
-## MapEntry :is_known ∷ Boolean
-
-whether or not the vulnerability is known (i.e. not a 0-day) at the time of characterization.
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :is_known
-
-* Boolean Value
-  * Plumatic Schema: Bool
-
 <a name="mapentry-is_public_acknowledged-boolean"/>
 ## MapEntry :is_public_acknowledged ∷ Boolean
 
@@ -407,44 +369,20 @@ whether or not the vulnerability is publicly acknowledged by the vendor
 * Boolean Value
   * Plumatic Schema: Bool
 
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
+<a name="mapentry-references-string"/>
+## MapEntry :references ∷ [String]
 
-short text description of this vulnerability
+list of external references describing this vulnerability
 
 * This entry is optional
+* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :short_description
+  * Plumatic Schema: :references
 
 * String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-cve_id-string"/>
-## MapEntry :cve_id ∷ String
-
-CVE identifier
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :cve_id
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-osvdb_id-integer"/>
-## MapEntry :osvdb_id ∷ Integer
-
-OSVDB identifier
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :osvdb_id
-
-* Integer Value
-  * Plumatic Schema: Int
+  * A URI
+  * Plumatic Schema: [Str]
 
 <a name="mapentry-source-string"/>
 ## MapEntry :source ∷ String
@@ -459,19 +397,31 @@ the source of the CVE or OSVDB as a textual description or URL
 * String Value
   * Plumatic Schema: Str
 
-<a name="mapentry-discovered_datetime-instdate"/>
-## MapEntry :discovered_datetime ∷ Inst (Date)
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
 
-date and time that this vulnerability was first discovered
+short text description of this vulnerability
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :discovered_datetime
+  * Plumatic Schema: :short_description
 
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+title for this vulnerability
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-published_datetime-instdate"/>
 ## MapEntry :published_datetime ∷ Inst (Date)
@@ -501,20 +451,58 @@ list of platforms and software that are affected by this vulnerability
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-references-string"/>
-## MapEntry :references ∷ [String]
+<a name="mapentry-cve_id-string"/>
+## MapEntry :cve_id ∷ String
 
-list of external references describing this vulnerability
+CVE identifier
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :references
+  * Plumatic Schema: :cve_id
 
 * String Value
-  * A URI
-  * Plumatic Schema: [Str]
+  * Plumatic Schema: Str
+
+<a name="mapentry-discovered_datetime-instdate"/>
+## MapEntry :discovered_datetime ∷ Inst (Date)
+
+date and time that this vulnerability was first discovered
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :discovered_datetime
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-is_known-boolean"/>
+## MapEntry :is_known ∷ Boolean
+
+whether or not the vulnerability is known (i.e. not a 0-day) at the time of characterization.
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :is_known
+
+* Boolean Value
+  * Plumatic Schema: Bool
+
+<a name="mapentry-osvdb_id-integer"/>
+## MapEntry :osvdb_id ∷ Integer
+
+OSVDB identifier
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :osvdb_id
+
+* Integer Value
+  * Plumatic Schema: Int
 
 <a name="map3"/>
 # *Weakness* Map

--- a/doc/structures/feedback.md
+++ b/doc/structures/feedback.md
@@ -6,43 +6,35 @@ Feedback on any entity.  Is it wrong?  If so why?  Was
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:entity_id](#mapentry-entity_id-string)|String|&#10003;|
 |[:feedback](#mapentry-feedback-integer)|Integer|&#10003;|
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
 |[:reason](#mapentry-reason-string)|String|&#10003;|
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:entity_id](#mapentry-entity_id-string)|String|&#10003;|
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
+<a name="mapentry-feedback-integer"/>
+## MapEntry :feedback ∷ Integer
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :type
+  * Plumatic Schema: :feedback
 
-* String Value
-  * Plumatic Schema: Str
+* Integer Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * -1
+    * 0
+    * 1
 
 <a name="mapentry-schema_version-string"/>
 ## MapEntry :schema_version ∷ String
@@ -58,18 +50,6 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "0.3.1"
 
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-revision-integer"/>
 ## MapEntry :revision ∷ Integer
 
@@ -80,6 +60,28 @@ CTIM schema version for this entity
 
 * Integer Value
   * Plumatic Schema: Int
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-external_ids-string"/>
 ## MapEntry :external_ids ∷ [String]
@@ -93,17 +95,28 @@ CTIM schema version for this entity
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
+<a name="mapentry-reason-string"/>
+## MapEntry :reason ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :reason
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :timestamp
+  * Plumatic Schema: :source_uri
 
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-language-string"/>
 ## MapEntry :language ∷ String
@@ -114,6 +127,18 @@ CTIM schema version for this entity
   * Plumatic Schema: :language
 
 * String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
   * Plumatic Schema: Str
 
 <a name="mapentry-tlp-string"/>
@@ -134,29 +159,6 @@ CTIM schema version for this entity
     * red
     * white
 
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-entity_id-string"/>
 ## MapEntry :entity_id ∷ String
 
@@ -169,28 +171,26 @@ CTIM schema version for this entity
   * A URI leading to an entity
   * Plumatic Schema: Str
 
-<a name="mapentry-feedback-integer"/>
-## MapEntry :feedback ∷ Integer
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
 
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :feedback
-
-* Integer Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * -1
-    * 0
-    * 1
-
-<a name="mapentry-reason-string"/>
-## MapEntry :reason ∷ String
-
-* This entry is required
+* This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :reason
+  * Plumatic Schema: :uri
 
 * String Value
+  * A URI
   * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -6,169 +6,59 @@ Discrete instance of indicators affecting an organization as well
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
+|[:related_indicators](#mapentry-related_indicators-relatedindicatormap)|*RelatedIndicator* Map||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
-|[:confidence](#mapentry-confidence-string)|String|&#10003;|
-|[:status](#mapentry-status-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:impact_assessment](#mapentry-impact_assessment-impactassessmentmap)|*ImpactAssessment* Map||
+|[:COA_taken](#mapentry-coa_taken-coarequestedmap)|*COARequested* Map||
+|[:leveraged_TTPs](#mapentry-leveraged_ttps-relatedttpmap)|*RelatedTTP* Map||
+|[:related_observables](#mapentry-related_observables-observablemap)|*Observable* Map||
+|[:COA_requested](#mapentry-coa_requested-coarequestedmap)|*COARequested* Map||
+|[:history](#mapentry-history-historymap)|*History* Map||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
 |[:incident_time](#mapentry-incident_time-incidenttimemap)|*IncidentTime* Map||
+|[:discovery_method](#mapentry-discovery_method-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:intended_effect](#mapentry-intended_effect-string)|String||
 |[:categories](#mapentry-categories-string)|String||
 |[:reporter](#mapentry-reporter-string)|String||
-|[:responder](#mapentry-responder-string)|String||
-|[:coordinator](#mapentry-coordinator-string)|String||
 |[:victim](#mapentry-victim-string)|String||
-|[:affected_assets](#mapentry-affected_assets-affectedassetmap)|*AffectedAsset* Map||
-|[:impact_assessment](#mapentry-impact_assessment-impactassessmentmap)|*ImpactAssessment* Map||
-|[:security_compromise](#mapentry-security_compromise-string)|String||
-|[:discovery_method](#mapentry-discovery_method-string)|String||
-|[:COA_requested](#mapentry-coa_requested-coarequestedmap)|*COARequested* Map||
-|[:COA_taken](#mapentry-coa_taken-coarequestedmap)|*COARequested* Map||
-|[:contact](#mapentry-contact-string)|String||
-|[:history](#mapentry-history-historymap)|*History* Map||
-|[:related_indicators](#mapentry-related_indicators-relatedindicatormap)|*RelatedIndicator* Map||
-|[:related_observables](#mapentry-related_observables-observablemap)|*Observable* Map||
-|[:leveraged_TTPs](#mapentry-leveraged_ttps-relatedttpmap)|*RelatedTTP* Map||
 |[:attributed_actors](#mapentry-attributed_actors-relatedactormap)|*RelatedActor* Map||
+|[:coordinator](#mapentry-coordinator-string)|String||
+|[:status](#mapentry-status-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
 |[:related_incidents](#mapentry-related_incidents-relatedincidentmap)|*RelatedIncident* Map||
-|[:intended_effect](#mapentry-intended_effect-string)|String||
+|[:responder](#mapentry-responder-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String|&#10003;|
+|[:contact](#mapentry-contact-string)|String||
+|[:security_compromise](#mapentry-security_compromise-string)|String||
+|[:affected_assets](#mapentry-affected_assets-affectedassetmap)|*AffectedAsset* Map||
 * Reference: [IncidentType](http://stixproject.github.io/data-model/1.2/incident/IncidentType/)
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-related_indicators-relatedindicatormap"/>
+## MapEntry :related_indicators ∷ [*RelatedIndicator* Map]
 
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
+identifies or characterizes one or more cyber threat Indicators related to this cyber threat Incident
 
 * This entry is optional
 * This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :external_ids
+  * Plumatic Schema: :related_indicators
 
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
+<a name="map8-ref"/>
+* *RelatedIndicator* Map Value
+  * Details: [*RelatedIndicator* Map](#map8)
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -181,52 +71,6 @@ CTIM schema version for this entity
 * String Value
   * Markdown text
   * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "incident"
 
 <a name="mapentry-valid_time-validtimemap"/>
 ## MapEntry :valid_time ∷ *ValidTime* Map
@@ -242,152 +86,30 @@ time stamp for the definition of a specific version of an Incident
 * *ValidTime* Map Value
   * Details: [*ValidTime* Map](#map1)
 
-<a name="mapentry-confidence-string"/>
-## MapEntry :confidence ∷ String
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
 
-level of confidence held in the characterization of this Incident
+CTIM schema version for this entity
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :confidence
+  * Plumatic Schema: :schema_version
 
 * String Value
   * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * High
-    * Low
-    * Medium
-    * None
-    * Unknown
-  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+  * Must equal: "0.3.1"
 
-<a name="mapentry-status-string"/>
-## MapEntry :status ∷ String
-
-current status of the incident
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :status
+  * Plumatic Schema: :revision
 
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * Closed
-    * Containment Achieved
-    * Deleted
-    * Incident Reported
-    * New
-    * Open
-    * Rejected
-    * Restoration Achieved
-    * Stalled
-
-<a name="mapentry-incident_time-incidenttimemap"/>
-## MapEntry :incident_time ∷ *IncidentTime* Map
-
-relevant time values associated with this Incident
-
-* This entry is optional
-* Dev Notes: Was 'time'; renamed for clarity
-
-* Keyword Key
-  * Plumatic Schema: :incident_time
-
-<a name="map2-ref"/>
-* *IncidentTime* Map Value
-  * Details: [*IncidentTime* Map](#map2)
-
-<a name="mapentry-categories-string"/>
-## MapEntry :categories ∷ [String]
-
-a set of categories for this incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :categories
-
-* String Value
-  * Plumatic Schema: [(enum ...)]
-  * Allowed Values:
-    * Denial of Service
-    * Exercise/Network Defense Testing
-    * Improper Usage
-    * Investigation
-    * Malicious Code
-    * Scans/Probes/Attempted Access
-    * Unauthorized Access
-
-<a name="mapentry-reporter-string"/>
-## MapEntry :reporter ∷ String
-
-information about the reporting source of this Incident
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :reporter
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-responder-string"/>
-## MapEntry :responder ∷ String
-
-information about the assigned responder for this Incident
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :responder
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-coordinator-string"/>
-## MapEntry :coordinator ∷ String
-
-information about the assigned coordinator for this Incident
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :coordinator
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-victim-string"/>
-## MapEntry :victim ∷ String
-
-information about a victim of this Incident
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :victim
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-affected_assets-affectedassetmap"/>
-## MapEntry :affected_assets ∷ [*AffectedAsset* Map]
-
-particular assets affected during the Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :affected_assets
-
-<a name="map3-ref"/>
-* *AffectedAsset* Map Value
-  * Details: [*AffectedAsset* Map](#map3)
+* Integer Value
+  * Plumatic Schema: Int
 
 <a name="mapentry-impact_assessment-impactassessmentmap"/>
 ## MapEntry :impact_assessment ∷ *ImpactAssessment* Map
@@ -403,23 +125,153 @@ a summary assessment of impact for this cyber threat Incident
 * *ImpactAssessment* Map Value
   * Details: [*ImpactAssessment* Map](#map4)
 
-<a name="mapentry-security_compromise-string"/>
-## MapEntry :security_compromise ∷ String
+<a name="mapentry-coa_taken-coarequestedmap"/>
+## MapEntry :COA_taken ∷ [*COARequested* Map]
 
-knowledge of whether the Incident involved a compromise of security properties
+specifies and characterizes a Course Of Action taken for this Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :COA_taken
+
+<a name="map6-ref"/>
+* *COARequested* Map Value
+  * Details: [*COARequested* Map](#map6)
+
+<a name="mapentry-leveraged_ttps-relatedttpmap"/>
+## MapEntry :leveraged_TTPs ∷ [*RelatedTTP* Map]
+
+specifies TTPs asserted to be related to this cyber threat Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :leveraged_TTPs
+
+<a name="map10-ref"/>
+* *RelatedTTP* Map Value
+  * Details: [*RelatedTTP* Map](#map10)
+
+<a name="mapentry-related_observables-observablemap"/>
+## MapEntry :related_observables ∷ [*Observable* Map]
+
+identifies or characterizes one or more cyber observables related to this cyber threat incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+* Dev Notes: Was related_observables
+
+* Keyword Key
+  * Plumatic Schema: :related_observables
+
+<a name="map9-ref"/>
+* *Observable* Map Value
+  * Details: [*Observable* Map](#map9)
+
+<a name="mapentry-coa_requested-coarequestedmap"/>
+## MapEntry :COA_requested ∷ [*COARequested* Map]
+
+specifies and characterizes requested Course Of Action for this Incident as specified by the Producer for the Consumer of the Incident Report
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :COA_requested
+
+<a name="map5-ref"/>
+* *COARequested* Map Value
+  * Details: [*COARequested* Map](#map5)
+
+<a name="mapentry-history-historymap"/>
+## MapEntry :history ∷ [*History* Map]
+
+a log of events or actions taken during the handling of the Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :history
+
+<a name="map7-ref"/>
+* *History* Map Value
+  * Details: [*History* Map](#map7)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "incident"
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :security_compromise
+  * Plumatic Schema: :source
 
 * String Value
-  * Plumatic Schema: (enum ...)
-  * Allowed Values:
-    * No
-    * Suspected
-    * Unknown
-    * Yes
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-incident_time-incidenttimemap"/>
+## MapEntry :incident_time ∷ *IncidentTime* Map
+
+relevant time values associated with this Incident
+
+* This entry is optional
+* Dev Notes: Was 'time'; renamed for clarity
+
+* Keyword Key
+  * Plumatic Schema: :incident_time
+
+<a name="map2-ref"/>
+* *IncidentTime* Map Value
+  * Details: [*IncidentTime* Map](#map2)
 
 <a name="mapentry-discovery_method-string"/>
 ## MapEntry :discovery_method ∷ String
@@ -453,140 +305,17 @@ identifies how the incident was discovered
     * Unrelated Party
     * User
 
-<a name="mapentry-coa_requested-coarequestedmap"/>
-## MapEntry :COA_requested ∷ [*COARequested* Map]
-
-specifies and characterizes requested Course Of Action for this Incident as specified by the Producer for the Consumer of the Incident Report
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :COA_requested
-
-<a name="map5-ref"/>
-* *COARequested* Map Value
-  * Details: [*COARequested* Map](#map5)
-
-<a name="mapentry-coa_taken-coarequestedmap"/>
-## MapEntry :COA_taken ∷ [*COARequested* Map]
-
-specifies and characterizes a Course Of Action taken for this Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :COA_taken
-
-<a name="map6-ref"/>
-* *COARequested* Map Value
-  * Details: [*COARequested* Map](#map6)
-
-<a name="mapentry-contact-string"/>
-## MapEntry :contact ∷ String
-
-identifies and characterizes organizations or personnel involved in this Incident
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :contact
+  * Plumatic Schema: :source_uri
 
 * String Value
+  * A URI
   * Plumatic Schema: Str
-
-<a name="mapentry-history-historymap"/>
-## MapEntry :history ∷ [*History* Map]
-
-a log of events or actions taken during the handling of the Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :history
-
-<a name="map7-ref"/>
-* *History* Map Value
-  * Details: [*History* Map](#map7)
-
-<a name="mapentry-related_indicators-relatedindicatormap"/>
-## MapEntry :related_indicators ∷ [*RelatedIndicator* Map]
-
-identifies or characterizes one or more cyber threat Indicators related to this cyber threat Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :related_indicators
-
-<a name="map8-ref"/>
-* *RelatedIndicator* Map Value
-  * Details: [*RelatedIndicator* Map](#map8)
-
-<a name="mapentry-related_observables-observablemap"/>
-## MapEntry :related_observables ∷ [*Observable* Map]
-
-identifies or characterizes one or more cyber observables related to this cyber threat incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-* Dev Notes: Was related_observables
-
-* Keyword Key
-  * Plumatic Schema: :related_observables
-
-<a name="map9-ref"/>
-* *Observable* Map Value
-  * Details: [*Observable* Map](#map9)
-
-<a name="mapentry-leveraged_ttps-relatedttpmap"/>
-## MapEntry :leveraged_TTPs ∷ [*RelatedTTP* Map]
-
-specifies TTPs asserted to be related to this cyber threat Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :leveraged_TTPs
-
-<a name="map10-ref"/>
-* *RelatedTTP* Map Value
-  * Details: [*RelatedTTP* Map](#map10)
-
-<a name="mapentry-attributed_actors-relatedactormap"/>
-## MapEntry :attributed_actors ∷ [*RelatedActor* Map]
-
-identifies ThreatActors asserted to be attributed for this Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-* Dev Notes: was attributed_threat_actors
-
-* Keyword Key
-  * Plumatic Schema: :attributed_actors
-
-<a name="map11-ref"/>
-* *RelatedActor* Map Value
-  * Details: [*RelatedActor* Map](#map11)
-
-<a name="mapentry-related_incidents-relatedincidentmap"/>
-## MapEntry :related_incidents ∷ [*RelatedIncident* Map]
-
-identifies or characterizes one or more other Incidents related to this cyber threat Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :related_incidents
-
-<a name="map12-ref"/>
-* *RelatedIncident* Map Value
-  * Details: [*RelatedIncident* Map](#map12)
 
 <a name="mapentry-intended_effect-string"/>
 ## MapEntry :intended_effect ∷ String
@@ -625,6 +354,265 @@ specifies the suspected intended effect of this incident
     * Theft - Theft of Proprietary Information
     * Traffic Diversion
     * Unauthorized Access
+
+<a name="mapentry-categories-string"/>
+## MapEntry :categories ∷ [String]
+
+a set of categories for this incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :categories
+
+* String Value
+  * Plumatic Schema: [(enum ...)]
+  * Allowed Values:
+    * Denial of Service
+    * Exercise/Network Defense Testing
+    * Improper Usage
+    * Investigation
+    * Malicious Code
+    * Scans/Probes/Attempted Access
+    * Unauthorized Access
+
+<a name="mapentry-reporter-string"/>
+## MapEntry :reporter ∷ String
+
+information about the reporting source of this Incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :reporter
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-victim-string"/>
+## MapEntry :victim ∷ String
+
+information about a victim of this Incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :victim
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-attributed_actors-relatedactormap"/>
+## MapEntry :attributed_actors ∷ [*RelatedActor* Map]
+
+identifies ThreatActors asserted to be attributed for this Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+* Dev Notes: was attributed_threat_actors
+
+* Keyword Key
+  * Plumatic Schema: :attributed_actors
+
+<a name="map11-ref"/>
+* *RelatedActor* Map Value
+  * Details: [*RelatedActor* Map](#map11)
+
+<a name="mapentry-coordinator-string"/>
+## MapEntry :coordinator ∷ String
+
+information about the assigned coordinator for this Incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :coordinator
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-status-string"/>
+## MapEntry :status ∷ String
+
+current status of the incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :status
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * Closed
+    * Containment Achieved
+    * Deleted
+    * Incident Reported
+    * New
+    * Open
+    * Rejected
+    * Restoration Achieved
+    * Stalled
+
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :language
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a name="mapentry-related_incidents-relatedincidentmap"/>
+## MapEntry :related_incidents ∷ [*RelatedIncident* Map]
+
+identifies or characterizes one or more other Incidents related to this cyber threat Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :related_incidents
+
+<a name="map12-ref"/>
+* *RelatedIncident* Map Value
+  * Details: [*RelatedIncident* Map](#map12)
+
+<a name="mapentry-responder-string"/>
+## MapEntry :responder ∷ String
+
+information about the assigned responder for this Incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :responder
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-confidence-string"/>
+## MapEntry :confidence ∷ String
+
+level of confidence held in the characterization of this Incident
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :confidence
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * High
+    * Low
+    * Medium
+    * None
+    * Unknown
+  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a name="mapentry-contact-string"/>
+## MapEntry :contact ∷ String
+
+identifies and characterizes organizations or personnel involved in this Incident
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :contact
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-security_compromise-string"/>
+## MapEntry :security_compromise ∷ String
+
+knowledge of whether the Incident involved a compromise of security properties
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :security_compromise
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Allowed Values:
+    * No
+    * Suspected
+    * Unknown
+    * Yes
+
+<a name="mapentry-affected_assets-affectedassetmap"/>
+## MapEntry :affected_assets ∷ [*AffectedAsset* Map]
+
+particular assets affected during the Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :affected_assets
+
+<a name="map3-ref"/>
+* *AffectedAsset* Map Value
+  * Details: [*AffectedAsset* Map](#map3)
 
 <a name="map1"/>
 # *ValidTime* Map

--- a/doc/structures/indicator.md
+++ b/doc/structures/indicator.md
@@ -18,164 +18,54 @@ _specification_ value.
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
+|[:related_indicators](#mapentry-related_indicators-relatedindicatormap)|*RelatedIndicator* Map||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
+|[:tags](#mapentry-tags-string)|String||
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
 |[:producer](#mapentry-producer-string)|String|&#10003;|
-|[:alternate_ids](#mapentry-alternate_ids-string)|String||
-|[:negate](#mapentry-negate-boolean)|Boolean||
-|[:indicator_type](#mapentry-indicator_type-string)|String||
-|[:tags](#mapentry-tags-string)|String||
-|[:judgements](#mapentry-judgements-relatedjudgementmap)|*RelatedJudgement* Map||
-|[:composite_indicator_expression](#mapentry-composite_indicator_expression-compositeindicatorexpressionmap)|*CompositeIndicatorExpression* Map||
-|[:indicated_TTP](#mapentry-indicated_ttp-relatedttpmap)|*RelatedTTP* Map||
-|[:likely_impact](#mapentry-likely_impact-string)|String||
-|[:suggested_COAs](#mapentry-suggested_coas-relatedcoamap)|*RelatedCOA* Map||
-|[:confidence](#mapentry-confidence-string)|String||
-|[:related_indicators](#mapentry-related_indicators-relatedindicatormap)|*RelatedIndicator* Map||
 |[:related_campaigns](#mapentry-related_campaigns-relatedcampaignmap)|*RelatedCampaign* Map||
-|[:related_COAs](#mapentry-related_coas-relatedcoamap)|*RelatedCOA* Map||
-|[:kill_chain_phases](#mapentry-kill_chain_phases-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:type](#mapentry-type-string)|String|&#10003;|
 |[:test_mechanisms](#mapentry-test_mechanisms-string)|String||
+|[:related_COAs](#mapentry-related_coas-relatedcoamap)|*RelatedCOA* Map||
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:composite_indicator_expression](#mapentry-composite_indicator_expression-compositeindicatorexpressionmap)|*CompositeIndicatorExpression* Map||
+|[:alternate_ids](#mapentry-alternate_ids-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:likely_impact](#mapentry-likely_impact-string)|String||
+|[:indicator_type](#mapentry-indicator_type-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:indicated_TTP](#mapentry-indicated_ttp-relatedttpmap)|*RelatedTTP* Map||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:judgements](#mapentry-judgements-relatedjudgementmap)|*RelatedJudgement* Map||
+|[:suggested_COAs](#mapentry-suggested_coas-relatedcoamap)|*RelatedCOA* Map||
+|[:tlp](#mapentry-tlp-string)|String||
+|[:kill_chain_phases](#mapentry-kill_chain_phases-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:negate](#mapentry-negate-boolean)|Boolean||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String||
 |[:specification](#mapentry-specification-either)|*JudgementSpecification* Map||
 * Reference: [IndicatorType](http://stixproject.github.io/data-model/1.2/indicator/IndicatorType/)
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-related_indicators-relatedindicatormap"/>
+## MapEntry :related_indicators ∷ [*RelatedIndicator* Map]
 
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
+relationship between the enclosing indicator and a disparate indicator
 
 * This entry is optional
 * This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :external_ids
+  * Plumatic Schema: :related_indicators
 
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
+<a name="map6-ref"/>
+* *RelatedIndicator* Map Value
+  * Details: [*RelatedIndicator* Map](#map6)
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -189,51 +79,19 @@ CTIM schema version for this entity
   * Markdown text
   * Plumatic Schema: Str
 
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
+<a name="mapentry-tags-string"/>
+## MapEntry :tags ∷ [String]
+
+Descriptors for this indicator
 
 * This entry is optional
+* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :short_description
+  * Plumatic Schema: :tags
 
 * String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "indicator"
+  * Plumatic Schema: [Str]
 
 <a name="mapentry-valid_time-validtimemap"/>
 ## MapEntry :valid_time ∷ *ValidTime* Map
@@ -259,6 +117,134 @@ CTIM schema version for this entity
 * String Value
   * Plumatic Schema: Str
 
+<a name="mapentry-related_campaigns-relatedcampaignmap"/>
+## MapEntry :related_campaigns ∷ [*RelatedCampaign* Map]
+
+references to related campaigns
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :related_campaigns
+
+<a name="map7-ref"/>
+* *RelatedCampaign* Map Value
+  * Details: [*RelatedCampaign* Map](#map7)
+
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
+
+CTIM schema version for this entity
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :schema_version
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "0.3.1"
+
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :revision
+
+* Integer Value
+  * Plumatic Schema: Int
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "indicator"
+
+<a name="mapentry-test_mechanisms-string"/>
+## MapEntry :test_mechanisms ∷ [String]
+
+Test Mechanisms effective at identifying the cyber Observables specified in this cyber threat Indicator
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+* Dev Notes: simplified
+
+* Keyword Key
+  * Plumatic Schema: :test_mechanisms
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-related_coas-relatedcoamap"/>
+## MapEntry :related_COAs ∷ [*RelatedCOA* Map]
+
+related Courses of Actions for this cyber threat Indicator
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :related_COAs
+
+<a name="map8-ref"/>
+* *RelatedCOA* Map Value
+  * Details: [*RelatedCOA* Map](#map8)
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-composite_indicator_expression-compositeindicatorexpressionmap"/>
+## MapEntry :composite_indicator_expression ∷ *CompositeIndicatorExpression* Map
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :composite_indicator_expression
+
+<a name="map3-ref"/>
+* *CompositeIndicatorExpression* Map Value
+  * Details: [*CompositeIndicatorExpression* Map](#map3)
+
 <a name="mapentry-alternate_ids-string"/>
 ## MapEntry :alternate_ids ∷ [String]
 
@@ -273,18 +259,29 @@ alternative identifier (or alias)
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-negate-boolean"/>
-## MapEntry :negate ∷ Boolean
-
-specifies the absence of the pattern
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :negate
+  * Plumatic Schema: :title
 
-* Boolean Value
-  * Plumatic Schema: Bool
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-likely_impact-string"/>
+## MapEntry :likely_impact ∷ String
+
+likely potential impact within the relevant context if this Indicator were to occur
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :likely_impact
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-indicator_type-string"/>
 ## MapEntry :indicator_type ∷ [String]
@@ -316,46 +313,17 @@ Specifies the type or types for this Indicator
     * URL Watchlist
   * Reference: [IndicatorTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/IndicatorTypeVocab-1.1/)
 
-<a name="mapentry-tags-string"/>
-## MapEntry :tags ∷ [String]
-
-Descriptors for this indicator
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :tags
+  * Plumatic Schema: :source_uri
 
 * String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-judgements-relatedjudgementmap"/>
-## MapEntry :judgements ∷ [*RelatedJudgement* Map]
-
-related Judgements for this Indicator
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :judgements
-
-<a name="map2-ref"/>
-* *RelatedJudgement* Map Value
-  * Details: [*RelatedJudgement* Map](#map2)
-
-<a name="mapentry-composite_indicator_expression-compositeindicatorexpressionmap"/>
-## MapEntry :composite_indicator_expression ∷ *CompositeIndicatorExpression* Map
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :composite_indicator_expression
-
-<a name="map3-ref"/>
-* *CompositeIndicatorExpression* Map Value
-  * Details: [*CompositeIndicatorExpression* Map](#map3)
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-indicated_ttp-relatedttpmap"/>
 ## MapEntry :indicated_TTP ∷ [*RelatedTTP* Map]
@@ -372,18 +340,43 @@ the relevant TTP indicated by this Indicator
 * *RelatedTTP* Map Value
   * Details: [*RelatedTTP* Map](#map4)
 
-<a name="mapentry-likely_impact-string"/>
-## MapEntry :likely_impact ∷ String
-
-likely potential impact within the relevant context if this Indicator were to occur
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :likely_impact
+  * Plumatic Schema: :language
 
 * String Value
   * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-judgements-relatedjudgementmap"/>
+## MapEntry :judgements ∷ [*RelatedJudgement* Map]
+
+related Judgements for this Indicator
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :judgements
+
+<a name="map2-ref"/>
+* *RelatedJudgement* Map Value
+  * Details: [*RelatedJudgement* Map](#map2)
 
 <a name="mapentry-suggested_coas-relatedcoamap"/>
 ## MapEntry :suggested_COAs ∷ [*RelatedCOA* Map]
@@ -399,6 +392,76 @@ suggested Courses of Action
 <a name="map5-ref"/>
 * *RelatedCOA* Map Value
   * Details: [*RelatedCOA* Map](#map5)
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a name="mapentry-kill_chain_phases-string"/>
+## MapEntry :kill_chain_phases ∷ [String]
+
+relevant kill chain phases indicated by this Indicator
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+* Dev Notes: simplified
+
+* Keyword Key
+  * Plumatic Schema: :kill_chain_phases
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-negate-boolean"/>
+## MapEntry :negate ∷ Boolean
+
+specifies the absence of the pattern
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :negate
+
+* Boolean Value
+  * Plumatic Schema: Bool
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
 
 <a name="mapentry-confidence-string"/>
 ## MapEntry :confidence ∷ String
@@ -419,81 +482,6 @@ level of confidence held in the accuracy of this Indicator
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
-
-<a name="mapentry-related_indicators-relatedindicatormap"/>
-## MapEntry :related_indicators ∷ [*RelatedIndicator* Map]
-
-relationship between the enclosing indicator and a disparate indicator
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :related_indicators
-
-<a name="map6-ref"/>
-* *RelatedIndicator* Map Value
-  * Details: [*RelatedIndicator* Map](#map6)
-
-<a name="mapentry-related_campaigns-relatedcampaignmap"/>
-## MapEntry :related_campaigns ∷ [*RelatedCampaign* Map]
-
-references to related campaigns
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :related_campaigns
-
-<a name="map7-ref"/>
-* *RelatedCampaign* Map Value
-  * Details: [*RelatedCampaign* Map](#map7)
-
-<a name="mapentry-related_coas-relatedcoamap"/>
-## MapEntry :related_COAs ∷ [*RelatedCOA* Map]
-
-related Courses of Actions for this cyber threat Indicator
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :related_COAs
-
-<a name="map8-ref"/>
-* *RelatedCOA* Map Value
-  * Details: [*RelatedCOA* Map](#map8)
-
-<a name="mapentry-kill_chain_phases-string"/>
-## MapEntry :kill_chain_phases ∷ [String]
-
-relevant kill chain phases indicated by this Indicator
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-* Dev Notes: simplified
-
-* Keyword Key
-  * Plumatic Schema: :kill_chain_phases
-
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-test_mechanisms-string"/>
-## MapEntry :test_mechanisms ∷ [String]
-
-Test Mechanisms effective at identifying the cyber Observables specified in this cyber threat Indicator
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-* Dev Notes: simplified
-
-* Keyword Key
-  * Plumatic Schema: :test_mechanisms
-
-* String Value
-  * Plumatic Schema: [Str]
 
 <a name="mapentry-specification-either"/>
 ## MapEntry :specification ∷ Either

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -15,51 +15,39 @@ A judgement about the intent or nature of an observable.  For
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:source](#mapentry-source-string)|String|&#10003;|
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:observable](#mapentry-observable-observablemap)|*Observable* Map|&#10003;|
-|[:disposition](#mapentry-disposition-integer)|Integer|&#10003;|
-|[:disposition_name](#mapentry-disposition_name-string)|String|&#10003;|
-|[:priority](#mapentry-priority-integer)|Integer|&#10003;|
-|[:confidence](#mapentry-confidence-string)|String|&#10003;|
-|[:severity](#mapentry-severity-integer)|Integer|&#10003;|
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
-|[:reason](#mapentry-reason-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:observable](#mapentry-observable-observablemap)|*Observable* Map|&#10003;|
 |[:reason_uri](#mapentry-reason_uri-string)|String||
 |[:indicators](#mapentry-indicators-relatedindicatormap)|*RelatedIndicator* Map||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String|&#10003;|
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:disposition](#mapentry-disposition-integer)|Integer|&#10003;|
+|[:reason](#mapentry-reason-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:disposition_name](#mapentry-disposition_name-string)|String|&#10003;|
+|[:priority](#mapentry-priority-integer)|Integer|&#10003;|
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:severity](#mapentry-severity-integer)|Integer|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String|&#10003;|
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-valid_time-validtimemap"/>
+## MapEntry :valid_time ∷ *ValidTime* Map
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :id
+  * Plumatic Schema: :valid_time
 
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
+<a name="map2-ref"/>
+* *ValidTime* Map Value
+  * Details: [*ValidTime* Map](#map2)
 
 <a name="mapentry-schema_version-string"/>
 ## MapEntry :schema_version ∷ String
@@ -75,18 +63,6 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "0.3.1"
 
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-revision-integer"/>
 ## MapEntry :revision ∷ Integer
 
@@ -98,81 +74,42 @@ CTIM schema version for this entity
 * Integer Value
   * Plumatic Schema: Int
 
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
+<a name="mapentry-observable-observablemap"/>
+## MapEntry :observable ∷ *Observable* Map
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :observable
+
+<a name="map1-ref"/>
+* *Observable* Map Value
+  * Details: [*Observable* Map](#map1)
+
+<a name="mapentry-reason_uri-string"/>
+## MapEntry :reason_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :reason_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-indicators-relatedindicatormap"/>
+## MapEntry :indicators ∷ [*RelatedIndicator* Map]
 
 * This entry is optional
 * This entry's type is sequential (allows zero or more values)
 
 * Keyword Key
-  * Plumatic Schema: :external_ids
+  * Plumatic Schema: :indicators
 
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
+<a name="map3-ref"/>
+* *RelatedIndicator* Map Value
+  * Details: [*RelatedIndicator* Map](#map3)
 
 <a name="mapentry-type-string"/>
 ## MapEntry :type ∷ String
@@ -186,17 +123,28 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "judgement"
 
-<a name="mapentry-observable-observablemap"/>
-## MapEntry :observable ∷ *Observable* Map
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :observable
+  * Plumatic Schema: :source
 
-<a name="map1-ref"/>
-* *Observable* Map Value
-  * Details: [*Observable* Map](#map1)
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
 
 <a name="mapentry-disposition-integer"/>
 ## MapEntry :disposition ∷ Integer
@@ -217,6 +165,29 @@ Matches :disposition_name as in {1 "Clean", 2 "Malicious", 3 "Suspicious", 4 "Co
     * 3
     * 4
     * 5
+
+<a name="mapentry-reason-string"/>
+## MapEntry :reason ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :reason
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-disposition_name-string"/>
 ## MapEntry :disposition_name ∷ String
@@ -248,6 +219,82 @@ Matches :disposition_name as in {1 "Clean", 2 "Malicious", 3 "Suspicious", 4 "Co
   * A value 0-100 that determine the priority of a judgement. Curated feeds of black/white lists, for example known good products within your organizations, should use a 95. All automated systems should use a priority of 90, or less.  Human judgements should have a priority of 100, so that humans can always override machines.
   * Plumatic Schema: Int
 
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :language
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-severity-integer"/>
+## MapEntry :severity ∷ Integer
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :severity
+
+* Integer Value
+  * Plumatic Schema: Int
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
 <a name="mapentry-confidence-string"/>
 ## MapEntry :confidence ∷ String
 
@@ -265,65 +312,6 @@ Matches :disposition_name as in {1 "Clean", 2 "Malicious", 3 "Suspicious", 4 "Co
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
-
-<a name="mapentry-severity-integer"/>
-## MapEntry :severity ∷ Integer
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :severity
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-valid_time-validtimemap"/>
-## MapEntry :valid_time ∷ *ValidTime* Map
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :valid_time
-
-<a name="map2-ref"/>
-* *ValidTime* Map Value
-  * Details: [*ValidTime* Map](#map2)
-
-<a name="mapentry-reason-string"/>
-## MapEntry :reason ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :reason
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-reason_uri-string"/>
-## MapEntry :reason_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :reason_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-indicators-relatedindicatormap"/>
-## MapEntry :indicators ∷ [*RelatedIndicator* Map]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :indicators
-
-<a name="map3-ref"/>
-* *RelatedIndicator* Map Value
-  * Details: [*RelatedIndicator* Map](#map3)
 
 <a name="map1"/>
 # *Observable* Map

--- a/doc/structures/relationship.md
+++ b/doc/structures/relationship.md
@@ -5,46 +5,34 @@ Represents a relationship between two entities
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:relationship_type](#mapentry-relationship_type-string)|String|&#10003;|
-|[:source_ref](#mapentry-source_ref-string)|String|&#10003;|
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
 |[:target_ref](#mapentry-target_ref-string)|String|&#10003;|
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:source_ref](#mapentry-source_ref-string)|String|&#10003;|
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:relationship_type](#mapentry-relationship_type-string)|String|&#10003;|
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-description-string"/>
+## MapEntry :description ∷ String
 
-* This entry is required
+* This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :id
+  * Plumatic Schema: :description
 
 * String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
+  * Markdown text
   * Plumatic Schema: Str
 
 <a name="mapentry-schema_version-string"/>
@@ -61,18 +49,6 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "0.3.1"
 
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-revision-integer"/>
 ## MapEntry :revision ∷ Integer
 
@@ -83,6 +59,41 @@ CTIM schema version for this entity
 
 * Integer Value
   * Plumatic Schema: Int
+
+<a name="mapentry-target_ref-string"/>
+## MapEntry :target_ref ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :target_ref
+
+* String Value
+  * A URI leading to an entity
+  * Plumatic Schema: Str
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "relationship"
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-external_ids-string"/>
 ## MapEntry :external_ids ∷ [String]
@@ -96,17 +107,51 @@ CTIM schema version for this entity
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :timestamp
+  * Plumatic Schema: :short_description
 
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_ref-string"/>
+## MapEntry :source_ref ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :source_ref
+
+* String Value
+  * A URI leading to an entity
+  * Plumatic Schema: Str
 
 <a name="mapentry-language-string"/>
 ## MapEntry :language ∷ String
@@ -117,6 +162,18 @@ CTIM schema version for this entity
   * Plumatic Schema: :language
 
 * String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
   * Plumatic Schema: Str
 
 <a name="mapentry-tlp-string"/>
@@ -137,74 +194,29 @@ CTIM schema version for this entity
     * red
     * white
 
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-description-string"/>
-## MapEntry :description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :description
-
-* String Value
-  * Markdown text
-  * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
+  * Plumatic Schema: :uri
 
 * String Value
   * A URI
   * Plumatic Schema: Str
 
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
 
-* This entry is required
+* This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :type
+  * Plumatic Schema: :timestamp
 
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "relationship"
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
 
 <a name="mapentry-relationship_type-string"/>
 ## MapEntry :relationship_type ∷ String
@@ -216,28 +228,4 @@ CTIM schema version for this entity
   * Plumatic Schema: :relationship_type
 
 * String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_ref-string"/>
-## MapEntry :source_ref ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :source_ref
-
-* String Value
-  * A URI leading to an entity
-  * Plumatic Schema: Str
-
-<a name="mapentry-target_ref-string"/>
-## MapEntry :target_ref ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :target_ref
-
-* String Value
-  * A URI leading to an entity
   * Plumatic Schema: Str

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -5,52 +5,40 @@ A single sighting of an [indicator](indicator.md)
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:observed_time](#mapentry-observed_time-observedtimemap)|*ObservedTime* Map|&#10003;|
-|[:confidence](#mapentry-confidence-string)|String|&#10003;|
-|[:count](#mapentry-count-integer)|Integer|&#10003;|
-|[:sensor](#mapentry-sensor-string)|String||
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
+|[:relations](#mapentry-relations-observedrelationmap)|*ObservedRelation* Map||
 |[:observables](#mapentry-observables-observablemap)|*Observable* Map||
 |[:indicators](#mapentry-indicators-relatedindicatormap)|*RelatedIndicator* Map||
-|[:relations](#mapentry-relations-observedrelationmap)|*ObservedRelation* Map||
+|[:type](#mapentry-type-string)|String|&#10003;|
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:count](#mapentry-count-integer)|Integer|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
 |[:incidents](#mapentry-incidents-relatedincidentmap)|*RelatedIncident* Map||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:confidence](#mapentry-confidence-string)|String|&#10003;|
+|[:observed_time](#mapentry-observed_time-observedtimemap)|*ObservedTime* Map|&#10003;|
+|[:sensor](#mapentry-sensor-string)|String||
 * Reference: [SightingType](http://stixproject.github.io/data-model/1.2/indicator/SightingType/)
 
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
+<a name="mapentry-description-string"/>
+## MapEntry :description ∷ String
 
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
+* This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :type
+  * Plumatic Schema: :description
 
 * String Value
+  * Markdown text
   * Plumatic Schema: Str
 
 <a name="mapentry-schema_version-string"/>
@@ -67,18 +55,6 @@ CTIM schema version for this entity
   * Plumatic Schema: (enum ...)
   * Must equal: "0.3.1"
 
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
 <a name="mapentry-revision-integer"/>
 ## MapEntry :revision ∷ Integer
 
@@ -89,6 +65,74 @@ CTIM schema version for this entity
 
 * Integer Value
   * Plumatic Schema: Int
+
+<a name="mapentry-relations-observedrelationmap"/>
+## MapEntry :relations ∷ [*ObservedRelation* Map]
+
+Provide any context we can about where the observable came from
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :relations
+
+<a name="map4-ref"/>
+* *ObservedRelation* Map Value
+  * Details: [*ObservedRelation* Map](#map4)
+
+<a name="mapentry-observables-observablemap"/>
+## MapEntry :observables ∷ [*Observable* Map]
+
+The object(s) of interest
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :observables
+
+<a name="map2-ref"/>
+* *Observable* Map Value
+  * Details: [*Observable* Map](#map2)
+
+<a name="mapentry-indicators-relatedindicatormap"/>
+## MapEntry :indicators ∷ [*RelatedIndicator* Map]
+
+The indicators with think we are seeing
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :indicators
+
+<a name="map3-ref"/>
+* *RelatedIndicator* Map Value
+  * Details: [*RelatedIndicator* Map](#map3)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "sighting"
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
 
 <a name="mapentry-external_ids-string"/>
 ## MapEntry :external_ids ∷ [String]
@@ -102,17 +146,39 @@ CTIM schema version for this entity
 * String Value
   * Plumatic Schema: [Str]
 
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :timestamp
+  * Plumatic Schema: :short_description
 
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-language-string"/>
 ## MapEntry :language ∷ String
@@ -124,6 +190,29 @@ CTIM schema version for this entity
 
 * String Value
   * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-count-integer"/>
+## MapEntry :count ∷ Integer
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :count
+
+* Integer Value
+  * Plumatic Schema: Int
 
 <a name="mapentry-tlp-string"/>
 ## MapEntry :tlp ∷ String
@@ -143,86 +232,42 @@ CTIM schema version for this entity
     * red
     * white
 
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
+<a name="mapentry-incidents-relatedincidentmap"/>
+## MapEntry :incidents ∷ [*RelatedIncident* Map]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :incidents
+
+<a name="map5-ref"/>
+* *RelatedIncident* Map Value
+  * Details: [*RelatedIncident* Map](#map5)
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
+  * Plumatic Schema: :uri
 
 * String Value
   * A URI
   * Plumatic Schema: Str
 
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :title
+  * Plumatic Schema: :timestamp
 
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-description-string"/>
-## MapEntry :description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :description
-
-* String Value
-  * Markdown text
-  * Plumatic Schema: Str
-
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :short_description
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "sighting"
-
-<a name="mapentry-observed_time-observedtimemap"/>
-## MapEntry :observed_time ∷ *ObservedTime* Map
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :observed_time
-
-<a name="map1-ref"/>
-* *ObservedTime* Map Value
-  * Details: [*ObservedTime* Map](#map1)
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
 
 <a name="mapentry-confidence-string"/>
 ## MapEntry :confidence ∷ String
@@ -242,16 +287,17 @@ CTIM schema version for this entity
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
-<a name="mapentry-count-integer"/>
-## MapEntry :count ∷ Integer
+<a name="mapentry-observed_time-observedtimemap"/>
+## MapEntry :observed_time ∷ *ObservedTime* Map
 
 * This entry is required
 
 * Keyword Key
-  * Plumatic Schema: :count
+  * Plumatic Schema: :observed_time
 
-* Integer Value
-  * Plumatic Schema: Int
+<a name="map1-ref"/>
+* *ObservedTime* Map Value
+  * Details: [*ObservedTime* Map](#map1)
 
 <a name="mapentry-sensor-string"/>
 ## MapEntry :sensor ∷ String
@@ -314,64 +360,6 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.virtualization-service
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
-
-<a name="mapentry-observables-observablemap"/>
-## MapEntry :observables ∷ [*Observable* Map]
-
-The object(s) of interest
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :observables
-
-<a name="map2-ref"/>
-* *Observable* Map Value
-  * Details: [*Observable* Map](#map2)
-
-<a name="mapentry-indicators-relatedindicatormap"/>
-## MapEntry :indicators ∷ [*RelatedIndicator* Map]
-
-The indicators with think we are seeing
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :indicators
-
-<a name="map3-ref"/>
-* *RelatedIndicator* Map Value
-  * Details: [*RelatedIndicator* Map](#map3)
-
-<a name="mapentry-relations-observedrelationmap"/>
-## MapEntry :relations ∷ [*ObservedRelation* Map]
-
-Provide any context we can about where the observable came from
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :relations
-
-<a name="map4-ref"/>
-* *ObservedRelation* Map Value
-  * Details: [*ObservedRelation* Map](#map4)
-
-<a name="mapentry-incidents-relatedincidentmap"/>
-## MapEntry :incidents ∷ [*RelatedIncident* Map]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :incidents
-
-<a name="map5-ref"/>
-* *RelatedIncident* Map Value
-  * Details: [*RelatedIncident* Map](#map5)
 
 <a name="map1"/>
 # *ObservedTime* Map

--- a/doc/structures/ttp.md
+++ b/doc/structures/ttp.md
@@ -5,156 +5,31 @@ A TTP is an instance of a Tool, Technique, or Procedure used by a cyber [actor](
 
 | key | type | required? |
 | --- | ---- | --------- |
-|[:id](#mapentry-id-string)|String|&#10003;|
-|[:type](#mapentry-type-string)|String|&#10003;|
-|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
-|[:uri](#mapentry-uri-string)|String||
-|[:revision](#mapentry-revision-integer)|Integer||
-|[:external_ids](#mapentry-external_ids-string)|String||
-|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
-|[:language](#mapentry-language-string)|String||
-|[:tlp](#mapentry-tlp-string)|String||
-|[:title](#mapentry-title-string)|String||
 |[:description](#mapentry-description-string)|String||
-|[:short_description](#mapentry-short_description-string)|String||
-|[:source](#mapentry-source-string)|String||
-|[:source_uri](#mapentry-source_uri-string)|String||
-|[:type](#mapentry-type-string)|String|&#10003;|
+|[:victim_targeting](#mapentry-victim_targeting-victimtargetingmap)|*VictimTargeting* Map||
 |[:valid_time](#mapentry-valid_time-validtimemap)|*ValidTime* Map|&#10003;|
 |[:ttp_type](#mapentry-ttp_type-string)|String|&#10003;|
+|[:schema_version](#mapentry-schema_version-string)|String|&#10003;|
+|[:revision](#mapentry-revision-integer)|Integer||
 |[:indicators](#mapentry-indicators-relatedindicatormap)|*RelatedIndicator* Map|&#10003;|
-|[:intended_effect](#mapentry-intended_effect-string)|String||
+|[:type](#mapentry-type-string)|String|&#10003;|
 |[:behavior](#mapentry-behavior-behaviormap)|*Behavior* Map||
-|[:resources](#mapentry-resources-resourcemap)|*Resource* Map||
-|[:victim_targeting](#mapentry-victim_targeting-victimtargetingmap)|*VictimTargeting* Map||
-|[:exploit_targets](#mapentry-exploit_targets-relatedexploittargetmap)|*RelatedExploitTarget* Map||
+|[:source](#mapentry-source-string)|String||
+|[:external_ids](#mapentry-external_ids-string)|String||
+|[:short_description](#mapentry-short_description-string)|String||
+|[:title](#mapentry-title-string)|String||
+|[:source_uri](#mapentry-source_uri-string)|String||
+|[:intended_effect](#mapentry-intended_effect-string)|String||
 |[:related_TTPs](#mapentry-related_ttps-relatedttpmap)|*RelatedTTP* Map||
+|[:language](#mapentry-language-string)|String||
+|[:id](#mapentry-id-string)|String|&#10003;|
+|[:tlp](#mapentry-tlp-string)|String||
 |[:kill_chains](#mapentry-kill_chains-string)|String||
+|[:uri](#mapentry-uri-string)|String||
+|[:timestamp](#mapentry-timestamp-instdate)|Inst (Date)||
+|[:resources](#mapentry-resources-resourcemap)|*Resource* Map||
+|[:exploit_targets](#mapentry-exploit_targets-relatedexploittargetmap)|*RelatedExploitTarget* Map||
 * Reference: [TTPType](http://stixproject.github.io/data-model/1.2/ttp/TTPType/)
-
-<a name="mapentry-id-string"/>
-## MapEntry :id ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :id
-
-* String Value
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-schema_version-string"/>
-## MapEntry :schema_version ∷ String
-
-CTIM schema version for this entity
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :schema_version
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "0.3.1"
-
-<a name="mapentry-uri-string"/>
-## MapEntry :uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-revision-integer"/>
-## MapEntry :revision ∷ Integer
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :revision
-
-* Integer Value
-  * Plumatic Schema: Int
-
-<a name="mapentry-external_ids-string"/>
-## MapEntry :external_ids ∷ [String]
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :external_ids
-
-* String Value
-  * Plumatic Schema: [Str]
-
-<a name="mapentry-timestamp-instdate"/>
-## MapEntry :timestamp ∷ Inst (Date)
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :timestamp
-
-* Inst (Date) Value
-  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
-  * Plumatic Schema: Inst
-
-<a name="mapentry-language-string"/>
-## MapEntry :language ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :language
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-tlp-string"/>
-## MapEntry :tlp ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :tlp
-
-* String Value
-  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
-  * Plumatic Schema: (enum ...)
-  * Default: green
-  * Allowed Values:
-    * amber
-    * green
-    * red
-    * white
-
-<a name="mapentry-title-string"/>
-## MapEntry :title ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :title
-
-* String Value
-  * Plumatic Schema: Str
 
 <a name="mapentry-description-string"/>
 ## MapEntry :description ∷ String
@@ -168,51 +43,19 @@ CTIM schema version for this entity
   * Markdown text
   * Plumatic Schema: Str
 
-<a name="mapentry-short_description-string"/>
-## MapEntry :short_description ∷ String
+<a name="mapentry-victim_targeting-victimtargetingmap"/>
+## MapEntry :victim_targeting ∷ *VictimTargeting* Map
+
+characterizes the people, organizations, information or access being targeted
 
 * This entry is optional
 
 * Keyword Key
-  * Plumatic Schema: :short_description
+  * Plumatic Schema: :victim_targeting
 
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source-string"/>
-## MapEntry :source ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source
-
-* String Value
-  * Plumatic Schema: Str
-
-<a name="mapentry-source_uri-string"/>
-## MapEntry :source_uri ∷ String
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :source_uri
-
-* String Value
-  * A URI
-  * Plumatic Schema: Str
-
-<a name="mapentry-type-string"/>
-## MapEntry :type ∷ String
-
-* This entry is required
-
-* Keyword Key
-  * Plumatic Schema: :type
-
-* String Value
-  * Plumatic Schema: (enum ...)
-  * Must equal: "ttp"
+<a name="map5-ref"/>
+* *VictimTargeting* Map Value
+  * Details: [*VictimTargeting* Map](#map5)
 
 <a name="mapentry-valid_time-validtimemap"/>
 ## MapEntry :valid_time ∷ *ValidTime* Map
@@ -241,6 +84,31 @@ type of this TTP
 * String Value
   * Plumatic Schema: Str
 
+<a name="mapentry-schema_version-string"/>
+## MapEntry :schema_version ∷ String
+
+CTIM schema version for this entity
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :schema_version
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "0.3.1"
+
+<a name="mapentry-revision-integer"/>
+## MapEntry :revision ∷ Integer
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :revision
+
+* Integer Value
+  * Plumatic Schema: Int
+
 <a name="mapentry-indicators-relatedindicatormap"/>
 ## MapEntry :indicators ∷ [*RelatedIndicator* Map]
 
@@ -255,6 +123,89 @@ related indicators
 <a name="map2-ref"/>
 * *RelatedIndicator* Map Value
   * Details: [*RelatedIndicator* Map](#map2)
+
+<a name="mapentry-type-string"/>
+## MapEntry :type ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :type
+
+* String Value
+  * Plumatic Schema: (enum ...)
+  * Must equal: "ttp"
+
+<a name="mapentry-behavior-behaviormap"/>
+## MapEntry :behavior ∷ *Behavior* Map
+
+describes the attack patterns, malware, or exploits that the attacker leverages to execute this TTP
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :behavior
+
+<a name="map3-ref"/>
+* *Behavior* Map Value
+  * Details: [*Behavior* Map](#map3)
+
+<a name="mapentry-source-string"/>
+## MapEntry :source ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-external_ids-string"/>
+## MapEntry :external_ids ∷ [String]
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :external_ids
+
+* String Value
+  * Plumatic Schema: [Str]
+
+<a name="mapentry-short_description-string"/>
+## MapEntry :short_description ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :short_description
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-title-string"/>
+## MapEntry :title ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :title
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-source_uri-string"/>
+## MapEntry :source_uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :source_uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
 
 <a name="mapentry-intended_effect-string"/>
 ## MapEntry :intended_effect ∷ [String]
@@ -295,63 +246,6 @@ the suspected intended effect for this TTP
     * Traffic Diversion
     * Unauthorized Access
 
-<a name="mapentry-behavior-behaviormap"/>
-## MapEntry :behavior ∷ *Behavior* Map
-
-describes the attack patterns, malware, or exploits that the attacker leverages to execute this TTP
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :behavior
-
-<a name="map3-ref"/>
-* *Behavior* Map Value
-  * Details: [*Behavior* Map](#map3)
-
-<a name="mapentry-resources-resourcemap"/>
-## MapEntry :resources ∷ *Resource* Map
-
-infrastructure or tools that the adversary uses to execute this TTP
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :resources
-
-<a name="map4-ref"/>
-* *Resource* Map Value
-  * Details: [*Resource* Map](#map4)
-
-<a name="mapentry-victim_targeting-victimtargetingmap"/>
-## MapEntry :victim_targeting ∷ *VictimTargeting* Map
-
-characterizes the people, organizations, information or access being targeted
-
-* This entry is optional
-
-* Keyword Key
-  * Plumatic Schema: :victim_targeting
-
-<a name="map5-ref"/>
-* *VictimTargeting* Map Value
-  * Details: [*VictimTargeting* Map](#map5)
-
-<a name="mapentry-exploit_targets-relatedexploittargetmap"/>
-## MapEntry :exploit_targets ∷ [*RelatedExploitTarget* Map]
-
-potential vulnerability, weakness or configuration targets for exploitation by this TTP
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-* Keyword Key
-  * Plumatic Schema: :exploit_targets
-
-<a name="map6-ref"/>
-* *RelatedExploitTarget* Map Value
-  * Details: [*RelatedExploitTarget* Map](#map6)
-
 <a name="mapentry-related_ttps-relatedttpmap"/>
 ## MapEntry :related_TTPs ∷ [*RelatedTTP* Map]
 
@@ -366,6 +260,47 @@ specifies other TTPs asserted to be related to this cyber threat TTP
 <a name="map7-ref"/>
 * *RelatedTTP* Map Value
   * Details: [*RelatedTTP* Map](#map7)
+
+<a name="mapentry-language-string"/>
+## MapEntry :language ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :language
+
+* String Value
+  * Plumatic Schema: Str
+
+<a name="mapentry-id-string"/>
+## MapEntry :id ∷ String
+
+* This entry is required
+
+* Keyword Key
+  * Plumatic Schema: :id
+
+* String Value
+  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * Plumatic Schema: Str
+
+<a name="mapentry-tlp-string"/>
+## MapEntry :tlp ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :tlp
+
+* String Value
+  * TLP Stand for [Traffic Light Protocol](https://www.us-cert.gov/tlp). It indicates precisely how this resource is intended to be shared, replicated, copied...
+  * Plumatic Schema: (enum ...)
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
 
 <a name="mapentry-kill_chains-string"/>
 ## MapEntry :kill_chains ∷ [String]
@@ -386,6 +321,59 @@ specifies other TTPs asserted to be related to this cyber threat TTP
     * Installation
     * Reconnaissance
     * Weaponization
+
+<a name="mapentry-uri-string"/>
+## MapEntry :uri ∷ String
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :uri
+
+* String Value
+  * A URI
+  * Plumatic Schema: Str
+
+<a name="mapentry-timestamp-instdate"/>
+## MapEntry :timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :timestamp
+
+* Inst (Date) Value
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object, serialized as a string the field should follow the rules of the ISO8601 standard.
+  * Plumatic Schema: Inst
+
+<a name="mapentry-resources-resourcemap"/>
+## MapEntry :resources ∷ *Resource* Map
+
+infrastructure or tools that the adversary uses to execute this TTP
+
+* This entry is optional
+
+* Keyword Key
+  * Plumatic Schema: :resources
+
+<a name="map4-ref"/>
+* *Resource* Map Value
+  * Details: [*Resource* Map](#map4)
+
+<a name="mapentry-exploit_targets-relatedexploittargetmap"/>
+## MapEntry :exploit_targets ∷ [*RelatedExploitTarget* Map]
+
+potential vulnerability, weakness or configuration targets for exploitation by this TTP
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+* Keyword Key
+  * Plumatic Schema: :exploit_targets
+
+<a name="map6-ref"/>
+* *RelatedExploitTarget* Map Value
+  * Details: [*RelatedExploitTarget* Map](#map6)
 
 <a name="map1"/>
 # *ValidTime* Map


### PR DESCRIPTION
Related to #83 

The way that markdown generation was implemented, there were duplicate map entries in the documentation.  This fixes that.

See also threatgrid/flanders#1