### PR TITLE
Update sorting logic that works in CLJS

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -62,4 +62,4 @@
                                          :pretty-print true}}}}
   :test-selectors {:no-gen #(not (:gen %))}
   :profiles {:provided
-             {:dependencies [[org.clojure/clojurescript "1.9.542"]]}})
+             {:dependencies [[org.clojure/clojurescript "1.9.521"]]}})

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [prismatic/schema ~schema-version]
                  ;; for schema descriptions
                  [metosin/ring-swagger "0.22.11"
-                  :exclusions [com.google.code.findbugs/jsr305]]
+                  :exclusions [clj-time
+                               com.google.code.findbugs/jsr305]]
                  [threatgrid/flanders "0.1.5c"
                   :exclusions [com.google.code.findbugs/jsr305]]
                  ;; for merge and such
@@ -20,16 +21,15 @@
                  ;; for generators
                  [org.clojure/test.check "0.9.0"]
                  [com.gfredericks/test.chuck "0.2.7"
-                  :exclusions [instaparse]]
+                  :exclusions [clj-time
+                               com.andrewmcveigh/cljs-time
+                               instaparse]]
                  [prismatic/schema-generators "0.1.0"
                   :exclusions [prismatic/schema]]
                  ;; for url
                  [com.cemerick/url "0.1.1"]
-                 ;; time
-                 [com.andrewmcveigh/cljs-time "0.5.0-alpha1"]
-                 [clj-time "0.12.0"]
                  ;; shared libs
-                 [threatgrid/clj-momo "0.2.6"]
+                 [threatgrid/clj-momo "0.2.8-SNAPSHOT"]
 
                  ;; dependency overrides
 
@@ -62,4 +62,4 @@
                                          :pretty-print true}}}}
   :test-selectors {:no-gen #(not (:gen %))}
   :profiles {:provided
-             {:dependencies [[org.clojure/clojurescript "1.9.293"]]}})
+             {:dependencies [[org.clojure/clojurescript "1.9.542"]]}})

--- a/src/ctim/domain/disposition.cljc
+++ b/src/ctim/domain/disposition.cljc
@@ -1,15 +1,10 @@
-(ns ctim.domain.disposition)
-
-(def ^:private weights
-  {"Clean"      1
-   "Malicious"  2
-   "Suspicious" 3
-   "Unknown"    4})
+(ns ctim.domain.disposition
+  (:require [ctim.schemas.common :as c]))
 
 (defn importance [a b]
   (compare
-   (get weights a 99)
-   (get weights b 99)))
+   (get c/disposition-map-inverted a 99)
+   (get c/disposition-map-inverted b 99)))
 
 (defn sort-by-importance
   ([f objs]

--- a/src/ctim/domain/disposition.cljc
+++ b/src/ctim/domain/disposition.cljc
@@ -1,13 +1,16 @@
 (ns ctim.domain.disposition
   (:require [ctim.schemas.common :as c]))
 
-(defn importance [a b]
+(defn importance [disp]
+  (get c/disposition-map-inverted disp 99))
+
+(defn compare-importance [a b]
   (compare
-   (get c/disposition-map-inverted a 99)
-   (get c/disposition-map-inverted b 99)))
+   (importance a)
+   (importance b)))
 
 (defn sort-by-importance
   ([f objs]
-   (sort-by f importance objs))
+   (sort-by f compare-importance objs))
   ([dispositions]
    (sort-by-importance identity dispositions)))

--- a/src/ctim/domain/id.cljc
+++ b/src/ctim/domain/id.cljc
@@ -1,14 +1,16 @@
 (ns ctim.domain.id
+  (:refer-clojure :exclude [random-uuid])
   (:require #?(:clj  [clojure.spec :as cs]
                :cljs [cljs.spec :as cs])
             [clj-momo.lib.url :as url]
             [schema.core :as s])
-  (:import [java.util UUID]))
+  #?(:clj (:import [java.util UUID])))
 
 (defn- random-uuid
   "This exists for easy mocking"
   []
-  (UUID/randomUUID))
+  #?(:clj  (UUID/randomUUID)
+     :cljs (cljs.core/random-uuid)))
 
 (defn make-transient-id [type]
   (str "transient:" (random-uuid)))

--- a/src/ctim/domain/sorting.cljc
+++ b/src/ctim/domain/sorting.cljc
@@ -1,27 +1,43 @@
 (ns ctim.domain.sorting
-  (:require [ctim.domain.disposition :as dispositions]))
+  (:require
+   [clj-momo.lib.clj-time.core :as time]
+   [ctim.domain.validity :as validity]))
 
 ;;------------------------------------------------------------------------------
 ;; Judgements
 ;;------------------------------------------------------------------------------
 
