### PR TITLE
Use of flanders def-eq and def-enum-type macros for enums

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [metosin/ring-swagger "0.22.11"
                   :exclusions [clj-time
                                com.google.code.findbugs/jsr305]]
-                 [threatgrid/flanders "0.1.5c"
+                 [threatgrid/flanders "0.1.6-SNAPSHOT"
                   :exclusions [com.google.code.findbugs/jsr305]]
                  ;; for merge and such
                  [metosin/schema-tools ~schema-tools-version]

--- a/src/ctim/schemas/actor.cljc
+++ b/src/ctim/schemas/actor.cljc
@@ -2,12 +2,12 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-eq]])))
 
 (def type-identifier "actor")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq ActorTypeIdentifier type-identifier)
 
 (def actor-desc
   "Describes malicious actors (or adversaries) related to a cyber attack")
@@ -22,7 +22,7 @@
   c/sourced-object-entries
   c/describable-entity-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type ActorTypeIdentifier)
    (f/entry :valid_time c/ValidTime)
    (f/entry :actor_type v/ThreatActorType))
   (f/optional-entries
@@ -41,7 +41,7 @@
   (:entries Actor)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type ActorTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredActor

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -15,12 +15,12 @@
             [ctim.schemas.sighting :refer [SightingRef StoredSighting]]
             [ctim.schemas.ttp :refer [StoredTTP TTPRef]]
             [ctim.schemas.verdict :refer [StoredVerdict VerdictRef]]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def type-identifier "bundle")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq BundleTypeIdentifier type-identifier)
 
 (def objects-entries
   (f/optional-entries
@@ -69,7 +69,7 @@
 
 (def bundle-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type BundleTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type Bundle

--- a/src/ctim/schemas/campaign.cljc
+++ b/src/ctim/schemas/campaign.cljc
@@ -2,12 +2,12 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-eq]])))
 
 (def type-identifier "campaign")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq CampaignTypeIdentifier type-identifier)
 
 (def campaign-desc
   "Represents a campaign by an [actor](actor.md) pursing an intent")
@@ -22,7 +22,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type CampaignTypeIdentifier)
    (f/entry :valid_time c/ValidTime
             :description (str "Timestamp for the definition of a specific "
                               "version of a campaign"))
@@ -49,7 +49,7 @@
   (:entries Campaign)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type CampaignTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredCampaign

--- a/src/ctim/schemas/coa.cljc
+++ b/src/ctim/schemas/coa.cljc
@@ -5,15 +5,17 @@
             [ctim.schemas.openc2vocabularies :as openc2v]
             [ctim.schemas.openc2-network :as open_c2_network_coa]
             [ctim.schemas.openc2-network-sdn :as open_c2_network_sdn_coa]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def type-identifier "coa")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq COATypeIdentifier type-identifier)
+
+(def-eq StructuredCOAType "structured_coa")
 
 (def structured-coa-entries
-  [(f/entry :type (f/eq "structured_coa"))
+  [(f/entry :type StructuredCOAType)
    (f/entry :id f/any-str)])
 
 (def-map-type ActionType
@@ -101,6 +103,8 @@
 (def coa-desc-link
   "[CourseOfActionType](http://stixproject.github.io/data-model/1.2/coa/CourseOfActionType/)")
 
+(def-eq OpenC2StructuredCOAType "openc2")
+
 (def-entity-type COA
   {:description coa-desc
    :reference coa-desc-link}
@@ -108,7 +112,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type COATypeIdentifier)
    (f/entry :valid_time c/ValidTime))
   (f/optional-entries
    (f/entry :stage v/COAStage
@@ -133,7 +137,7 @@
             :description (str "Identifies or characterizes relationships to"
                               " one or more related courses of action"))
    ;; Technical params using the CybOX language
-   (f/entry :structured_coa_type (f/eq "openc2"))
+   (f/entry :structured_coa_type OpenC2StructuredCOAType)
    (f/entry :open_c2_coa OpenC2COA))
   ;; Not provided: handling
   ;; Not provided: parameter_observables
@@ -145,7 +149,7 @@
   (:entries COA)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type COATypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredCOA

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -7,13 +7,19 @@
             [ctim.domain.id :as id]
             [ctim.generators.id :as gen-id]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-map-type]])
+            #?(:clj  [flanders.core :as f :refer [def-map-type
+                                                  def-enum-type
+                                                  def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-map-type
+                                                         def-enum-type
+                                                         def-eq]])
             [flanders.navigation :as fn]
             [flanders.predicates :as fp]
             [schema.core :as s]))
 
 (def ctim-schema-version "0.4.9")
