### PR TITLE
Fixing bug where UtcDateTime comparisons failed in CLJS

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                  ;; for url
                  [com.cemerick/url "0.1.1"]
                  ;; shared libs
-                 [threatgrid/clj-momo "0.2.8"]
+                 [threatgrid/clj-momo "0.2.9-SNAPSHOT"]
 
                  ;; dependency overrides
 

--- a/src/ctim/domain/sorting.cljc
+++ b/src/ctim/domain/sorting.cljc
@@ -1,6 +1,7 @@
 (ns ctim.domain.sorting
   (:require
    [clj-momo.lib.clj-time.core :as time]
+   [clj-momo.lib.clj-time.coerce :as time-coerce]
    [ctim.domain.validity :as validity]))
 
 ;;------------------------------------------------------------------------------
@@ -15,22 +16,30 @@
   depends on a stable 'now', so it must be passed in.  Returns -1, 0,
   or 1, as per 'compare."
   [dt-now
-   {{j1_start :start_time} :valid_time
+   {{j1_start :start_time
+     j1_end   :end_time} :valid_time
     j1_disp :disposition
-    :as j1}
-   {{j2_start :start_time} :valid_time
+    :as _judgement-1_}
+   {{j2_start :start_time
+     j2_end   :end_time} :valid_time
     j2_disp :disposition
-    :as j2}]
-  (let [;; Validity is reverse sorted so that true comes before false
-        result1 (compare (validity/valid-now? dt-now j2)
-                         (validity/valid-now? dt-now j1))]
+    :as _judgement-2_}]
+  (let [j1_start (time-coerce/to-internal-date j1_start)
+        j1_end   (time-coerce/to-internal-date j1_end)
+        j2_start (time-coerce/to-internal-date j2_start)
+        j2_end   (time-coerce/to-internal-date j2_end)
+
+        ;; Validity is reverse sorted so that true comes before false
+        result1 (compare (validity/valid-now? dt-now j2_start j2_end)
+                         (validity/valid-now? dt-now j1_start j1_end))]
     (if (not= 0 result1)
       result1
       (let [result2 (compare j1_disp j2_disp)]
         (if (not= 0 result2)
           result2
           ;; Start-time is reverse sorted
-          (compare j2_start j1_start))))))
+          (compare (time-coerce/to-long j2_start)
+                   (time-coerce/to-long j1_start)))))))
 
 (defn sort-judgements
   "Sorts Judgements based on validity, disposition, and finally by start-time"

--- a/src/ctim/domain/sorting.cljc
+++ b/src/ctim/domain/sorting.cljc
@@ -1,14 +1,12 @@
 (ns ctim.domain.sorting
   (:require
    [clj-momo.lib.clj-time.core :as time]
-   [clj-momo.lib.clj-time.coerce :as time-coerce]
+   [clj-momo.lib.clj-time.coerce :refer [to-internal-date]]
    [ctim.domain.validity :as validity]))
 
 ;;------------------------------------------------------------------------------
 ;; Judgements
 ;;------------------------------------------------------------------------------
-
-
 
 (defn compare-judgements
   "Compare judgements, first by validity (valid first), then by
@@ -16,30 +14,33 @@
   depends on a stable 'now', so it must be passed in.  Returns -1, 0,
   or 1, as per 'compare."
   [dt-now
-   {{j1_start :start_time
-     j1_end   :end_time} :valid_time
-    j1_disp :disposition
+   {{j1-start :start_time
+     j1-end   :end_time} :valid_time
+    j1-disp :disposition
     :as _judgement-1_}
-   {{j2_start :start_time
-     j2_end   :end_time} :valid_time
-    j2_disp :disposition
+   {{j2-start :start_time
+     j2-end   :end_time} :valid_time
+    j2-disp :disposition
     :as _judgement-2_}]
-  (let [j1_start (time-coerce/to-internal-date j1_start)
-        j1_end   (time-coerce/to-internal-date j1_end)
-        j2_start (time-coerce/to-internal-date j2_start)
-        j2_end   (time-coerce/to-internal-date j2_end)
+  (let [dt-j1-start (to-internal-date j1-start)
+        dt-j2-start (to-internal-date j2-start)
 
         ;; Validity is reverse sorted so that true comes before false
-        result1 (compare (validity/valid-now? dt-now j2_start j2_end)
-                         (validity/valid-now? dt-now j1_start j1_end))]
-    (if (not= 0 result1)
-      result1
-      (let [result2 (compare j1_disp j2_disp)]
-        (if (not= 0 result2)
-          result2
+        validity-comp (compare
+                       (validity/valid-now? dt-now
+                                            dt-j2-start
+                                            (to-internal-date j2-end))
+                       (validity/valid-now? dt-now
+                                            dt-j1-start
+                                            (to-internal-date j1-end)))]
+    (if (not= 0 validity-comp)
+      validity-comp
+      (let [disposition-comp (compare j1-disp j2-disp)]
+        (if (not= 0 disposition-comp)
+          disposition-comp
           ;; Start-time is reverse sorted
-          (compare (time-coerce/to-long j2_start)
-                   (time-coerce/to-long j1_start)))))))
+          (compare dt-j2-start
+                   dt-j1-start))))))
 
 (defn sort-judgements
   "Sorts Judgements based on validity, disposition, and finally by start-time"
@@ -47,6 +48,7 @@
   (sort-by identity
            (partial compare-judgements (time/internal-now))
            judgements))
+
 
 ;;------------------------------------------------------------------------------
 ;; Sightings

--- a/src/ctim/domain/validity.cljc
+++ b/src/ctim/domain/validity.cljc
@@ -6,20 +6,21 @@
   "Determine if an entity (such as a judgement) is valid, based
   on :valid_time.  Depends on knowing the time 'now', so that is
   passed in."
-  [dt-now
-   {{:keys [start_time end_time]} :valid_time}]
-  (let [start (time-coerce/to-internal-date start_time)
-        end (time-coerce/to-internal-date end_time)]
-    (cond
-      (and start end)
-      (time/within? start end dt-now)
+  ([dt-now {{:keys [start_time end_time]} :valid_time}]
+   (valid-now? dt-now start_time end_time))
+  ([dt-now start_time end_time]
+   (let [start (time-coerce/to-internal-date start_time)
+         end   (time-coerce/to-internal-date end_time)]
+     (cond
+       (and start end)
+       (time/within? start end dt-now)
 
-      end
-      (time/before? dt-now end)
+       end
+       (time/before? dt-now end)
 
-      start
-      (or
-       (time/after? dt-now start)
-       (time/equal? dt-now start))
+       start
+       (or
+        (time/after? dt-now start)
+        (time/equal? dt-now start))
 
-      :else true)))
+       :else true))))

