### PR TITLE
Observable types cleaning

### DIFF
--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -331,11 +331,10 @@
     "url"
     ;; PKI Certificate serial numbers for revoked
     ;; code signing or server certificates
-    "pki-serial"
+    "pki_serial"
     "email"
     "imei"
     "imsi"
-    "amp-device"
     "amp_computer_guid"
     "hostname"
     "mac_address"


### PR DESCRIPTION
- Removing `amp_device` observable type. `amp_computer_guid` is used for AMP connector GUID.
- Replacing all '-' characters by '_'