+
+(def-eq CTIMSchemaVersion ctim-schema-version)
 
 (def Reference
   (f/str :description "A URI leading to an entity"
@@ -67,16 +73,15 @@
 (def Markdown
   (f/str :description "Markdown text"))
 
-(def TLP
-  (f/enum #{"red" "amber" "green" "white"}
-          :default "green"
-          :description (str "TLP stands for [Traffic Light Protocol]"
-                            "(https://www.us-cert.gov/tlp), which indicates precisely "
-                            "how this resource is intended to be shared, replicated, "
-                            "copied, etc.")))
+(def default-tlp "green")
 
-(def default-tlp
-  (:default TLP))
+(def-enum-type TLP
+  #{"red" "amber" "green" "white"}
+  :default default-tlp
+  :description (str "TLP stands for [Traffic Light Protocol]"
+                             "(https://www.us-cert.gov/tlp), which indicates precisely "
+                             "how this resource is intended to be shared, replicated, "
+                             "copied, etc."))
 
 (cs/def ::ctim-schema-version
   #(re-matches #"\w+.\w+\.\w+" %))
@@ -112,7 +117,7 @@
     (f/entry :id ID)
     (f/entry :type f/any-str
              :description "A valid entity type identifer")
-    (f/entry :schema_version (f/eq ctim-schema-version)
+    (f/entry :schema_version CTIMSchemaVersion
              :description "CTIM schema version for this entity"))))
 
 (def describable-entity-entries
@@ -141,11 +146,11 @@
     "Snort"
     "OpenIOC"})
 
-(def SpecificationType
-  (f/enum specification-types
-          :description (str "Types of Indicator we support Currently only Judgement "
-                            "indicators,which contain a list of Judgements "
-                            "associated with this indicator.")))
+(def-enum-type SpecificationType
+  specification-types
+  :description (str "Types of Indicator we support Currently only Judgement "
+                    "indicators,which contain a list of Judgements "
+                    "associated with this indicator."))
 
 (def-map-type Tool
   (concat
@@ -277,13 +282,13 @@
 (def disposition-map-inverted
   (map-invert disposition-map))
 
-(def DispositionNumber
-  (f/enum (keys disposition-map)
-          :description "Numeric verdict identifiers"))
+(def-enum-type DispositionNumber
+  (keys disposition-map)
+  :description "Numeric verdict identifiers")
 
-(def DispositionName
-  (f/enum (vals disposition-map)
-          :description "String verdict identifiers"))
+(def-enum-type DispositionName
+  (vals disposition-map)
+  :description "String verdict identifiers")
 
 ;; ## Relations
 
@@ -425,11 +430,13 @@
    "Wrote_To" "Specifies that this object wrote to the related object."
    "Created" "Specifies that this object created the related object."})
 
-(def ObservableRelationType
-  (let [relation-types (set (keys observable-relations-map))]
-    (f/enum relation-types
-            :open? true
-            :gen (cs/gen relation-types))))
+(def relation-types
+  (set (keys observable-relations-map)))
+
+(def-enum-type ObservableRelationType
+  relation-types
+  :open? true
+  :gen (cs/gen relation-types))
 
 (def-map-type ObservedRelation
   [(f/entry :origin f/any-str)

--- a/src/ctim/schemas/data_table.cljc
+++ b/src/ctim/schemas/data_table.cljc
@@ -3,14 +3,20 @@
             [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type
+                                                  def-enum-type
+                                                  def-map-type
+                                                  def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type
+                                                         def-enum-type
+                                                         def-map-type
+                                                         def-eq]])))
 
 (def type-identifier "data-table")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq DataTableTypeIdentifier type-identifier)
 
-(def ColumnType
+(def column-type
   #{"observable"
     "string"
     "markdown"
@@ -18,11 +24,13 @@
     "number"
     "url"})
 
+(def-enum-type ColumnType column-type)
+
 (def-map-type ColumnDefinition
   (concat
    (f/required-entries
     (f/entry :name f/any-str)
-    (f/entry :type (f/enum ColumnType)))
+    (f/entry :type ColumnType))
    (f/optional-entries
     (f/entry :description c/Markdown)
     (f/entry :required f/any-bool
@@ -41,7 +49,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type DataTableTypeIdentifier)
    (f/entry :columns (f/seq-of ColumnDefinition)
             :description "an ordered list of column definitions")
    (f/entry :rows (f/seq-of (f/seq-of Datum))
@@ -57,7 +65,7 @@
   (:entries DataTable)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type DataTableTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredDataTable

--- a/src/ctim/schemas/exploit_target.cljc
+++ b/src/ctim/schemas/exploit_target.cljc
@@ -2,12 +2,12 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def type-identifier "exploit-target")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq ExploitTargetTypeIdentifier type-identifier)
 
 (def-map-type Vulnerability
   (concat
@@ -83,7 +83,7 @@
   c/sourcable-object-entries
   c/describable-entity-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type ExploitTargetTypeIdentifier)
    (f/entry :valid_time c/ValidTime))
   (f/optional-entries
    (f/entry :vulnerability [Vulnerability]
@@ -104,7 +104,7 @@
   (:entries ExploitTarget)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type ExploitTargetTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredExploitTarget

--- a/src/ctim/schemas/feedback.cljc
+++ b/src/ctim/schemas/feedback.cljc
@@ -1,11 +1,11 @@
 (ns ctim.schemas.feedback
   (:require [ctim.schemas.common :as c]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-eq]])))
 
 (def type-identifier "feedback")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq FeedbackTypeIdentifier type-identifier)
 
 (def-entity-type Feedback
   "Feedback on any entity.  Is it wrong?  If so why?  Was
@@ -13,7 +13,7 @@
   c/base-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type FeedbackTypeIdentifier)
    (f/entry :entity_id c/Reference)
    (f/entry :feedback #{-1 0 1})
    (f/entry :reason f/any-str)))