+
+
 (defn compare-judgements
-  [{{j1_start :start_time} :valid_time
-    j1_disp :disposition}
+  "Compare judgements, first by validity (valid first), then by
+  disposition number, and then by start-time (newest first).  It
+  depends on a stable 'now', so it must be passed in.  Returns -1, 0,
+  or 1, as per 'compare."
+  [dt-now
+   {{j1_start :start_time} :valid_time
+    j1_disp :disposition
+    :as j1}
    {{j2_start :start_time} :valid_time
-    j2_disp :disposition}]
-  (let [result (dispositions/importance j1_disp
-                                        j2_disp)]
-    (if (not= 0 result)
-      result
-      (compare j2_start j1_start)))) ;; reverse sort
+    j2_disp :disposition
+    :as j2}]
+  (let [;; Validity is reverse sorted so that true comes before false
+        result1 (compare (validity/valid-now? dt-now j2)
+                         (validity/valid-now? dt-now j1))]
+    (if (not= 0 result1)
+      result1
+      (let [result2 (compare j1_disp j2_disp)]
+        (if (not= 0 result2)
+          result2
+          ;; Start-time is reverse sorted
+          (compare j2_start j1_start))))))
 
 (defn sort-judgements
-  "Sorts Judgements based on disposition first, then valid_time"
+  "Sorts Judgements based on validity, disposition, and finally by start-time"
   [judgements]
   (sort-by identity
-          compare-judgements
-          judgements))
+           (partial compare-judgements (time/internal-now))
+           judgements))
 
 ;;------------------------------------------------------------------------------
 ;; Sightings

--- a/src/ctim/domain/sorting.cljc
+++ b/src/ctim/domain/sorting.cljc
@@ -1,0 +1,34 @@
+(ns ctim.domain.sorting
+  (:require [ctim.domain.disposition :as dispositions]))
+
+;;------------------------------------------------------------------------------
+;; Judgements
+;;------------------------------------------------------------------------------
+
+(defn compare-judgements
+  [{{j1_start :start_time} :valid_time
+    j1_disp :disposition}
+   {{j2_start :start_time} :valid_time
+    j2_disp :disposition}]
+  (let [result (dispositions/importance j1_disp
+                                        j2_disp)]
+    (if (not= 0 result)
+      result
+      (compare j2_start j1_start)))) ;; reverse sort
+
+(defn sort-judgements
+  "Sorts Judgements based on disposition first, then valid_time"
+  [judgements]
+  (sort-by identity
+          compare-judgements
+          judgements))
+
+;;------------------------------------------------------------------------------
+;; Sightings
+;;------------------------------------------------------------------------------
+
+(defn sort-sightings
+  [sightings]
+  (sort-by (comp :start_time :observed_time)
+           #(compare %2 %1)
+           sightings))

--- a/src/ctim/domain/time.cljc
+++ b/src/ctim/domain/time.cljc
@@ -1,0 +1,3 @@
+(ns ctim.domain.time)
+
+(def default-expire-date (time/internal-date 2525 1 1))

--- a/src/ctim/domain/validity.cljc
+++ b/src/ctim/domain/validity.cljc
@@ -1,0 +1,25 @@
+(ns ctim.domain.validity
+  (:require [clj-momo.lib.clj-time.core :as time]
+            [clj-momo.lib.clj-time.coerce :as time-coerce]))
+
+(defn valid-now?
+  "Determine if an entity (such as a judgement) is valid, based
+  on :valid_time.  Depends on knowing the time 'now', so that is
+  passed in."
+  [dt-now
+   {{:keys [start_time end_time]} :valid_time}]
+  (let [start (time-coerce/to-internal-date start_time)
+        end (time-coerce/to-internal-date end_time)]
+    (cond
+      (and start end)
+      (time/within? start end dt-now)
+
+      end
+      (time/before? dt-now end)
+
+      start
+      (or
+       (time/after? dt-now start)
+       (time/equal? dt-now start))
+
+      :else true)))

