### PR TITLE
Testing that URI fields are indeed URIs

### DIFF
--- a/src/ctim/examples/ttps.cljc
+++ b/src/ctim/examples/ttps.cljc
@@ -32,7 +32,16 @@
                        :type ["Malware"]
                        :references ["foo" "bar"]
                        :vendor "vendor"
-                       :service_pack "sp"}}
+                       :service_pack "sp"}
+               :infrastructure {:title "title"
+                                :description "description"
+                                :short_description "short desc"
+                                :type "Anonymization"}
+               :personas {:description "description"
+                          :related_identities [{:identity "ref-123"
+                                                :confidence "Low"
+                                                :information_source "foo"
+                                                :relationship "rel"}]}}
    :victim_targeting {:identity {:description "desc"
                                  :related_identities [{:identity "ref-123"
                                                        :confidence "Low"
@@ -81,7 +90,16 @@
                        :type ["Malware"]
                        :references ["foo" "bar"]
                        :vendor "vendor"
-                       :service_pack "sp"}}
+                       :service_pack "sp"}
+               :infrastructure {:title "title"
+                                :description "description"
+                                :short_description "short desc"
+                                :type "Anonymization"}
+               :personas {:description "description"
+                          :related_identities [{:identity "ref-123"
+                                                :confidence "Low"
+                                                :information_source "foo"
+                                                :relationship "rel"}]}}
    :victim_targeting {:identity {:description "desc"
                                  :related_identities [{:identity "ref-123"
                                                        :confidence "Low"
@@ -127,7 +145,16 @@
                        :type ["Malware"]
                        :references ["foo" "bar"]
                        :vendor "vendor"
-                       :service_pack "sp"}}
+                       :service_pack "sp"}
+               :infrastructure {:title "title"
+                                :description "description"
+                                :short_description "short desc"
+                                :type "Anonymization"}
+               :personas {:description "description"
+                          :related_identities [{:identity "ref-123"
+                                                :confidence "Low"
+                                                :information_source "foo"
+                                                :relationship "rel"}]}}
    :victim_targeting {:identity {:description "desc"
                                  :related_identities [{:identity "ref-123"
                                                        :confidence "Low"

--- a/src/ctim/lib/generators.clj
+++ b/src/ctim/lib/generators.clj
@@ -1,5 +1,6 @@
 (ns ctim.lib.generators
   (:require
+   [clojure.string :as str]
    [clojure.test.check.generators :as gen]))
 
 (defn string-max-len [max-len]
@@ -10,3 +11,18 @@
                       (min max-len
                            (count base-str)))))
             gen/string-ascii))
+
+(def uri
+  (gen/fmap (fn [[proto parts]]
+              (str proto "://" (apply str (interpose "/" parts)) "/"))
+            (gen/tuple (gen/elements ["http" "https"])
+                       (gen/such-that
+                        seq
+                        (gen/resize
+                         10
+                         (gen/vector
+                          (gen/such-that
+                           seq
+                           (gen/resize
+                            6
+                            gen/string-alphanumeric))))))))

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -57,10 +57,20 @@
          :spec (cs/and string? :ctim.domain.id/short-id)
          :loc-gen id-generator))
 
