### PR TITLE
Set entity ID as an URL

### DIFF
--- a/src/ctim/examples/actors.cljc
+++ b/src/ctim/examples/actors.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def actor-maximal
-  {:id "actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -32,7 +32,7 @@
    :tlp "green"})
 
 (def actor-minimal
-  {:id "actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
    :actor_type "Hacker",
@@ -41,7 +41,7 @@
    :valid_time {}})
 
 (def new-actor-maximal
-  {:id "actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -76,7 +76,7 @@
    :source "a source"})
 
 (def stored-actor-maximal
-  {:id "actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -110,7 +110,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-actor-minimal
-  {:id "actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
    :actor_type "Hacker",

--- a/src/ctim/examples/campaigns.cljc
+++ b/src/ctim/examples/campaigns.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def campaign-maximal
-  {:id "campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :names ["foo" "bar"]
    :schema_version c/ctim-schema-version
@@ -27,14 +27,14 @@
                :description "activity"}]})
 
 (def campaign-minimal
-  {:id "campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :schema_version c/ctim-schema-version
    :campaign_type "anything goes here"
    :valid_time {}})
 
 (def new-campaign-maximal
-  {:id "campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :names ["foo" "bar"]
    :schema_version c/ctim-schema-version
@@ -62,7 +62,7 @@
   {:campaign_type "anything goes here"})
 
 (def stored-campaign-maximal
-  {:id "campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :names ["foo" "bar"]
    :schema_version c/ctim-schema-version
@@ -91,7 +91,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-campaign-minimal
-  {:id "campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :schema_version c/ctim-schema-version
    :campaign_type "anything goes here"

--- a/src/ctim/examples/coas.cljc
+++ b/src/ctim/examples/coas.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def coa-openc2-variant1
-  {:id "coa-40c6ab14-5bda-4f79-b756-e24c9dc8c52c"
+  {:id "http://ex.tld/ctia/coa/coa-40c6ab14-5bda-4f79-b756-e24c9dc8c52c"
    :type "coa"
    :schema_version c/ctim-schema-version
    :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
@@ -19,7 +19,7 @@
                             :location "perimeter"}}})
 
 (def coa-openc2-variant2
-  {:id "coa-cb117f67-4d17-4d6c-a220-16e04f9b712a"
+  {:id "http://ex.tld/ctia/coa/coa-cb117f67-4d17-4d6c-a220-16e04f9b712a"
    :type "coa"
    :schema_version c/ctim-schema-version
    :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
@@ -37,7 +37,7 @@
                             :option "vlan=1002"}}})
 
 (def coa-maximal
-  {:id "coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
+  {:id "http://ex.tld/ctia/coa/coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
    :type "coa"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -75,13 +75,13 @@
                              :location "perimeter"}}})
 
 (def coa-minimal
-  {:id "coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
+  {:id "http://ex.tld/ctia/coa/coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
    :type "coa"
    :schema_version c/ctim-schema-version
    :valid_time {}})
 
 (def new-coa-maximal
-  {:id "coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
+  {:id "http://ex.tld/ctia/coa/coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
    :type "coa"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -122,7 +122,7 @@
   {:schema_version c/ctim-schema-version})
 
 (def stored-coa-maximal
-  {:id "coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
+  {:id "http://ex.tld/ctia/coa/coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
    :type "coa"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -164,7 +164,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-coa-minimal
-  {:id "coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
+  {:id "http://ex.tld/ctia/coa/coa-599c96cb-9e88-4d19-a3ee-a94802a39660"
    :type "coa"
    :schema_version c/ctim-schema-version
    :valid_time {}

--- a/src/ctim/examples/exploit_targets.cljc
+++ b/src/ctim/examples/exploit_targets.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def exploit-target-maximal
-  {:id "exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
+  {:id "http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
    :type "exploit-target"
    :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
                   "http://ex.tld/ctia/exploit-target/exploit-target-345"]
@@ -37,13 +37,13 @@
                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}})
 
 (def exploit-target-minimal
-  {:id "exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
+  {:id "http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
    :type "exploit-target"
    :schema_version c/ctim-schema-version
    :valid_time {}})
 
 (def new-exploit-target-maximal
-  {:id "exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
+  {:id "http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
    :type "exploit-target"
    :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
                   "http://ex.tld/ctia/exploit-target/exploit-target-345"]
@@ -81,7 +81,7 @@
   {})
 
 (def stored-exploit-target-maximal
-  {:id "exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
+  {:id "http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
    :type "exploit-target"
    :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
                   "http://ex.tld/ctia/exploit-target/exploit-target-345"]
@@ -120,7 +120,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-exploit-target-minimal
-  {:id "exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
+  {:id "http://ex.tld/ctia/exploit-target/exploit-target-9e50cded-8631-41d4-9fb9-fbabf292b862"
    :type "exploit-target"
    :schema_version c/ctim-schema-version
    :valid_time {}

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def incident-maximal
-  {:id "incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :type "incident"
@@ -75,14 +75,14 @@
    :intended_effect "Extortion"})
 
 (def incident-minimal
-  {:id "incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
    :type "incident"
    :schema_version c/ctim-schema-version
    :confidence "High"
    :valid_time {}})
 
 (def new-incident-maximal
-  {:id "incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :type "incident"
@@ -158,7 +158,7 @@
   {:confidence "High"})
 
 (def stored-incident-maximal
-  {:id "incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :type "incident"
@@ -235,7 +235,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-incident-minimal
-  {:id "incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
    :type "incident"
    :schema_version c/ctim-schema-version
    :confidence "High"

--- a/src/ctim/examples/indicators.cljc
+++ b/src/ctim/examples/indicators.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def indicator-maximal
-  {:id "indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
+  {:id "http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
    :type "indicator"
    :external_ids ["http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
                   "http://ex.tld/ctia/indicator/indicator-345"]
@@ -37,14 +37,14 @@
                                           :confidence "High"}]}})
 
 (def indicator-minimal
-  {:id "indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
+  {:id "http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
    :type "indicator"
    :producer "producer"
    :schema_version c/ctim-schema-version
    :valid_time {}})
 
 (def new-indicator-maximal
-  {:id "indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
+  {:id "http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
    :type "indicator"
    :external_ids ["http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
                   "http://ex.tld/ctia/indicator/indicator-345"]
@@ -82,7 +82,7 @@
   {:producer "prod"})
 
 (def stored-indicator-maximal
-  {:id "indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
+  {:id "http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
    :type "indicator"
    :external_ids ["http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
                   "http://ex.tld/ctia/indicator/indicator-345"]
@@ -121,7 +121,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-indicator-minimal
-  {:id "indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
+  {:id "http://ex.tld/ctia/indicator/indicator-10b490f8-7c1d-4c3b-9be3-52a7fa5c5042"
    :type "indicator"
    :producer "producer"
    :schema_version c/ctim-schema-version

--- a/src/ctim/examples/judgements.cljc
+++ b/src/ctim/examples/judgements.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def judgement-maximal
-  {:id "judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
+  {:id "http://ex.tld/ctia/judgement/judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
    :type "judgement"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -25,7 +25,7 @@
    :reason_uri "http://example.com/a-really-good-reason"})
 
 (def judgement-minimal
-  {:id "judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
+  {:id "http://ex.tld/ctia/judgement/judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
    :type "judgement"
    :schema_version c/ctim-schema-version
    :source "source"
@@ -39,7 +39,7 @@
    :valid_time {}})
 
 (def new-judgement-maximal
-  {:id "judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
+  {:id "http://ex.tld/ctia/judgement/judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
    :type "judgement"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -70,7 +70,7 @@
    :severity "Medium"})
 
 (def stored-judgement-maximal
-  {:id "judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
+  {:id "http://ex.tld/ctia/judgement/judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
    :type "judgement"
    :schema_version c/ctim-schema-version
    :revision 1
@@ -97,7 +97,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-judgement-minimal
-  {:id "judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
+  {:id "http://ex.tld/ctia/judgement/judgement-494d13ae-e914-43f0-883b-085062a8d9a1"
    :type "judgement"
    :schema_version c/ctim-schema-version
    :revision 1

--- a/src/ctim/examples/relationships.cljc
+++ b/src/ctim/examples/relationships.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def relationship-maximal
-  {:id "relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
+  {:id "http://ex.tld/ctia/relationship/relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
    :type "relationship"
    :schema_version c/ctim-schema-version
    :title "title"
@@ -20,7 +20,7 @@
    :target_ref "http://example.com/ctia/incident/incident-558d3812-3434-4085-87b4-4bf32f95c42c"})
 
 (def relationship-minimal
-  {:id "relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
+  {:id "http://ex.tld/ctia/relationship/relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
    :type "relationship"
    :schema_version c/ctim-schema-version
    :relationship_type "targets"
@@ -28,7 +28,7 @@
    :target_ref "http://example.com/ctia/incident/incident-558d3812-3434-4085-87b4-4bf32f95c42c"})
 
 (def new-relationship-maximal
-  {:id "relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
+  {:id "http://ex.tld/ctia/relationship/relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
    :type "relationship"
    :schema_version c/ctim-schema-version
    :title "title"
@@ -51,7 +51,7 @@
    :target_ref "http://example.com/ctia/incident/incident-558d3812-3434-4085-87b4-4bf32f95c42c"})
 
 (def stored-relationship-maximal
-  {:id "relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
+  {:id "http://ex.tld/ctia/relationship/relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
    :type "relationship"
    :schema_version c/ctim-schema-version
    :title "title"
@@ -73,7 +73,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-relationship-minimal
-  {:id "relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
+  {:id "http://ex.tld/ctia/relationship/relationship-ece41fa5-a74c-4048-8a55-f0033b45701e"
    :type "relationship"
    :schema_version c/ctim-schema-version
    :relationship_type "targets"

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def sighting-maximal
-  {:id "sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
+  {:id "http://ex.tld/ctia/sighting/sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
    :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                   "http://ex.tld/ctia/sighting/sighting-456"]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
@@ -37,7 +37,7 @@
                 :related {:type "ipv6" :value "bar"}}]})
 
 (def sighting-minimal
-  {:id "sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
+  {:id "http://ex.tld/ctia/sighting/sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
    :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                    :end_time #inst "2016-02-11T00:40:48.212-00:00"}
    :confidence "High"
@@ -46,7 +46,7 @@
    :count 1})
 
 (def new-sighting-maximal
-  {:id "sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
+  {:id "http://ex.tld/ctia/sighting/sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
    :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                   "http://ex.tld/ctia/sighting/sighting-456"]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
@@ -85,7 +85,7 @@
                    :end_time #inst "2016-02-11T00:40:48.212-00:00"}})
 
 (def stored-sighting-maximal
-  {:id "sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
+  {:id "http://ex.tld/ctia/sighting/sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
    :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                   "http://ex.tld/ctia/sighting/sighting-456"]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
@@ -124,7 +124,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-sighting-minimal
-  {:id "sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
+  {:id "http://ex.tld/ctia/sighting/sighting-eb965192-9f85-4bc8-baa2-0766f9f63db3"
    :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                    :end_time #inst "2016-02-11T00:40:48.212-00:00"}
    :confidence "High"

--- a/src/ctim/examples/ttps.cljc
+++ b/src/ctim/examples/ttps.cljc
@@ -2,7 +2,7 @@
   (:require [ctim.schemas.common :as c]))
 
 (def ttp-maximal
-  {:id "ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
+  {:id "http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
    :external_ids ["http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
                   "http://ex.tld/ctia/ttp/ttp-345"]
    :type "ttp"
@@ -53,14 +53,14 @@
    :kill_chains ["Delivery"]})
 
 (def ttp-minimal
-  {:id "ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
+  {:id "http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
    :type "ttp"
    :ttp_type "foo"
    :schema_version c/ctim-schema-version
    :valid_time {}})
 
 (def new-ttp-maximal
-  {:id "ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
+  {:id "http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
    :external_ids ["http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
                   "http://ex.tld/ctia/ttp/ttp-345"]
    :type "ttp"
@@ -115,7 +115,7 @@
    :schema_version c/ctim-schema-version})
 
 (def stored-ttp-maximal
-  {:id "ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
+  {:id "http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
    :external_ids ["http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
                   "http://ex.tld/ctia/ttp/ttp-345"]
    :type "ttp"
@@ -170,7 +170,7 @@
    :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def stored-ttp-minimal
-  {:id "ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
+  {:id "http://ex.tld/ctia/ttp/ttp-78b9b012-3dee-4844-ae4f-ee2744c389d1"
    :type "ttp"
    :ttp_type "foo"
    :schema_version c/ctim-schema-version

--- a/src/ctim/generators/events.clj
+++ b/src/ctim/generators/events.clj
@@ -17,6 +17,6 @@
                            :type event-type
                            :id id}))
             (gen/tuple
-             (gi/gen-short-id-of-type :event)
+             (gi/gen-url-id-of-type :event)
              ge/gen-any-example-entity
              gen-event-type)))

--- a/test/ctim/specs/actor_test.clj
+++ b/test/ctim/specs/actor_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.actor :as a]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.actors :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec a/StoredActor kwns)
-         e/stored-actor-minimal))))
+         e/stored-actor-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec a/StoredActor kwns)
+         (update e/stored-actor-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/campaign_test.clj
+++ b/test/ctim/specs/campaign_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.campaign :as c]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.campaigns :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec c/StoredCampaign kwns)
-         e/stored-campaign-minimal))))
+         e/stored-campaign-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec c/StoredCampaign kwns)
+         (update e/stored-campaign-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/coa_test.clj
+++ b/test/ctim/specs/coa_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.coa :as c]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.coas :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -52,4 +53,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec c/StoredCOA kwns)
-         e/stored-coa-minimal))))
+         e/stored-coa-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec c/StoredCOA kwns)
+         (update e/stored-coa-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/exploit_target_test.clj
+++ b/test/ctim/specs/exploit_target_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.exploit-target :as et]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.exploit-targets :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec et/StoredExploitTarget kwns)
-         e/stored-exploit-target-minimal))))
+         e/stored-exploit-target-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec et/StoredExploitTarget kwns)
+         (update e/stored-exploit-target-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/incident_test.clj
+++ b/test/ctim/specs/incident_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.incident :as i]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.incidents :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec i/StoredIncident kwns)
-         e/stored-incident-minimal))))
+         e/stored-incident-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec i/StoredIncident kwns)
+         (update e/stored-incident-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/indicator_test.clj
+++ b/test/ctim/specs/indicator_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.indicator :as i]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.indicators :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec i/StoredIndicator kwns)
-         e/stored-indicator-minimal))))
+         e/stored-indicator-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec i/StoredIndicator kwns)
+         (update e/stored-indicator-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/judgement_test.clj
+++ b/test/ctim/specs/judgement_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.judgement :as j]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.judgements :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -39,4 +40,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec j/StoredJudgement "stored-judgement")
-         e/stored-judgement-minimal))))
+         e/stored-judgement-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec j/StoredJudgement "stored-judgement")
+         (update e/stored-judgement-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/relationship_test.clj
+++ b/test/ctim/specs/relationship_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.relationship :as r]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.relationships :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec r/StoredRelationship kwns)
-         e/stored-relationship-minimal))))
+         e/stored-relationship-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec r/StoredRelationship kwns)
+         (update e/stored-relationship-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/sighting_test.clj
+++ b/test/ctim/specs/sighting_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.sighting :as si]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.sightings :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec si/StoredSighting kwns)
-         e/stored-sighting-minimal))))
+         e/stored-sighting-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec si/StoredSighting kwns)
+         (update e/stored-sighting-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/specs/ttp_test.clj
+++ b/test/ctim/specs/ttp_test.clj
@@ -4,7 +4,8 @@
             [ctim.schemas.ttp :as t]
             [ctim.test-helpers.core :refer [fixture-spec-validation]]
             [ctim.examples.ttps :as e]
-            [flanders.spec :as fs]))
+            [flanders.spec :as fs]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once fixture-spec-validation)
 