@@ -23,7 +23,7 @@
   (:entries Feedback)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)))
+   (f/entry :type FeedbackTypeIdentifier)))
 
 (def-entity-type StoredFeedback
   "A feedback record at rest in the storage service"

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -2,8 +2,8 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def-map-type COARequested
   (concat
@@ -171,7 +171,7 @@
 
 (def type-identifier "incident")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq IncidentTypeIdentifier type-identifier)
 
 (def incident-desc
    "Discrete instance of indicators affecting an organization as well
@@ -187,7 +187,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type IncidentTypeIdentifier)
    (f/entry :valid_time c/ValidTime
             :description (str "time stamp for the definition of a specific "
                               "version of an Incident"))
@@ -270,7 +270,7 @@
   c/base-new-entity-entries
   (f/optional-entries
    (f/entry :valid_time c/ValidTime)
-   (f/entry :type TypeIdentifier)))
+   (f/entry :type IncidentTypeIdentifier)))
 
 
 (def-entity-type StoredIncident

--- a/src/ctim/schemas/indicator.cljc
+++ b/src/ctim/schemas/indicator.cljc
@@ -2,12 +2,20 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type
+                                                  def-enum-type
+                                                  def-map-type
+                                                  def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type
+                                                         def-enum-type
+                                                         def-map-type
+                                                         def-eq]])))
+
+(def-eq JudgementSpecificationType "Judgement")
 
 (def-map-type JudgementSpecification
   (f/required-entries
-   (f/entry :type (f/eq "Judgement"))
+   (f/entry :type JudgementSpecificationType)
    (f/entry :judgements [rel/JudgementReference])
    (f/entry :required_judgements rel/RelatedJudgements))
   :description (str "An indicator based on a list of judgements.  If any of the "
@@ -16,40 +24,51 @@
                     "they all must be matched in order for the indicator to be "
                     "considered a match."))
 
