### PR TITLE
Make Malware objects sourcable and describable

### DIFF
--- a/src/ctim/schemas/malware.cljc
+++ b/src/ctim/schemas/malware.cljc
@@ -25,17 +25,13 @@
   {:description malware-desc
    :reference malware-desc-link}
   c/base-entity-entries
+  c/sourcable-object-entries
+  c/describable-entity-entries
   (f/required-entries
-   (f/entry :type MalwareTypeIdentifier)
-   (f/entry :name c/ShortString
-            :description "A name used to identify the Malware sample.")
-   (f/entry :labels [v/MalwareLabel]
-            :description "The type of malware being described."))
+   (f/entry :type MalwareTypeIdentifier))
   (f/optional-entries
-   (f/entry :description c/Markdown
-            :description (str "A description that provides more details and "
-                              "context about the Malware, potentially including "
-                              "its purpose and its key characteristics."))
+   (f/entry :labels [v/MalwareLabel]
+            :description "The type of malware being described.")
    (f/entry :kill_chain_phases [c/KillChainPhase]
             :description (str "The list of Kill Chain Phases for which this "
                               "Malware can be used."))


### PR DESCRIPTION
- now inherits from `sourcable-object-entries` and `describable-object-entries`
- `:name` key replaced with `:title`
- `:labels` key now optional
- `:description removed` (as we are now describable)