### PR TITLE
bumped clj-momo to 0.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  [com.andrewmcveigh/cljs-time "0.5.0-alpha1"]
                  [clj-time "0.12.0"]
                  ;; shared libs
-                 [threatgrid/clj-momo "0.2.4"]
+                 [threatgrid/clj-momo "0.2.5"]
 
                  ;; dependency overrides
 


### PR DESCRIPTION
bumped clj-momo to 0.2.5 as CTIM provides CTIA this dep.

connected to https://github.com/threatgrid/ctia/pull/556