+(def-eq ThreatBrainSpecificationType "ThreatBrain")
+
 (def-map-type ThreatBrainSpecification
-  [(f/entry :type (f/eq "ThreatBrain"))
+  [(f/entry :type ThreatBrainSpecificationType)
    (f/entry :query f/any-str
             :required? false)
    (f/entry :variables f/any-str-seq)]
   :description "An indicator which runs in threatbrain...")
 
+(def-eq SnortSpecificationType "Snort")
+
 (def-map-type SnortSpecification
   (f/required-entries
-   (f/entry :type (f/eq "Snort"))
+   (f/entry :type SnortSpecificationType)
    (f/entry :snort_sig f/any-str))
   :description "An indicator which runs in snort...")
 
+(def-eq SIOCSpecificationType "SIOC")
+
 (def-map-type SIOCSpecification
   (f/required-entries
-   (f/entry :type (f/eq "SIOC"))
+   (f/entry :type SIOCSpecificationType)
    (f/entry :SIOC f/any-str))
   :description "An indicator which runs in snort...")
 
+(def-eq OpenIOCSpecificationType "OpenIOC")
+
 (def-map-type OpenIOCSpecification
   (f/required-entries
-   (f/entry :type (f/eq "OpenIOC"))
+   (f/entry :type OpenIOCSpecificationType)
    (f/entry :open_IOC f/any-str))
   :description "An indicator which contains an XML blob of an openIOC indicator..")
 
+(def-enum-type BooleanOperator
+  #{"and" "or" "not"})
+
 (def-map-type CompositeIndicatorExpression
   (f/required-entries
-   (f/entry :operator (f/enum #{"and" "or" "not"}))
+   (f/entry :operator BooleanOperator)
    (f/entry :indicator_ids [rel/IndicatorReference]))
   :reference "[CompositeIndicatorExpressionType](http://stixproject.github.io/data-model/1.2/indicator/CompositeIndicatorExpressionType/)")
 
 (def type-identifier "indicator")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq IndicatorTypeIdentifier type-identifier)
 
 (def indicator-desc
   "An indicator is a test, or a collection of judgements that define
@@ -77,7 +96,7 @@ _specification_ value.")
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type IndicatorTypeIdentifier)
    (f/entry :valid_time c/ValidTime)
    (f/entry :producer f/any-str
             :comment "TODO - Document what is supposed to be in this field!"))
@@ -119,7 +138,7 @@ _specification_ value.")
   c/base-new-entity-entries
   (f/optional-entries
    (f/entry :valid_time c/ValidTime)
-   (f/entry :type TypeIdentifier)))
+   (f/entry :type IndicatorTypeIdentifier)))
 
 (def-entity-type StoredIndicator
   "An indicator as stored in the data store"

--- a/src/ctim/schemas/judgement.cljc
+++ b/src/ctim/schemas/judgement.cljc
@@ -2,8 +2,10 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type
+                                                  def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type
+                                                         def-eq]])))
 
 (def Priority
   (f/int :description
@@ -16,7 +18,7 @@
 
 (def type-identifier "judgement")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq JudgementTypeIdentifier type-identifier)
 
 (def judgement-desc
   "A judgement about the intent or nature of an observable.  For
@@ -36,7 +38,7 @@
   c/base-entity-entries
   c/sourced-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type JudgementTypeIdentifier)
    (f/entry :observable c/Observable)
    (f/entry :disposition c/DispositionNumber
             :description (str "Matches :disposition_name as in "
@@ -58,7 +60,7 @@
    (f/entry :disposition c/DispositionNumber)
    (f/entry :disposition_name c/DispositionName)
    (f/entry :valid_time c/ValidTime)
-   (f/entry :type TypeIdentifier)))
+   (f/entry :type JudgementTypeIdentifier)))
 
 (def-entity-type StoredJudgement
   "A judgement as stored in the data store"

--- a/src/ctim/schemas/openc2_network.cljc
+++ b/src/ctim/schemas/openc2_network.cljc
@@ -1,14 +1,18 @@
 (ns ctim.schemas.openc2-network
   (:require [ctim.schemas.openc2vocabularies :as openc2v]
-            #?(:clj  [flanders.core :as f :refer [def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-enum-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-enum-type def-map-type def-eq]])))
+
+(def-eq BGPBlackholeTypeIdentifier "BGPBlackhole")
 
 (def-map-type BGPBlackhole
-  [(f/entry :type (f/eq "BGPBlackhole"))
+  [(f/entry :type BGPBlackholeTypeIdentifier)
    (f/entry :host f/any-str)])
 
+(def-eq DNSSinkholeTypeIdentifier "DNSSinkhole")
+
 (def-map-type DNSSinkhole
-  [(f/entry :type (f/eq "DNSSinkhole"))
+  [(f/entry :type DNSSinkholeTypeIdentifier)
    (f/entry :host f/any-str)])
 
 (def protocol
@@ -17,8 +21,7 @@
     "ICMP"
     "Any"})
 
-(def Protocol
-  (f/enum protocol))
+(def-enum-type Protocol protocol)
 
 (def ACL-action
   #{"ALERT"
@@ -28,8 +31,7 @@
     "PASS"
     "REJECT"})
 
-(def ACLAction
-  (f/enum ACL-action))
+(def-enum-type ACLAction ACL-action)
 
 (def-map-type Traffic
   [(f/entry :protocol Protocol)
@@ -38,8 +40,10 @@
    (f/entry :destination_address f/any-str)
    (f/entry :destination_port f/any-str)])
 
+(def-eq NetworkACLTypeIdentifier "NetworkACL")
+
 (def-map-type NetworkACL
-  [(f/entry :type (f/eq "NetworkACL"))
+  [(f/entry :type NetworkACLTypeIdentifier)
    (f/entry :traffic Traffic)
    (f/entry :action ACLAction)])
 
@@ -50,8 +54,10 @@
   [(f/entry :sec_group_tag f/any-str)
    (f/entry :sec_group_ACL f/any-str)])
 
+(def-eq RemediationTypeIdentifier "Remediation")
+
 (def-map-type Remediation
-  [(f/entry :type (f/eq "Remediation"))
+  [(f/entry :type RemediationTypeIdentifier)
    (f/entry :server f/any-str)
    (f/entry :ACL NetworkACL)
    ;; (f/entry :containment_profile_VLAN VLANProfile
@@ -60,8 +66,10 @@
    ;;          :required? false)
    ])
 
+(def-eq NonSensitiveTypeIdentifier "NonSensitive")
+
 (def-map-type NonSensitive
-  [(f/entry :type (f/eq "NonSensitive"))
+  [(f/entry :type NonSensitiveTypeIdentifier)
    (f/entry :permissible_IPs f/any-string-seq)
    (f/entry :ACL NetworkACL)])
 
@@ -70,44 +78,55 @@
    (f/entry :next_hop f/any-str)
    (f/entry :next_hope_type f/any-str)])
 
+(def-eq HoneyPotTypeIdentifier "Honeypot")
+
 (def-map-type HoneyPot
-  [(f/entry :type (f/eq "Honeypot"))
+  [(f/entry :type HoneyPotTypeIdentifier)
    (f/entry :permissible_IPs f/any-str-seq)
    (f/entry :ACL NetworkACL)
    (f/entry :routes HoneyPotRoutes)])
 
-(def Encapsulation
-  (f/enum #{"GRE"
-            "VXLAN"}))
+(def-enum-type Encapsulation
+  #{"GRE"
+    "VXLAN"})
+
+(def-enum-type BlockModifierType
+  #{"Perimeter"
+    "Internal"})
 
 (def-map-type BlockModifier
   (concat
-   [(f/entry :type (f/enum #{"Perimeter"
-                             "Internal"}))]
+   [(f/entry :type BlockModifierType)]
    (f/optional-entries
     (f/entry :method_network_ACL NetworkACL)
     (f/entry :method_BGP_blackhole BGPBlackhole)
     (f/entry :method_DNS_sinkhole DNSSinkhole))))
 