--- a/src/ctim/generators/common.cljc
+++ b/src/ctim/generators/common.cljc
@@ -1,6 +1,6 @@
 (ns ctim.generators.common
   (:refer-clojure :exclude [vector set])
-  (:require [clj-momo.lib.time :as time]
+  (:require [clj-momo.lib.clj-time.core :as time]
             [clojure.test.check.generators :as gen]
             [schema-generators.complete :as sec]
             [schema-generators.generators :as seg]
@@ -78,7 +78,7 @@
                                     (gen/choose 97 122)))
 
 (def leaf-generators
-  {s/Inst (gen/fmap #(time/plus-n-weeks (time/now) %)
+  {s/Inst (gen/fmap #(time/plus (time/internal-now) (time/weeks %))
                     gen/int)})
 
 (defn generate-entity [schema]

--- a/test/ctim/domain/sorting_test.cljc
+++ b/test/ctim/domain/sorting_test.cljc
@@ -1,0 +1,31 @@
+(ns ctim.domain.sorting-test
+  (:require [ctim.domain.sorting :as sut]
+            #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+(deftest compare-judgements-test
+  (testing "sorting judgements"
+    (is (= (sort-by identity
+                    sut/compare-judgements
+                    [{:disposition "Malicious"
+                      :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
+                     {:disposition "Clean"
+                      :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
+                     {:disposition "Malicious"
+                      :valid_time {:start_time "2017-01-10T00:00:00.000Z"}}])
+           [{:disposition "Clean"
+             :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
+            {:disposition "Malicious"
+             :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
+            {:disposition "Malicious"
+             :valid_time {:start_time "2017-01-10T00:00:00.000Z"}}]))))
+
+(deftest sort-sightings-test
+  (testing "sort sightings"
+    (is (= (sut/sort-sightings
+            [{:id 3 :observed_time {:start_time "2017-01-12T00:00:00.000Z"}}
+             {:id 2 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
+             {:id 1 :observed_time {:start_time "2017-01-12T00:00:00.002Z"}}])
+           [{:id 1 :observed_time {:start_time "2017-01-12T00:00:00.002Z"}}
+            {:id 2 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
+            {:id 3 :observed_time {:start_time "2017-01-12T00:00:00.000Z"}}]))))

--- a/test/ctim/domain/sorting_test.cljc
+++ b/test/ctim/domain/sorting_test.cljc
@@ -1,24 +1,72 @@
 (ns ctim.domain.sorting-test
-  (:require [ctim.domain.sorting :as sut]
+  (:require [clj-momo.lib.clj-time.core :as time]
+            [ctim.domain.sorting :as sut]
             #?(:clj [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])))
 
-(deftest compare-judgements-test
-  (testing "sorting judgements"
-    (is (= (sort-by identity
-                    sut/compare-judgements
-                    [{:disposition "Malicious"
-                      :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
-                     {:disposition "Clean"
-                      :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
-                     {:disposition "Malicious"
-                      :valid_time {:start_time "2017-01-10T00:00:00.000Z"}}])
-           [{:disposition "Clean"
-             :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
-            {:disposition "Malicious"
-             :valid_time {:start_time "2017-01-12T00:00:00.000Z"}}
-            {:disposition "Malicious"
-             :valid_time {:start_time "2017-01-10T00:00:00.000Z"}}]))))
+(deftest sort-judgements-test
+  (with-redefs [time/internal-now
+                (constantly
+                  (time/internal-date 2017 5 12))]
+    (is (= (sut/sort-judgements
+            [{:disposition 5,
+              :disposition_name "Unknown",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           :end_time "2017-05-15T21:46:41.690Z"}}
+             {:disposition 2,
+              :disposition_name "Malicious",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           :end_time "2017-05-15T21:46:41.690Z"}}
+             {:disposition 2,
+              :disposition_name "Malicious",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           ;; This one is expired based on mocked 'now'
+                           :end_time "2017-05-10T21:46:41.690Z"}}
+             {:disposition 1,
+              :disposition_name "Clean",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           :end_time "2017-05-15T21:46:41.690Z"}}
+             {:disposition 3,
+              :disposition_name "Suspicious",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           :end_time "2017-05-15T21:46:41.690Z"}}
+             {:disposition 2,
+              :disposition_name "Malicious",
+              :valid_time {:start_time "2017-05-01T21:46:41.690Z",
+                           :end_time "2017-05-15T22:46:41.690Z"}}
+             {:disposition 4,
+              :disposition_name "Common",
+              :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                           :end_time "2017-05-15T21:46:41.690Z"}}])
+           [{:disposition 1,
+             :disposition_name "Clean",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T21:46:41.690Z",
+                          :end_time "2017-05-15T22:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 3,
+             :disposition_name "Suspicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 4,
+             :disposition_name "Common",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 5,
+             :disposition_name "Unknown",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          ;; Expired one comes last
+                          :end_time "2017-05-10T21:46:41.690Z"}}]))))
 
 (deftest sort-sightings-test
   (testing "sort sightings"

--- a/test/ctim/runner.cljs
+++ b/test/ctim/runner.cljs
@@ -2,6 +2,7 @@
   (:require [doo.runner :refer-macros [doo-tests]]
             [ctim.domain.disposition-test]
             [ctim.domain.id-test]
+            [ctim.domain.sorting-test]
             [ctim.schemas.actor-test]
             [ctim.schemas.campaign-test]
             [ctim.schemas.coa-test]
@@ -19,6 +20,7 @@
 
 (doo-tests 'ctim.domain.disposition-test
            'ctim.domain.id-test
+           'ctim.domain.sorting-test
            'ctim.schemas.actor-test
            'ctim.schemas.campaign-test
            'ctim.schemas.coa-test


### PR DESCRIPTION
Improving sorting and related domain logic: 

- Created ctim.domain.time NS
- Added a new feature to Judgement sorting (sorts first by validity)
- Improved the dispositions logic (naming was bad)
- New clj-momo and updated deps / resolved overrides
- This CTIM should work in CLJS

Related to threatgrid/iroh#752
Related to threatgrid/iroh#281
Closes #142 
Depends on threatgrid/clj-momo#14