### PR TITLE
Using timestamp as the primary Sighting sort field (descending)

### DIFF
--- a/src/ctim/domain/sorting.cljc
+++ b/src/ctim/domain/sorting.cljc
@@ -45,17 +45,20 @@
 (defn sort-judgements
   "Sorts Judgements based on validity, disposition, and finally by start-time"
   [judgements]
-  (sort-by identity
-           (partial compare-judgements (time/internal-now))
-           judgements))
+  (sort (partial compare-judgements (time/internal-now))
+        judgements))
 
 
 ;;------------------------------------------------------------------------------
 ;; Sightings
 ;;------------------------------------------------------------------------------
 
-(defn sort-sightings
-  [sightings]
-  (sort-by (comp :start_time :observed_time)
+(defn get-sighting-sort-field [{timestamp :timestamp
+                                {start-time :start_time} :observed_time}]
+  (some-> (or timestamp start-time)
+          to-internal-date))
+
+(defn sort-sightings [sightings]
+  (sort-by get-sighting-sort-field
            #(compare %2 %1)
            sightings))

--- a/test/ctim/domain/sorting_test.cljc
+++ b/test/ctim/domain/sorting_test.cljc
@@ -158,9 +158,16 @@
 (deftest sort-sightings-test
   (testing "sort sightings"
     (is (= (sut/sort-sightings
-            [{:id 3 :observed_time {:start_time "2017-01-12T00:00:00.000Z"}}
-             {:id 2 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
-             {:id 1 :observed_time {:start_time "2017-01-12T00:00:00.002Z"}}])
-           [{:id 1 :observed_time {:start_time "2017-01-12T00:00:00.002Z"}}
-            {:id 2 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
-            {:id 3 :observed_time {:start_time "2017-01-12T00:00:00.000Z"}}]))))
+            [{:id 4 :timestamp "2017-01-12T00:00:00.000Z"}
+             {:id 3 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
+             {:id 2
+              :timestamp "2017-01-12T00:00:00.002Z"
+              ;; start_time should be ignored
+              :observed_time {:start_time "2017-01-12T00:00:00.004Z"}}
+             {:id 1 :observed_time {:start_time "2017-01-12T00:00:00.003Z"}}])
+           [{:id 1 :observed_time {:start_time "2017-01-12T00:00:00.003Z"}}
+            {:id 2
+             :timestamp "2017-01-12T00:00:00.002Z"
+             :observed_time {:start_time "2017-01-12T00:00:00.004Z"}}
+            {:id 3 :observed_time {:start_time "2017-01-12T00:00:00.001Z"}}
+            {:id 4 :timestamp "2017-01-12T00:00:00.000Z"}]))))


### PR DESCRIPTION
Also uses observed start-time as a backup field.