+(def-eq ContainTypeIdentifier "Contain")
+
 (def-map-type ContainModifier
   (concat
-   [(f/entry :type (f/eq "Contain"))]
+   [(f/entry :type ContainTypeIdentifier)]
    (f/optional-entries
     (f/entry :method_remediation Remediation)
     (f/entry :method_nonsensitive NonSensitive)
     (f/entry :method_honeypot HoneyPot))))
 
+(def-eq InspectModifierTypeIdentifier "Inspect")
+
 (def-map-type InspectModifier
   (concat
-   [(f/entry :type (f/eq "Inspect"))]
+   [(f/entry :type InspectModifierTypeIdentifier)]
    (f/optional-entries
     (f/entry :profile f/any-str)
     (f/entry :server f/any-str)
     (f/entry :encapsulation Encapsulation))))
 
+(def-eq PacketCaptureModifierTypeIdentifier "PacketCapture")
+
 (def-map-type PacketCaptureModifier
   (concat
-   [(f/entry :type (f/eq "PacketCapture"))]
+   [(f/entry :type PacketCaptureModifierTypeIdentifier)]
    (f/optional-entries
     (f/entry :server f/any-str)
     (f/entry :traffic Traffic))))

--- a/src/ctim/schemas/openc2_network_sdn.cljc
+++ b/src/ctim/schemas/openc2_network_sdn.cljc
@@ -1,15 +1,17 @@
 (ns ctim.schemas.openc2-network-sdn
-  (:require #?(:clj  [flanders.core :as f :refer [def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-map-type]])))
+  (:require #?(:clj  [flanders.core :as f :refer [def-enum-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-enum-type def-map-type def-eq]])))
 
 
-(def ScanMethods
-  (f/enum #{"arp"
-            "ping"
-            "tcpsyn"
-            "udpprobe"}))
+(def-enum-type ScanMethods
+  #{"arp"
+    "ping"
+    "tcpsyn"
+    "udpprobe"})
+
+(def-eq ScanTypeIdentifier "scan")
 
 (def-map-type Scan
-  [(f/entry :type (f/eq "Scan"))
+  [(f/entry :type ScanTypeIdentifier)
    (f/entry :method ScanMethods)
    (f/entry :search f/any-str)])

--- a/src/ctim/schemas/openc2vocabularies.cljc
+++ b/src/ctim/schemas/openc2vocabularies.cljc
@@ -1,5 +1,6 @@
 (ns ctim.schemas.openc2vocabularies
-  (:require [flanders.core :as f]))
+  (:require #?(:clj [flanders.core :as f :refer [def-enum-type]]
+               :cljs [flanders.core :as :refer-macros [def-enum-type]])))
 
 (def COA-type
   #{"alert"
@@ -38,11 +39,11 @@
     "throttle"
     "update"})
 
-(def COAType
-  (f/enum COA-type
-          :reference (str "[OpenC2/STIX COA XML schema](https://"
-                          "github.com/OpenC2-org/subgroup-stix/blob/"
-                          "master/schema/openc2_stix_coa.xsd)")))
+(def-enum-type COAType
+  COA-type
+  :reference (str "[OpenC2/STIX COA XML schema](https://"
+                           "github.com/OpenC2-org/subgroup-stix/blob/"
+                           "master/schema/openc2_stix_coa.xsd)"))
 
 (def actuator-type
   #{"endpoint",
@@ -92,8 +93,7 @@
     "process.vulnerability-scanner",
     "other"})
 
-(def ActuatorType
-  (f/enum actuator-type))
+(def-enum-type ActuatorType actuator-type)
 
 (def modifier-type
   #{"delay"
@@ -103,8 +103,7 @@
     "time"
     "reportTo"})
 
-(def ModifierType
-  (f/enum modifier-type))
+(def-enum-type ModifierType modifier-type)
 
 (def location-class
   #{"Internally-Located"
@@ -113,8 +112,7 @@
     "Mobile"
     "Unknown"})
 
-(def LocationClass
-  (f/enum location-class))
+(def-enum-type LocationClass location-class)
 
 (def loss-duration
   #{"Permanent"
@@ -125,5 +123,4 @@
     "Seconds"
     "Unknown"})
 
-(def LossDuration
-  (f/enum loss-duration))
+(def-enum-type LossDuration loss-duration)