@@ -41,4 +42,10 @@
   (testing "example with only required fields"
     (is (s/assert
          (fs/->spec t/StoredTTP kwns)
-         e/stored-ttp-minimal))))
+         e/stored-ttp-minimal)))
+
+  (testing "example with short id"
+    (is (s/assert
+         (fs/->spec t/StoredTTP kwns)
+         (update e/stored-ttp-minimal
+                 :id id/str->short-id)))))

--- a/test/ctim/test_helpers/properties.clj
+++ b/test/ctim/test_helpers/properties.clj
@@ -13,19 +13,19 @@
             (cs/valid? spec entity))))
 
 (defn generated-entity-id-is-valid
-  ([spec id-prefix]
-   (generated-entity-id-is-valid spec id-prefix false (cs/gen spec)))
-  ([spec id-prefix optional?]
-   (generated-entity-id-is-valid spec id-prefix optional? (cs/gen spec)))
-  ([spec id-prefix optional? gen]
+  ([spec entity-type]
+   (generated-entity-id-is-valid spec entity-type false (cs/gen spec)))
+  ([spec entity-type optional?]
+   (generated-entity-id-is-valid spec entity-type optional? (cs/gen spec)))
+  ([spec entity-type optional? gen]
    (for-all [entity gen]
             (let [id (:id entity)]
               (if (and optional?
                        (nil? id))
                 true
                 (and (string? id)
-                     (str/starts-with? id id-prefix)
-                     (re-matches id/short-id-re id)))))))
+                     (str/includes? id entity-type)
+                     (re-matches id/long-id-re id)))))))
 
 (defn generated-entity-has-ctim-schema-version [spec]
   (for-all [entity (cs/gen spec)]


### PR DESCRIPTION
Set entity IDs as URLs (ex: `https://intel.int.iroh.site:443/ctia/relationship/relationship-000003b0-ec1c-412e-8bea-fdd4e006fda1`).

Short IDs (ex: `relationship-000003b0-ec1c-412e-8bea-fdd4e006fda1`) are only allowed for stored entities for backward compatibility