+(defn uri? [str]
+  (if (> (count str) 0)
+    (try
+      (some? (java.net.URI/create str))
+      (catch Exception e
+        false))
+    false))
+
 (def URI
   (f/str :description "A URI"
-         :spec (cs/and string? (pred/max-len 2048))
-         :gen #?(:clj (gen/string-max-len 2048))))
+         :spec (cs/and string?
+                       (pred/max-len 2048)
+                       uri?)
+         :gen #?(:clj gen/uri)))
 
 (cs/def ::recent-time (cs/inst-in #inst "2010" #inst "2025"))
 (cs/def ::relevant-time (cs/inst-in #inst "1970" #inst "2525-01-01T00:00:00.000-00:01"))

--- a/test/ctim/specs/fields_test.clj
+++ b/test/ctim/specs/fields_test.clj
@@ -4,7 +4,10 @@
    [clojure.spec :as spec]
    [clojure.test :refer [are deftest testing use-fixtures]]
    [ctim.examples
-    [actors :refer [actor-minimal
+    [actors :refer [actor-maximal
+                    new-actor-maximal
+                    stored-actor-maximal
+                    actor-minimal
                     new-actor-minimal
                     stored-actor-minimal]]
     [campaigns :refer [campaign-minimal
@@ -34,7 +37,10 @@
     [judgements :refer [judgement-minimal
                         new-judgement-minimal
                         stored-judgement-minimal]]
-    [sightings :refer [sighting-minimal
+    [sightings :refer [sighting-maximal
+                       new-sighting-maximal
+                       stored-sighting-maximal
+                       sighting-minimal
                        new-sighting-minimal
                        stored-sighting-minimal]]
     [ttps :refer [ttp-maximal
@@ -134,7 +140,10 @@
 
 (def get-example
   (let [examples
-        {'actor {'minimal {'plain  actor-minimal
+        {'actor {'maximal {'plain  actor-maximal
+                           'new    new-actor-maximal
+                           'stored stored-actor-maximal}
+                 'minimal {'plain  actor-minimal
                            'new    new-actor-minimal
                            'stored stored-actor-minimal}}
          'campaign {'minimal {'plain  campaign-minimal
@@ -164,7 +173,10 @@
          'judgement {'minimal {'plain judgement-minimal
                                'new   new-judgement-minimal
                                'stored stored-judgement-minimal}}
-         'sighting {'minimal {'plain  sighting-minimal
+         'sighting {'maximal {'plain  sighting-maximal
+                              'new    new-sighting-maximal
+                              'stored stored-sighting-maximal}
+                    'minimal {'plain  sighting-minimal
                               'new    new-sighting-minimal
                               'stored stored-sighting-minimal}}
          'ttp {'maximal {'plain  ttp-maximal
@@ -175,6 +187,128 @@
                          'stored stored-ttp-minimal}}}]
     (fn get-example-impl [type-variety]
       (get-in examples [*type-sym* *example-sym* type-variety]))))
+
+(defn test-uri [key]
+  (let [plain-kw  (get-type-kw 'plain)
+        new-kw    (get-type-kw 'new)
+        stored-kw (get-type-kw 'stored)
+
+        plain-ex  (get-example 'plain)
+        new-ex    (get-example 'new)
+        stored-ex (get-example 'stored)]
+    (testing (pr-str key)
+      (are [expected value spec entity]
+          (= expected
+             (spec/valid? spec
+                          (assoc entity key value)))
+        false nil   plain-kw plain-ex
+        false nil   new-kw new-ex
+        false nil   stored-kw stored-ex
+        false ""    plain-kw plain-ex
+        false ""    new-kw new-ex
+        false ""    stored-kw stored-ex
+        true  "foo" plain-kw plain-ex
+        true  "foo" new-kw new-ex
+        true  "foo" stored-kw stored-ex
+        false ")^^)&)&" plain-kw plain-ex
+        false ")^^)&)&" new-kw new-ex
+        false ")^^)&)&" stored-kw stored-ex
+        true  "http://www.example.com" plain-kw plain-ex
+        true  "http://www.example.com" new-kw new-ex
+        true  "http://www.example.com" stored-kw stored-ex))))
+
+(defn test-uri-in [key-path]
+  (let [plain-kw  (get-type-kw 'plain)
+        new-kw    (get-type-kw 'new)
+        stored-kw (get-type-kw 'stored)
+
+        plain-ex  (get-example 'plain)
+        new-ex    (get-example 'new)
+        stored-ex (get-example 'stored)]
+    (testing (pr-str key-path)
+      (are [expected value spec entity]
+          (= expected
+             (spec/valid? spec
+                          (assoc-in entity key-path value)))
+        false nil   plain-kw plain-ex
+        false nil   new-kw new-ex
+        false nil   stored-kw stored-ex
+        false ""    plain-kw plain-ex
+        false ""    new-kw new-ex
+        false ""    stored-kw stored-ex
+        true  "foo" plain-kw plain-ex
+        true  "foo" new-kw new-ex
+        true  "foo" stored-kw stored-ex
+        false ")^^)&)&" plain-kw plain-ex
+        false ")^^)&)&" new-kw new-ex
+        false ")^^)&)&" stored-kw stored-ex
+        true  "http://www.example.com" plain-kw plain-ex
+        true  "http://www.example.com" new-kw new-ex
+        true  "http://www.example.com" stored-kw stored-ex))))
+
+(defn test-uri-seq [key]
+  (let [plain-kw  (get-type-kw 'plain)
+        new-kw    (get-type-kw 'new)
+        stored-kw (get-type-kw 'stored)
+
+        plain-ex  (get-example 'plain)
+        new-ex    (get-example 'new)
+        stored-ex (get-example 'stored)]
+    (testing (pr-str key)
+      (are [expected value spec entity]
+          (= expected
+             (spec/valid? spec
+                          (assoc entity key value)))
+        false nil   plain-kw plain-ex
+        false nil   new-kw new-ex
+        false nil   stored-kw stored-ex
+        false [nil] plain-kw plain-ex
+        false [nil] new-kw new-ex
+        false [nil] stored-kw stored-ex
+        false [""]  plain-kw plain-ex
+        false [""]  new-kw new-ex
+        false [""]  stored-kw stored-ex
+        true  ["foo"] plain-kw plain-ex
+        true  ["foo"] new-kw new-ex
+        true  ["foo"] stored-kw stored-ex
+        false [")^^)&)&"] plain-kw plain-ex
+        false [")^^)&)&"] new-kw new-ex
+        false [")^^)&)&"] stored-kw stored-ex
+        true  ["http://www.example.com"] plain-kw plain-ex
+        true  ["http://www.example.com"] new-kw new-ex
+        true  ["http://www.example.com"] stored-kw stored-ex))))
+
+(defn test-uri-seq-in [key-path]
+  (let [plain-kw  (get-type-kw 'plain)
+        new-kw    (get-type-kw 'new)
+        stored-kw (get-type-kw 'stored)
+
+        plain-ex  (get-example 'plain)
+        new-ex    (get-example 'new)
+        stored-ex (get-example 'stored)]
+    (testing (pr-str key-path)
+      (are [expected value spec entity]
+          (= expected
+             (spec/valid? spec
+                          (assoc-in entity key-path value)))
+        false nil   plain-kw plain-ex
+        false nil   new-kw new-ex
+        false nil   stored-kw stored-ex
+        false [nil] plain-kw plain-ex
+        false [nil] new-kw new-ex
+        false [nil] stored-kw stored-ex
+        false [""]  plain-kw plain-ex
+        false [""]  new-kw new-ex
+        false [""]  stored-kw stored-ex
+        true  ["foo"] plain-kw plain-ex
+        true  ["foo"] new-kw new-ex
+        true  ["foo"] stored-kw stored-ex
+        false [")^^)&)&"] plain-kw plain-ex
+        false [")^^)&)&"] new-kw new-ex
+        false [")^^)&)&"] stored-kw stored-ex
+        true  ["http://www.example.com"] plain-kw plain-ex
+        true  ["http://www.example.com"] new-kw new-ex
+        true  ["http://www.example.com"] stored-kw stored-ex))))
 
 (defn test-short-string [key]
   (let [plain-kw  (get-type-kw 'plain)
@@ -482,21 +616,24 @@
 (deftest test-field-validators
 
   (testing "Actor"
-    (binding [*type-sym* 'actor
-              *example-sym* 'minimal]
-      (test-long-string :description)
+    (binding [*type-sym* 'actor]
+      (binding [*example-sym* 'minimal]
+        (test-long-string :description)
 
-      (test-medium-string :short_description)
+        (test-medium-string :short_description)
 
-      (test-short-string :language)
+        (test-short-string :language)
 
-      (test-short-string :title)
+        (test-short-string :title)
 
-      (test-medium-string :source)
+        (test-medium-string :source)
 
-      (test-medium-string :source_uri)
+        (test-uri :source_uri)
 
-      (test-long-string :planning_and_operational_support)))
+        (test-long-string :planning_and_operational_support))
+
+      (binding [*example-sym* 'maximal]
+        (test-uri-in [:identity :related_identities 0 :identity]))))
 
   (testing "Campaign"
     (binding [*type-sym* 'campaign
@@ -511,7 +648,7 @@
 
       (test-medium-string :source)
 
-      (test-medium-string :source_uri)
+      (test-uri :source_uri)
 
       (test-short-string :campaign_type)
 
@@ -530,7 +667,7 @@
 
         (test-medium-string :source)
 
-        (test-medium-string :source_uri))
+        (test-uri :source_uri))
 
       (binding [*example-sym* 'maximal]
         (test-short-string-in [:open_c2_coa :id])
@@ -570,7 +707,7 @@
 
         (test-medium-string :source)
 
-        (test-medium-string :source_uri))
+        (test-uri :source_uri))
 
       (binding [*example-sym* 'maximal]
         (test-short-string-in [:vulnerability 0 :title])
@@ -582,6 +719,8 @@
         (test-short-string-in [:vulnerability 0 :cve_id])
 
         (test-short-string-in [:vulnerability 0 :source])
+
+        (test-uri-seq-in [:vulnerability 0 :references])
 
         (test-short-string-seq-in [:vulnerability 0 :affected_software])
 
@@ -608,7 +747,7 @@
 
         (test-medium-string :source)
 
-        (test-medium-string :source_uri))
+        (test-uri :source_uri))
 
       (binding [*example-sym* 'maximal]
         (test-long-string-in [:affected_assets
@@ -656,7 +795,7 @@
 
       (test-medium-string :source)
 
-      (test-medium-string :source_uri)
+      (test-uri :source_uri)
 
       (test-short-string :producer)
 
@@ -673,24 +812,29 @@
               *example-sym* 'minimal]
       (test-medium-string :source)
 
-      (test-medium-string :source_uri)
+      (test-uri :source_uri)
 
-      (test-short-string :reason)))
+      (test-short-string :reason)
+
+      (test-uri :reason_uri)))
 
   (testing "Sighting"
-    (binding [*type-sym* 'sighting
-              *example-sym* 'minimal]
-      (test-long-string :description)
+    (binding [*type-sym* 'sighting]
+      (binding [*example-sym* 'minimal]
+        (test-long-string :description)
 
-      (test-medium-string :short_description)
+        (test-medium-string :short_description)
 
-      (test-short-string :language)
+        (test-short-string :language)
 
-      (test-short-string :title)
+        (test-short-string :title)
 
-      (test-medium-string :source)
+        (test-medium-string :source)
 
-      (test-medium-string :source_uri)))
+        (test-uri :source_uri))
+
+      (binding [*example-sym* 'maximal]
+        (test-uri-in [:relations 0 :origin_uri]))))
 
   (testing "TTP"
     (binding [*type-sym* 'ttp]
@@ -705,7 +849,7 @@
 
         (test-medium-string :source)
 
-        (test-medium-string :source_uri)
+        (test-uri :source_uri)
 
         (test-short-string :ttp_type))
 
@@ -750,4 +894,16 @@
 
         (test-medium-string-in [:resources
                                 :infrastructure
-                                :short_description])))))
+                                :short_description])
+
+        (test-uri-in [:resources
+                      :personas
+                      :related_identities
+                      0
+                      :identity])
+
+        (test-uri-in [:victim_targeting
+                      :identity
+                      :related_identities
+                      0
+                      :identity])))))


### PR DESCRIPTION
- Uses java.net.URI instances to validate
- Validation failure throws exceptions, which is less than ideal
- Using URI and not URL, we avoid making DNS lookups