--- a/src/ctim/schemas/relationship.cljc
+++ b/src/ctim/schemas/relationship.cljc
@@ -1,12 +1,12 @@
 (ns ctim.schemas.relationship
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def type-identifier "relationship")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq RelationshipTypeIdentifier type-identifier)
 
 (def-entity-type Relationship
   "Represents a relationship between two entities"
@@ -14,7 +14,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type RelationshipTypeIdentifier)
    (f/entry :relationship_type v/RelationshipType)
    (f/entry :source_ref c/Reference)
    (f/entry :target_ref c/Reference)))
@@ -24,7 +24,7 @@
   (:entries Relationship)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)))
+   (f/entry :type RelationshipTypeIdentifier)))
 
 (def-entity-type StoredRelationship
   "An Relationship stored in the data store"

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -2,12 +2,12 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-eq]])))
 
 (def type-identifier "sighting")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq SightingTypeIdentifier type-identifier)
 
 (def sighting-desc
   "A single sighting of an [indicator](indicator.md)")
@@ -30,7 +30,7 @@
   c/sourcable-object-entries
   c/describable-entity-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type SightingTypeIdentifier)
    (f/entry :observed_time c/ObservedTime)
    (f/entry :confidence v/HighMedLow)
    (f/entry :count f/any-int
@@ -51,7 +51,7 @@
   (:entries Sighting)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type SightingTypeIdentifier)
    (f/entry :count f/any-int)
    (f/entry :confidence v/HighMedLow)))
 

--- a/src/ctim/schemas/ttp.cljc
+++ b/src/ctim/schemas/ttp.cljc
@@ -2,8 +2,8 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 
 (def-map-type AttackPattern
   (f/optional-entries
@@ -72,7 +72,7 @@
 
 (def type-identifier "ttp")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq TTPTypeIdentifier type-identifier)
 
 (def ttp-desc
   "A TTP is an instance of a Tool, Technique, or Procedure used by a cyber [actor](actor.md)")
@@ -87,7 +87,7 @@
   c/describable-entity-entries
   c/sourcable-object-entries
   (f/required-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type TTPTypeIdentifier)
    (f/entry :valid_time c/ValidTime
             :description (str "a timestamp for the definition of a specific "
                               "version of a TTP item"))
@@ -116,7 +116,7 @@
   (:entries TTP)
   c/base-new-entity-entries
   (f/optional-entries
-   (f/entry :type TypeIdentifier)
+   (f/entry :type TTPTypeIdentifier)
    (f/entry :valid_time c/ValidTime)))
 
 (def-entity-type StoredTTP

--- a/src/ctim/schemas/verdict.cljc
+++ b/src/ctim/schemas/verdict.cljc
@@ -1,12 +1,16 @@
 (ns ctim.schemas.verdict
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
-            #?(:clj  [flanders.core :as f :refer [def-entity-type]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type]])))
+            #?(:clj  [flanders.core :as f :refer [def-entity-type
+                                                  def-enum-type
+                                                  def-eq]]
+               :cljs [flanders.core :as f :refer-macros [def-entity-type
+                                                         def-enum-type
+                                                         def-eq]])))
 
 (def type-identifier "verdict")
 
-(def TypeIdentifier (f/eq type-identifier))
+(def-eq VerdictTypeIdentifier type-identifier)
 
 (def-entity-type Verdict
   (str
@@ -16,7 +20,7 @@
    "disposition has priority over all others, then Malicious disposition, and so "
    "on down to Unknown.\n\n The ID of a verdict is a a str of the form "
    "\"observable.type:observable.value\" for example, \"ip:1.1.1.1\"")
-  [(f/entry :type TypeIdentifier)
+  [(f/entry :type VerdictTypeIdentifier)
    (f/entry :disposition c/DispositionNumber)
    (f/entry :observable c/Observable)
    (f/entry :judgement_id rel/JudgementReference

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -2,7 +2,8 @@
   (:require #?(:clj  [clojure.spec :as cs]
                :cljs [cljs.spec :as cs])
             [clojure.test.check.generators]
-            [flanders.core :as f]))
+            #?(:clj [flanders.core :as f :refer [def-enum-type]]
+               :cljs [flanders.core :as f :refer-macros [def-enum-type]])))
 
 (def attack-infrastructure
   #{"Anonymization"
@@ -30,9 +31,9 @@
     "Hosting - Legitimate Hosting"
     "Electronic Payment Methods"})
 
-(def AttackerInfrastructure
-  (f/enum attack-infrastructure
-          :reference "[AttackInfrastructureTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/AttackerInfrastructureTypeVocab-1.0/)"))
+(def-enum-type AttackerInfrastructure
+  attack-infrastructure
+  :reference "[AttackInfrastructureTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/AttackerInfrastructureTypeVocab-1.0/)")
 
 (def attack-tool-type
   #{"Malware"
@@ -43,25 +44,25 @@
     "Application Scanner"
     "Password Cracking"})
 