--- a/test/ctim/domain/sorting_test.cljc
+++ b/test/ctim/domain/sorting_test.cljc
@@ -1,5 +1,6 @@
 (ns ctim.domain.sorting-test
   (:require [clj-momo.lib.clj-time.core :as time]
+            [clj-momo.lib.clj-time.coerce :as time-coerce]
             [ctim.domain.sorting :as sut]
             #?(:clj [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])))
@@ -38,6 +39,92 @@
               :disposition_name "Common",
               :valid_time {:start_time "2017-05-01T20:46:41.690Z",
                            :end_time "2017-05-15T21:46:41.690Z"}}])
+           [{:disposition 1,
+             :disposition_name "Clean",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T21:46:41.690Z",
+                          :end_time "2017-05-15T22:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 3,
+             :disposition_name "Suspicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 4,
+             :disposition_name "Common",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 5,
+             :disposition_name "Unknown",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          :end_time "2017-05-15T21:46:41.690Z"}}
+            {:disposition 2,
+             :disposition_name "Malicious",
+             :valid_time {:start_time "2017-05-01T20:46:41.690Z",
+                          ;; Expired one comes last
+                          :end_time "2017-05-10T21:46:41.690Z"}}]))))
+
+(deftest sort-judgements-with-internal-date-test
+  (with-redefs [time/internal-now
+                (constantly
+                 (time/internal-date 2017 5 12))]
+    (is (= (->> [{:disposition 5,
+                  :disposition_name "Unknown",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T21:46:41.690Z")}}
+                 {:disposition 2,
+                  :disposition_name "Malicious",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T21:46:41.690Z")}}
+                 {:disposition 2,
+                  :disposition_name "Malicious",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               ;; This one is expired based on mocked 'now'
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-10T21:46:41.690Z")}}
+                 {:disposition 1,
+                  :disposition_name "Clean",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T21:46:41.690Z")}}
+                 {:disposition 3,
+                  :disposition_name "Suspicious",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T21:46:41.690Z")}}
+                 {:disposition 2,
+                  :disposition_name "Malicious",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T21:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T22:46:41.690Z")}}
+                 {:disposition 4,
+                  :disposition_name "Common",
+                  :valid_time {:start_time (time-coerce/to-internal-date
+                                            "2017-05-01T20:46:41.690Z"),
+                               :end_time (time-coerce/to-internal-date
+                                          "2017-05-15T21:46:41.690Z")}}]
+                sut/sort-judgements
+                ;; JS dates of the same instant are still not equal, so
+                ;; convert them back to strings for equality check
+                (map (fn [m]
+                       (-> m
+                           (update-in [:valid_time :start_time]
+                                      time-coerce/to-internal-string)
+                           (update-in [:valid_time :end_time]
+                                      time-coerce/to-internal-string)))))
            [{:disposition 1,
              :disposition_name "Clean",
              :valid_time {:start_time "2017-05-01T20:46:41.690Z",


### PR DESCRIPTION
Closes #156

* Relies on latest clj-momo.lib.clj-time.core which makes UtcDateTime comparable.
* Also adds some guarding coercions that make sure input dates are acceptable.