-(def AttackToolType
-  (f/enum attack-tool-type
-          :reference "[AttackerToolTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/AttackerToolTypeVocab-1.0/)"))
+(def-enum-type AttackToolType
+  attack-tool-type
+  :reference "[AttackerToolTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/AttackerToolTypeVocab-1.0/)")
 
 (def campaign-status
   #{"Ongoing"
     "Historic"
     "Future"})
 
-(def CampaignStatus
-  (f/enum campaign-status))
+(def-enum-type CampaignStatus
+  campaign-status)
 
 (def COA-stage
   #{"Remedy"
     "Response"})
 
-(def COAStage
-  (f/enum COA-stage
-          :reference "[COAStageVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/COAStageVocab-1.0/)"))
+(def-enum-type COAStage
+  COA-stage
+  :reference "[COAStageVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/COAStageVocab-1.0/)")
 
 (def COA-type
   #{"Perimeter Blocking"
@@ -81,9 +82,9 @@
     "Policy Actions"
     "Other"})
 
-(def COAType
-  (f/enum COA-type
-          :reference "[CourseOfActionTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/CourseOfActionTypeVocab-1.0/)"))
+(def-enum-type COAType
+  COA-type
+  :reference "[CourseOfActionTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/CourseOfActionTypeVocab-1.0/)")
 
 (def discovery-method
   #{"Agent Disclosure"
@@ -105,8 +106,7 @@
     "User"
     "Unknown"})
 
-(def DiscoveryMethod
-  (f/enum discovery-method))
+(def-enum-type DiscoveryMethod discovery-method)
 
 (def effect
   #{"Brand or Image Degradation"
@@ -124,8 +124,7 @@
     "Unintended Access"
     "User Data Loss"})
 
-(def Effect
-  (f/enum effect))
+(def-enum-type Effect effect)
 
 (def high-med-low
   #{"Low"
@@ -134,10 +133,10 @@
     "None"
     "Unknown"})
 
-(def HighMedLow
-  (f/enum high-med-low
-          :reference (str "[HighMedLowVocab](http://stixproject.github.io/"
-                          "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)")))
+(def-enum-type HighMedLow
+  high-med-low
+  :reference (str "[HighMedLowVocab](http://stixproject.github.io/"
+                           "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)"))
 
 (def impact-qualification
   #{"Insignificant"
@@ -147,8 +146,7 @@
     "Catastrophic"
     "Unknown"})
 
-(def ImpactQualification
-  (f/enum impact-qualification))
+(def-enum-type ImpactQualification impact-qualification)
 
 (def impact-rating
   #{"None"
@@ -157,8 +155,7 @@
     "Major"
     "Unknown"})
 
-(def ImpactRating
-  (f/enum impact-rating))
+(def-enum-type ImpactRating impact-rating)
 
 (def incident-category
   #{"Exercise/Network Defense Testing"
@@ -169,8 +166,7 @@
     "Scans/Probes/Attempted Access"
     "Investigation"})
 
-(def IncidentCategory
-  (f/enum incident-category))
+(def-enum-type IncidentCategory incident-category)
 
 (def indicator-type
   #{"Malicious E-mail"
@@ -188,9 +184,9 @@
     "IMEI Watchlist"
     "IMSI Watchlist"})
 
-(def IndicatorType
-  (f/enum indicator-type
-          :reference "[IndicatorTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/IndicatorTypeVocab-1.1/)"))
+(def-enum-type IndicatorType
+  indicator-type
+  :reference "[IndicatorTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/IndicatorTypeVocab-1.1/)")
 
 (def information-type
   #{"Information Assets"
@@ -203,9 +199,9 @@
     "Information Assets - User Credentials"
     "Authentication Cookies"})
 
-(def InformationType
-  (f/enum information-type
-          :reference "[InformationTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/InformationTypeVocab-1.0/)"))
+(def-enum-type InformationType
+  information-type
+  :reference "[InformationTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/InformationTypeVocab-1.0/)")
 
 (def intended-effect
   #{"Advantage"
@@ -233,8 +229,7 @@
     "Traffic Diversion"
     "Unauthorized Access"})
 
-(def IntendedEffect
-  (f/enum intended-effect))
+(def-enum-type IntendedEffect intended-effect)
 
 (def kill-chain
   #{"Reconnaissance"
@@ -245,8 +240,7 @@
     "Command & Control"
     "Actions on Objectives"})
 
-(def KillChain
-  (f/enum kill-chain))
+(def-enum-type KillChain kill-chain)
 
 (def location-class
   #{"Internally-Located"
@@ -255,8 +249,7 @@
     "Mobile"
     "Unknown"})
 
-(def LocationClass
-  (f/enum location-class))
+(def-enum-type LocationClass location-class)
 
 (def loss-duration
   #{"Permanent"
@@ -267,8 +260,7 @@
     "Seconds"
     "Unknown"})
 
-(def LossDuration
-  (f/enum loss-duration))
+(def-enum-type LossDuration loss-duration)
 
 (def loss-property
   #{"Confidentiality"
@@ -277,8 +269,7 @@
     "Accountability"
     "Non-Repudiation"})
 
-(def LossProperty
-  (f/enum loss-property))
+(def-enum-type LossProperty loss-property)
 
 (def malware-type
   #{"Automated Transfer Scripts"
@@ -300,8 +291,7 @@
     "Rogue Antivirus"
     "Rootkit"})
 
-(def MalwareType
-  (f/enum malware-type))
+(def-enum-type MalwareType malware-type)
 
 (def management-class
   #{"Internally-Managed"
@@ -309,8 +299,7 @@
     "CO-Management"
     "Unknown"})
 
-(def ManagementClass
-  (f/enum management-class))
+(def-enum-type ManagementClass management-class)
 
 (def motivation
   #{"Ideological"
@@ -328,8 +317,7 @@
     "Opportunistic"
     "Political"})
 
-(def Motivation
-  (f/enum motivation))
+(def-enum-type Motivation motivation)
 
 (def observable-type-identifier
   #{"ip"
@@ -349,9 +337,9 @@
     "imsi"
     "amp-device"})
 
-(def ObservableTypeIdentifier
-  (f/enum observable-type-identifier
-          :description "Observable type names"))
+(def-enum-type ObservableTypeIdentifier
+  observable-type-identifier
+  :description "Observable type names")
 
 (def ownership-class
   #{"Internally-Owned"
@@ -360,15 +348,13 @@
     "Customer-Owned"
     "Unknown"})
 
-(def OwnershipClass
-  (f/enum ownership-class))
+(def-enum-type OwnershipClass ownership-class)
 
 (def scope
   #{"inclusive"
     "exclusive"})
 
-(def Scope
-  (f/enum scope))
+(def-enum-type Scope scope)
 
 (def security-compromise
   #{"Yes"
@@ -376,8 +362,7 @@
     "No"
     "Unknown"})
 
-(def SecurityCompromise
-  (f/enum security-compromise))
+(def-enum-type SecurityCompromise security-compromise)
 
 (def sophistication
   #{"Innovator"
@@ -386,8 +371,7 @@
     "Novice"
     "Aspirant"})
 
-(def Sophistication
-  (f/enum sophistication))
+(def-enum-type Sophistication sophistication)
 
 (def status
   #{"New"
@@ -400,8 +384,7 @@
     "Rejected"
     "Deleted"})
 
-(def Status
-  (f/enum status))
+(def-enum-type Status status)
 
 (def system-type
   #{"Enterprise Systems"
@@ -432,9 +415,9 @@
     "Users - Workstation"
     "Users - Removable Media"})
 
-(def SystemType
-  (f/enum system-type
-          :reference "[SystemTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/SystemTypeVocab-1.0/)"))
+(def-enum-type SystemType
+  system-type
+  :reference "[SystemTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/SystemTypeVocab-1.0/)")
 
 (def threat-actor-type
   #{"Cyber Espionage Operations"
@@ -455,8 +438,7 @@
     "Insider Threat"
     "Disgruntled Customer / User"})
 
-(def ThreatActorType
-  (f/enum threat-actor-type))
+(def-enum-type ThreatActorType threat-actor-type)
 
 (def sensor
   #{"endpoint"
@@ -505,12 +487,12 @@
     "process.virtualization-service"
     "process.vulnerability-scanner"})
 
-(def Sensor
-  (f/enum sensor
-          :description (str "The openC2 Actuator name that best fits a device\n"
-                            "See also the Open C2 Language Description, Actuator "
-                            "Vocabulary, page 24.")
-          :reference "[OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)"))
+(def-enum-type Sensor
+  sensor
+  :description (str "The openC2 Actuator name that best fits a device\n"
+                             "See also the Open C2 Language Description, Actuator "
+                             "Vocabulary, page 24.")
+  :reference "[OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)")
 
 (def relationship-type
   #{"attributed-to"
@@ -528,7 +510,7 @@
     "uses"
     "variant-of"})
 
-(def RelationshipType
-  (f/enum relationship-type
-          :open? true
-          :gen (cs/gen relationship-type)))
+(def-enum-type RelationshipType
+  relationship-type
+  :open? true
+  :gen (cs/gen relationship-type))


### PR DESCRIPTION
Use of flanders `def-eq` and `def-enum-type` macros to define enums. The definition symbol is used to set the name of the enum.

Ex:
```clojure
(def HighMedLow
  (f/enum high-med-low
          :reference (str "[HighMedLowVocab](http://stixproject.github.io/"
                          "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)")))
```
->
```clojure
(def-enum HighMedLow
  high-med-low
 :reference (str "[HighMedLowVocab](http://stixproject.github.io/"
                          "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/))
```

Depends on threatgrid/flanders#11
Linked to threatgrid/ctia#568. The GraphQL refactoring in `threatgrid/ctia` use the GraphQLEnumType where a name is required.