### PR TITLE
Make attack-pattern, malware and tool schemas sourcable

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -31,6 +31,7 @@ a few simplifications:
 ## Models
 
 - [Actor](structures/actor.md)
+- [Attack Pattern](structures/attack_pattern.md)
 - [Campaign](structures/campaign.md)
 - [Course of Action](structures/coa.md)
 - [Exploit Target](structures/exploit_target.md)
@@ -38,8 +39,10 @@ a few simplifications:
 - [Incident](structures/incident.md)
 - [Indicator](structures/indicator.md)
 - [Judgement](structures/judgement.md)
+- [Malware](structures/malware.md)
 - [Relationship](structures/relationship.md)
 - [Sighting](structures/sighting.md)
+- [Tool](structures/tool.md)
 - [Verdict](structures/verdict.md)
 
 ## Relationships
@@ -53,7 +56,7 @@ a few simplifications:
 ## Examples
 
 - [Actor](json/actor.json) JSON
-- [AttackPattern](json/attack_pattern.json) JSON
+- [Attack Pattern](json/attack_pattern.json) JSON
 - [Campaign](json/campaign.json) JSON
 - [Course of Action](json/coa.json) JSON
 - [Exploit Target](json/exploit_target.json) JSON

--- a/doc/json/actor.json
+++ b/doc/json/actor.json
@@ -27,6 +27,13 @@
   "intended_effect" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "motivation" : "string",
   "actor_type" : "string",
   "description" : "string",

--- a/doc/json/attack_pattern.json
+++ b/doc/json/attack_pattern.json
@@ -1,14 +1,19 @@
 {
   "tlp" : "string",
-  "entity_id" : "string",
+  "x_mitre_platforms" : [ "string" ],
+  "x_mitre_data_sources" : [ "string" ],
+  "kill_chain_phases" : [ {
+    "kill_chain_name" : "string",
+    "phase_name" : "string"
+  } ],
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
   "revision" : 10,
-  "feedback" : 10,
+  "x_mitre_contributors" : [ "string" ],
+  "name" : "string",
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
-  "reason" : "string",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {
@@ -18,5 +23,6 @@
     "hashes" : [ "string" ],
     "external_id" : "string"
   } ],
+  "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/json/campaign.json
+++ b/doc/json/campaign.json
@@ -23,6 +23,13 @@
   "intended_effect" : [ "string" ],
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/json/coa.json
+++ b/doc/json/coa.json
@@ -60,6 +60,13 @@
   "type" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "coa_type" : "string",
   "description" : "string",
   "external_ids" : [ "string" ],

--- a/doc/json/exploit_target.json
+++ b/doc/json/exploit_target.json
@@ -37,6 +37,13 @@
   "type" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -19,12 +19,6 @@
     "value" : "string",
     "type" : "string"
   } ],
-  "leveraged_TTPs" : [ {
-    "confidence" : "string",
-    "source" : "string",
-    "relationship" : "string",
-    "TTP_id" : "string"
-  } ],
   "responder" : "string",
   "attributed_actors" : [ {
     "confidence" : "string",
@@ -149,6 +143,13 @@
   } ],
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "security_compromise" : "string",
   "coordinator" : "string",
   "contact" : "string",

--- a/doc/json/indicator.json
+++ b/doc/json/indicator.json
@@ -8,7 +8,10 @@
   },
   "tlp" : "string",
   "negate" : true,
-  "kill_chain_phases" : [ "string" ],
+  "kill_chain_phases" : [ {
+    "kill_chain_name" : "string",
+    "phase_name" : "string"
+  } ],
   "tags" : [ "string" ],
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -26,6 +29,13 @@
   "type" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "description" : "string",
   "external_ids" : [ "string" ],
   "specification" : {

--- a/doc/json/judgement.json
+++ b/doc/json/judgement.json
@@ -21,6 +21,13 @@
   "reason" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "severity" : "string",
   "reason_uri" : "string",
   "external_ids" : [ "string" ]

--- a/doc/json/malware.json
+++ b/doc/json/malware.json
@@ -1,14 +1,18 @@
 {
   "tlp" : "string",
-  "entity_id" : "string",
+  "kill_chain_phases" : [ {
+    "kill_chain_name" : "string",
+    "phase_name" : "string"
+  } ],
+  "x_mitre_aliases" : [ "string" ],
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
   "revision" : 10,
-  "feedback" : 10,
+  "name" : "string",
+  "labels" : [ "string" ],
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
-  "reason" : "string",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {
@@ -18,5 +22,6 @@
     "hashes" : [ "string" ],
     "external_id" : "string"
   } ],
+  "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/json/relationship.json
+++ b/doc/json/relationship.json
@@ -13,6 +13,13 @@
   "type" : "string",
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/json/sighting.json
+++ b/doc/json/sighting.json
@@ -44,6 +44,13 @@
   },
   "source_uri" : "string",
   "language" : "string",
+  "external_references" : [ {
+    "source_name" : "string",
+    "description" : "string",
+    "url" : "string",
+    "hashes" : [ "string" ],
+    "external_id" : "string"
+  } ],
   "observed_time" : {
     "start_time" : "2016-01-01T01:01:01.000Z",
     "end_time" : "2016-01-01T01:01:01.000Z"

--- a/doc/json/tool.json
+++ b/doc/json/tool.json
@@ -1,14 +1,19 @@
 {
   "tlp" : "string",
-  "entity_id" : "string",
+  "kill_chain_phases" : [ {
+    "kill_chain_name" : "string",
+    "phase_name" : "string"
+  } ],
+  "x_mitre_aliases" : [ "string" ],
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
   "revision" : 10,
-  "feedback" : 10,
+  "name" : "string",
+  "labels" : [ "string" ],
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
-  "reason" : "string",
+  "tool_version" : "string",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {
@@ -18,5 +23,6 @@
     "hashes" : [ "string" ],
     "external_id" : "string"
   } ],
+  "description" : "string",
   "external_ids" : [ "string" ]
 }

--- a/doc/structures/actor.md
+++ b/doc/structures/actor.md
@@ -14,6 +14,7 @@ Describes malicious actors (or adversaries) related to a cyber attack
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLow String| ||
 |[description](#propertydescription-string)| String| ||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[identity](#propertyidentity-identityobject)|*Identity* Object| ||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffect String| ||
 |[language](#propertylanguage-string)| String| ||
@@ -84,13 +85,26 @@ Describes malicious actors (or adversaries) related to a cyber attack
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertyidentity-identityobject"></a>
 ## Property identity ∷ *Identity* Object
@@ -98,9 +112,9 @@ Describes malicious actors (or adversaries) related to a cyber attack
 * This entry is optional
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *Identity* Object Value
-  * Details: [*Identity* Object](#map2)
+  * Details: [*Identity* Object](#map3)
 
 <a id="propertyintended_effect-intendedeffectstring"></a>
 ## Property intended_effect ∷ IntendedEffect String
@@ -271,11 +285,73 @@ CTIM schema version for this entity
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -307,7 +383,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *Identity* Object
 
 Describes a person or an organization
@@ -336,11 +412,11 @@ Identifies other entity Identities related to this Identity
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *RelatedIdentity* Object Value
-  * Details: [*RelatedIdentity* Object](#map3)
+  * Details: [*RelatedIdentity* Object](#map4)
 
-<a id="map3"></a>
+<a id="map4"></a>
 # *RelatedIdentity* Object
 
 Describes a related Identity

--- a/doc/structures/attack_pattern.md
+++ b/doc/structures/attack_pattern.md
@@ -1,0 +1,360 @@
+<a id="top"></a>
+# *AttackPattern* Object
+
+Attack Patterns are a type of TTP that describe ways that adversaries attempt to compromise targets.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[description](#propertydescription-string)| String|A description that provides more details and context about the Attack Pattern, potentially including its purpose and its key characteristics.|&#10003;|
+|[id](#propertyid-string)| String| |&#10003;|
+|[name](#propertyname-string)| String|A name used to identify the Attack Pattern.|&#10003;|
+|[schema_version](#propertyschema_version-string)| String|CTIM schema version for this entity|&#10003;|
+|[type](#propertytype-attackpatterntypeidentifierstring)|AttackPatternTypeIdentifier String| |&#10003;|
+|[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|A list of external references which refer to non-STIX information. This property MAY be used to provide one or more Attack Pattern identifiers, such as a CAPEC ID. When specifying a CAPEC ID, the source_name property of the external reference MUST be set to capec and the external_id property MUST be formatted as CAPEC-[id].||
+|[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Attack Pattern is used.||
+|[language](#propertylanguage-string)| String| ||
+|[revision](#propertyrevision-integer)|Integer| ||
+|[source](#propertysource-string)| String| ||
+|[source_uri](#propertysource_uri-string)| String| ||
+|[timestamp](#propertytimestamp-instdate)|Inst (Date)| ||
+|[tlp](#propertytlp-tlpstring)|TLP String| ||
+|[x_mitre_contributors](#propertyx_mitre_contributors-stringlist)| String List|ATT&CK Technique.Contributors||
+|[x_mitre_data_sources](#propertyx_mitre_data_sources-stringlist)| String List|ATT&CK Technique.Data Sources||
+|[x_mitre_platforms](#propertyx_mitre_platforms-stringlist)| String List|ATT&CK Technique.Platforms||
+
+* Reference: [Attack Pattern](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.axjijf603msy)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+A description that provides more details and context about the Attack Pattern, potentially including its purpose and its key characteristics.
+
+* This entry is required
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_ids-stringlist"></a>
+## Property external_ids ∷  String List
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+A list of external references which refer to non-STIX information. This property MAY be used to provide one or more Attack Pattern identifiers, such as a CAPEC ID. When specifying a CAPEC ID, the source_name property of the external reference MUST be set to capec and the external_id property MUST be formatted as CAPEC-[id].
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map2-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map2)
+
+<a id="propertyid-string"></a>
+## Property id ∷  String
+
+* This entry is required
+
+
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
+
+<a id="propertykill_chain_phases-killchainphaseobjectlist"></a>
+## Property kill_chain_phases ∷ *KillChainPhase* Object List
+
+The list of Kill Chain Phases for which this Attack Pattern is used.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map3-ref"></a>
+* *KillChainPhase* Object Value
+  * Details: [*KillChainPhase* Object](#map3)
+
+<a id="propertylanguage-string"></a>
+## Property language ∷  String
+
+* This entry is optional
+
+
+  * String with at most 1024 characters
+
+<a id="propertyname-string"></a>
+## Property name ∷  String
+
+A name used to identify the Attack Pattern.
+
+* This entry is required
+
+
+  * String with at most 1024 characters
+
+<a id="propertyrevision-integer"></a>
+## Property revision ∷ Integer
+
+* This entry is optional
+
+
+  * Zero, or a positive integer
+
+<a id="propertyschema_version-string"></a>
+## Property schema_version ∷  String
+
+CTIM schema version for this entity
+
+* This entry is required
+
+
+  * A semantic version matching the CTIM version against which this object should be valid.
+
+<a id="propertysource-string"></a>
+## Property source ∷  String
+
+* This entry is optional
+
+
+  * String with at most 2048 characters
+
+<a id="propertysource_uri-string"></a>
+## Property source_uri ∷  String
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="propertytimestamp-instdate"></a>
+## Property timestamp ∷ Inst (Date)
+
+* This entry is optional
+
+
+  * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="propertytlp-tlpstring"></a>
+## Property tlp ∷ TLP String
+
+* This entry is optional
+
+
+  * TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how this resource is intended to be shared, replicated, copied, etc.
+  * Default: green
+  * Allowed Values:
+    * amber
+    * green
+    * red
+    * white
+
+<a id="propertytype-attackpatterntypeidentifierstring"></a>
+## Property type ∷ AttackPatternTypeIdentifier String
+
+* This entry is required
+
+
+  * Must equal: "attack-pattern"
+
+<a id="propertyx_mitre_contributors-stringlist"></a>
+## Property x_mitre_contributors ∷  String List
+
+ATT&CK Technique.Contributors
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * String with at most 1024 characters
+
+<a id="propertyx_mitre_data_sources-stringlist"></a>
+## Property x_mitre_data_sources ∷  String List
+
+ATT&CK Technique.Data Sources
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * String with at most 1024 characters
+
+<a id="propertyx_mitre_platforms-stringlist"></a>
+## Property x_mitre_platforms ∷  String List
+
+ATT&CK Technique.Platforms
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * String with at most 1024 characters
+
+<a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map3"></a>
+# *KillChainPhase* Object
+
+The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[kill_chain_name](#propertykill_chain_name-string)| String|The name of the kill chain.|&#10003;|
+|[phase_name](#propertyphase_name-string)| String|The name of the phase in the kill chain.|&#10003;|
+
+* Reference: [Kill Chain Phase](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.i4tjv75ce50h)
+
+<a id="propertykill_chain_name-string"></a>
+## Property kill_chain_name ∷  String
+
+The name of the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Must equal: "lockheed-martin-cyber-kill-chain"
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
+
+<a id="propertyphase_name-string"></a>
+## Property phase_name ∷  String
+
+The name of the phase in the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Allowed Values:
+    * actions-on-objective
+    * command-and-control
+    * delivery
+    * exploitation
+    * installation
+    * reconnaissance
+    * weaponization
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)

--- a/doc/structures/campaign.md
+++ b/doc/structures/campaign.md
@@ -14,6 +14,7 @@ Represents a campaign by an [actor](actor.md) pursing an intent
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLow String|Level of confidence held in the characterization of this Campaign||
 |[description](#propertydescription-string)| String| ||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[intended_effect](#propertyintended_effect-intendedeffectstringlist)|IntendedEffect String List|Characterizes the intended effect of this cyber threat campaign||
 |[language](#propertylanguage-string)| String| ||
 |[names](#propertynames-stringlist)| String List|Names used to identify this campaign||
@@ -37,9 +38,9 @@ Actions taken in regards to this Campaign
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *Activity* Object Value
-  * Details: [*Activity* Object](#map2)
+  * Details: [*Activity* Object](#map3)
 
 <a id="propertycampaign_type-string"></a>
 ## Property campaign_type ∷  String
@@ -82,13 +83,26 @@ Level of confidence held in the characterization of this Campaign
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertyintended_effect-intendedeffectstringlist"></a>
 ## Property intended_effect ∷ IntendedEffect String List
@@ -245,11 +259,73 @@ Timestamp for the definition of a specific version of a campaign
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -281,7 +357,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *Activity* Object
 
 What happend, when?

--- a/doc/structures/coa.md
+++ b/doc/structures/coa.md
@@ -14,6 +14,7 @@ Course of Action. A corrective or preventative action to be taken in response to
 |[description](#propertydescription-string)| String| ||
 |[efficacy](#propertyefficacy-highmedlowstring)|HighMedLow String|Effectiveness of this course of action in achieving its targeted objective||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[impact](#propertyimpact-string)| String|Characterizes the estimated impact of applying this course of action||
 |[language](#propertylanguage-string)| String| ||
 |[objective](#propertyobjective-stringlist)| String List|Characterizes the objective of this course of action||
@@ -106,13 +107,26 @@ Effectiveness of this course of action in achieving its targeted objective
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertyimpact-string"></a>
 ## Property impact ∷  String
@@ -150,9 +164,9 @@ Characterizes the objective of this course of action
 * This entry is optional
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *OpenC2COA* Object Value
-  * Details: [*OpenC2COA* Object](#map3)
+  * Details: [*OpenC2COA* Object](#map4)
 
 <a id="propertyrelated_coas-relatedcoaobjectlist"></a>
 ## Property related_COAs ∷ *RelatedCOA* Object List
@@ -163,9 +177,9 @@ Identifies or characterizes relationships to one or more related courses of acti
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *RelatedCOA* Object Value
-  * Details: [*RelatedCOA* Object](#map2)
+  * Details: [*RelatedCOA* Object](#map3)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -274,11 +288,73 @@ Specifies what stage in the cyber threat management lifecycle this Course Of Act
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -310,7 +386,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *RelatedCOA* Object
 
 | Property | Type | Description | Required? |
@@ -357,7 +433,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
 
 
-<a id="map3"></a>
+<a id="map4"></a>
 # *OpenC2COA* Object
 
 | Property | Type | Description | Required? |
@@ -376,9 +452,9 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is required
 
 
-<a id="map4-ref"></a>
+<a id="map5-ref"></a>
 * *ActionType* Object Value
-  * Details: [*ActionType* Object](#map4)
+  * Details: [*ActionType* Object](#map5)
 
 <a id="propertyactuator-actuatortypeobject"></a>
 ## Property actuator ∷ *ActuatorType* Object
@@ -386,9 +462,9 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is optional
 
 
-<a id="map6-ref"></a>
+<a id="map7-ref"></a>
 * *ActuatorType* Object Value
-  * Details: [*ActuatorType* Object](#map6)
+  * Details: [*ActuatorType* Object](#map7)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -404,9 +480,9 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is optional
 
 
-<a id="map7-ref"></a>
+<a id="map8-ref"></a>
 * *ModifierType* Object Value
-  * Details: [*ModifierType* Object](#map7)
+  * Details: [*ModifierType* Object](#map8)
 
 <a id="propertytarget-targettypeobject"></a>
 ## Property target ∷ *TargetType* Object
@@ -414,9 +490,9 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is optional
 
 
-<a id="map5-ref"></a>
+<a id="map6-ref"></a>
 * *TargetType* Object Value
-  * Details: [*TargetType* Object](#map5)
+  * Details: [*TargetType* Object](#map6)
 
 <a id="propertytype-structuredcoatypestring"></a>
 ## Property type ∷ StructuredCOAType String
@@ -426,7 +502,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Must equal: "structured_coa"
 
-<a id="map7"></a>
+<a id="map8"></a>
 # *ModifierType* Object
 
 | Property | Type | Description | Required? |
@@ -452,9 +528,9 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is optional
 
 
-<a id="map9-ref"></a>
+<a id="map10-ref"></a>
 * *AdditionalProperties* Object Value
-  * Details: [*AdditionalProperties* Object](#map9)
+  * Details: [*AdditionalProperties* Object](#map10)
 
 <a id="propertydelay-instdate"></a>
 ## Property delay ∷ Inst (Date)
@@ -581,11 +657,11 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is optional
 
 
-<a id="map8-ref"></a>
+<a id="map9-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map8)
+  * Details: [*ValidTime* Object](#map9)
 
-<a id="map9"></a>
+<a id="map10"></a>
 # *AdditionalProperties* Object
 
 | Property | Type | Description | Required? |
@@ -601,7 +677,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * String with at most 1024 characters
 
-<a id="map8"></a>
+<a id="map9"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -633,7 +709,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map6"></a>
+<a id="map7"></a>
 # *ActuatorType* Object
 
 | Property | Type | Description | Required? |
@@ -707,7 +783,7 @@ list of additional properties describing the actuator
     * process.virtualization-service
     * process.vulnerability-scanner
 
-<a id="map5"></a>
+<a id="map6"></a>
 # *TargetType* Object
 
 | Property | Type | Description | Required? |
@@ -734,7 +810,7 @@ Cybox object representing the target
 
   * String with at most 1024 characters
 
-<a id="map4"></a>
+<a id="map5"></a>
 # *ActionType* Object
 
 | Property | Type | Description | Required? |

--- a/doc/structures/exploit_target.md
+++ b/doc/structures/exploit_target.md
@@ -12,6 +12,7 @@ Vulnerabilities or weaknesses in software, systems, networks, or configurations
 |[configuration](#propertyconfiguration-configurationobjectlist)|*Configuration* Object List|identifies and characterizes a Configuration as a potential Exploit Target||
 |[description](#propertydescription-string)| String| ||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[language](#propertylanguage-string)| String| ||
 |[revision](#propertyrevision-integer)|Integer| ||
 |[short_description](#propertyshort_description-string)| String| ||
@@ -34,9 +35,9 @@ identifies and characterizes a Configuration as a potential Exploit Target
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map4-ref"></a>
+<a id="map5-ref"></a>
 * *Configuration* Object Value
-  * Details: [*Configuration* Object](#map4)
+  * Details: [*Configuration* Object](#map5)
 
 <a id="propertydescription-string"></a>
 ## Property description ∷  String
@@ -54,13 +55,26 @@ identifies and characterizes a Configuration as a potential Exploit Target
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
@@ -156,9 +170,9 @@ CTIM schema version for this entity
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="propertyvulnerability-vulnerabilityobjectlist"></a>
 ## Property vulnerability ∷ *Vulnerability* Object List
@@ -169,9 +183,9 @@ identifies and characterizes a Vulnerability as a potential Exploit Target
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *Vulnerability* Object Value
-  * Details: [*Vulnerability* Object](#map2)
+  * Details: [*Vulnerability* Object](#map3)
 
 <a id="propertyweakness-weaknessobjectlist"></a>
 ## Property weakness ∷ *Weakness* Object List
@@ -182,11 +196,73 @@ identifies and characterizes a Weakness as a potential Exploit Target
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *Weakness* Object Value
-  * Details: [*Weakness* Object](#map3)
+  * Details: [*Weakness* Object](#map4)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -218,7 +294,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *Vulnerability* Object
 
 | Property | Type | Description | Required? |
@@ -357,7 +433,7 @@ title for this vulnerability
 
   * String with at most 1024 characters
 
-<a id="map3"></a>
+<a id="map4"></a>
 # *Weakness* Object
 
 | Property | Type | Description | Required? |
@@ -387,7 +463,7 @@ text description of this Weakness
 
   * String with at most 5000 characters
 
-<a id="map4"></a>
+<a id="map5"></a>
 # *Configuration* Object
 
 | Property | Type | Description | Required? |

--- a/doc/structures/feedback.md
+++ b/doc/structures/feedback.md
@@ -13,6 +13,7 @@ Feedback on any entity.  Is it wrong?  If so why?  Was
 |[schema_version](#propertyschema_version-string)| String|CTIM schema version for this entity|&#10003;|
 |[type](#propertytype-feedbacktypeidentifierstring)|FeedbackTypeIdentifier String| |&#10003;|
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[language](#propertylanguage-string)| String| ||
 |[revision](#propertyrevision-integer)|Integer| ||
 |[source](#propertysource-string)| String| ||
@@ -37,6 +38,19 @@ Feedback on any entity.  Is it wrong?  If so why?  Was
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyfeedback-integer"></a>
 ## Property feedback ∷ Integer
 
@@ -54,7 +68,7 @@ Feedback on any entity.  Is it wrong?  If so why?  Was
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
@@ -134,3 +148,65 @@ CTIM schema version for this entity
 
 
   * Must equal: "feedback"
+
+<a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -21,12 +21,12 @@ Discrete instance of indicators affecting an organization as well
 |[description](#propertydescription-string)| String| ||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethod String|identifies how the incident was discovered||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[history](#propertyhistory-historyobjectlist)|*History* Object List|a log of events or actions taken during the handling of the Incident||
 |[impact_assessment](#propertyimpact_assessment-impactassessmentobject)|*ImpactAssessment* Object|a summary assessment of impact for this cyber threat Incident||
 |[incident_time](#propertyincident_time-incidenttimeobject)|*IncidentTime* Object|relevant time values associated with this Incident||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffect String|specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-string)| String| ||
-|[leveraged_TTPs](#propertyleveraged_ttps-relatedttpobjectlist)|*RelatedTTP* Object List|specifies TTPs asserted to be related to this cyber threat Incident||
 |[related_incidents](#propertyrelated_incidents-relatedincidentobjectlist)|*RelatedIncident* Object List|identifies or characterizes one or more other Incidents related to this cyber threat Incident||
 |[related_indicators](#propertyrelated_indicators-relatedindicatorobjectlist)|*RelatedIndicator* Object List|identifies or characterizes one or more cyber threat Indicators related to this cyber threat Incident||
 |[related_observables](#propertyrelated_observables-observableobjectlist)|*Observable* Object List|identifies or characterizes one or more cyber observables related to this cyber threat incident||
@@ -54,9 +54,9 @@ specifies and characterizes requested Course Of Action for this Incident as spec
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map5-ref"></a>
+<a id="map6-ref"></a>
 * *COARequested* Object Value
-  * Details: [*COARequested* Object](#map5)
+  * Details: [*COARequested* Object](#map6)
 
 <a id="propertycoa_taken-coarequestedobjectlist"></a>
 ## Property COA_taken ∷ *COARequested* Object List
@@ -67,9 +67,9 @@ specifies and characterizes a Course Of Action taken for this Incident
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map6-ref"></a>
+<a id="map7-ref"></a>
 * *COARequested* Object Value
-  * Details: [*COARequested* Object](#map6)
+  * Details: [*COARequested* Object](#map7)
 
 <a id="propertyaffected_assets-affectedassetobjectlist"></a>
 ## Property affected_assets ∷ *AffectedAsset* Object List
@@ -80,9 +80,9 @@ particular assets affected during the Incident
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *AffectedAsset* Object Value
-  * Details: [*AffectedAsset* Object](#map3)
+  * Details: [*AffectedAsset* Object](#map4)
 
 <a id="propertyattributed_actors-relatedactorobjectlist"></a>
 ## Property attributed_actors ∷ *RelatedActor* Object List
@@ -196,6 +196,19 @@ identifies how the incident was discovered
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyhistory-historyobjectlist"></a>
 ## Property history ∷ *History* Object List
 
@@ -205,9 +218,9 @@ a log of events or actions taken during the handling of the Incident
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map7-ref"></a>
+<a id="map8-ref"></a>
 * *History* Object Value
-  * Details: [*History* Object](#map7)
+  * Details: [*History* Object](#map8)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -215,7 +228,7 @@ a log of events or actions taken during the handling of the Incident
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertyimpact_assessment-impactassessmentobject"></a>
 ## Property impact_assessment ∷ *ImpactAssessment* Object
@@ -225,9 +238,9 @@ a summary assessment of impact for this cyber threat Incident
 * This entry is optional
 
 
-<a id="map4-ref"></a>
+<a id="map5-ref"></a>
 * *ImpactAssessment* Object Value
-  * Details: [*ImpactAssessment* Object](#map4)
+  * Details: [*ImpactAssessment* Object](#map5)
 
 <a id="propertyincident_time-incidenttimeobject"></a>
 ## Property incident_time ∷ *IncidentTime* Object
@@ -238,9 +251,9 @@ relevant time values associated with this Incident
 * Dev Notes: Was 'time'; renamed for clarity
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *IncidentTime* Object Value
-  * Details: [*IncidentTime* Object](#map2)
+  * Details: [*IncidentTime* Object](#map3)
 
 <a id="propertyintended_effect-intendedeffectstring"></a>
 ## Property intended_effect ∷ IntendedEffect String
@@ -284,19 +297,6 @@ specifies the suspected intended effect of this incident
 
   * String with at most 1024 characters
 
-<a id="propertyleveraged_ttps-relatedttpobjectlist"></a>
-## Property leveraged_TTPs ∷ *RelatedTTP* Object List
-
-specifies TTPs asserted to be related to this cyber threat Incident
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-
-<a id="map10-ref"></a>
-* *RelatedTTP* Object Value
-  * Details: [*RelatedTTP* Object](#map10)
-
 <a id="propertyrelated_incidents-relatedincidentobjectlist"></a>
 ## Property related_incidents ∷ *RelatedIncident* Object List
 
@@ -319,9 +319,9 @@ identifies or characterizes one or more cyber threat Indicators related to this 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map8-ref"></a>
+<a id="map9-ref"></a>
 * *RelatedIndicator* Object Value
-  * Details: [*RelatedIndicator* Object](#map8)
+  * Details: [*RelatedIndicator* Object](#map9)
 
 <a id="propertyrelated_observables-observableobjectlist"></a>
 ## Property related_observables ∷ *Observable* Object List
@@ -333,9 +333,9 @@ identifies or characterizes one or more cyber observables related to this cyber 
 * Dev Notes: Was related_observables
 
 
-<a id="map9-ref"></a>
+<a id="map10-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map9)
+  * Details: [*Observable* Object](#map10)
 
 <a id="propertyreporter-string"></a>
 ## Property reporter ∷  String
@@ -478,9 +478,9 @@ time stamp for the definition of a specific version of an Incident
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="propertyvictim-string"></a>
 ## Property victim ∷  String
@@ -493,6 +493,68 @@ information about a victim of this Incident
   * String with at most 1024 characters
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -524,7 +586,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *IncidentTime* Object
 
 | Property | Type | Description | Required? |
@@ -613,7 +675,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map3"></a>
+<a id="map4"></a>
 # *AffectedAsset* Object
 
 | Property | Type | Description | Required? |
@@ -873,7 +935,7 @@ related security compromise
     * Unknown
     * Yes
 
-<a id="map4"></a>
+<a id="map5"></a>
 # *ImpactAssessment* Object
 
 | Property | Type | Description | Required? |
@@ -1177,7 +1239,7 @@ characterizes (at a high level) the level of response and recovery RELATED costs
     * None
     * Unknown
 
-<a id="map5"></a>
+<a id="map6"></a>
 # *COARequested* Object
 
 | Property | Type | Description | Required? |
@@ -1302,7 +1364,7 @@ role played by this contributor
 
 
 
-<a id="map6"></a>
+<a id="map7"></a>
 # *COARequested* Object
 
 | Property | Type | Description | Required? |
@@ -1427,7 +1489,7 @@ role played by this contributor
 
 
 
-<a id="map7"></a>
+<a id="map8"></a>
 # *History* Object
 
 | Property | Type | Description | Required? |
@@ -1586,7 +1648,7 @@ role played by this contributor
 
 
 
-<a id="map8"></a>
+<a id="map9"></a>
 # *RelatedIndicator* Object
 
 | Property | Type | Description | Required? |
@@ -1633,7 +1695,7 @@ role played by this contributor
 
 
 
-<a id="map9"></a>
+<a id="map10"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -1676,53 +1738,6 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 ## Property value ∷  String
 
 * This entry is required
-
-
-
-<a id="map10"></a>
-# *RelatedTTP* Object
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[TTP_id](#propertyttp_id-string)| String| |&#10003;|
-|[confidence](#propertyconfidence-highmedlowstring)|HighMedLow String| ||
-|[relationship](#propertyrelationship-string)| String| ||
-|[source](#propertysource-string)| String| ||
-
-
-<a id="propertyttp_id-string"></a>
-## Property TTP_id ∷  String
-
-* This entry is required
-
-
-  * A URI leading to a TTP
-
-<a id="propertyconfidence-highmedlowstring"></a>
-## Property confidence ∷ HighMedLow String
-
-* This entry is optional
-
-
-  * Allowed Values:
-    * High
-    * Low
-    * Medium
-    * None
-    * Unknown
-  * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
-
-<a id="propertyrelationship-string"></a>
-## Property relationship ∷  String
-
-* This entry is optional
-
-
-
-<a id="propertysource-string"></a>
-## Property source ∷  String
-
-* This entry is optional
 
 
 

--- a/doc/structures/indicator.md
+++ b/doc/structures/indicator.md
@@ -27,8 +27,9 @@ _specification_ value.
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLow String|level of confidence held in the accuracy of this Indicator||
 |[description](#propertydescription-string)| String| ||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[indicator_type](#propertyindicator_type-indicatortypestringlist)|IndicatorType String List|Specifies the type or types for this Indicator||
-|[kill_chain_phases](#propertykill_chain_phases-stringlist)| String List|relevant kill chain phases indicated by this Indicator||
+|[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|relevant kill chain phases indicated by this Indicator||
 |[language](#propertylanguage-string)| String| ||
 |[likely_impact](#propertylikely_impact-string)| String|likely potential impact within the relevant context if this Indicator were to occur||
 |[negate](#propertynegate-boolean)|Boolean|specifies the absence of the pattern||
@@ -51,9 +52,9 @@ _specification_ value.
 * This entry is optional
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *CompositeIndicatorExpression* Object Value
-  * Details: [*CompositeIndicatorExpression* Object](#map2)
+  * Details: [*CompositeIndicatorExpression* Object](#map3)
 
 <a id="propertyconfidence-highmedlowstring"></a>
 ## Property confidence ∷ HighMedLow String
@@ -87,13 +88,26 @@ level of confidence held in the accuracy of this Indicator
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertyindicator_type-indicatortypestringlist"></a>
 ## Property indicator_type ∷ IndicatorType String List
@@ -121,8 +135,8 @@ Specifies the type or types for this Indicator
     * URL Watchlist
   * Reference: [IndicatorTypeVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/IndicatorTypeVocab-1.1/)
 
-<a id="propertykill_chain_phases-stringlist"></a>
-## Property kill_chain_phases ∷  String List
+<a id="propertykill_chain_phases-killchainphaseobjectlist"></a>
+## Property kill_chain_phases ∷ *KillChainPhase* Object List
 
 relevant kill chain phases indicated by this Indicator
 
@@ -131,7 +145,9 @@ relevant kill chain phases indicated by this Indicator
 * Dev Notes: simplified
 
 
-  * String with at most 2048 characters
+<a id="map4-ref"></a>
+* *KillChainPhase* Object Value
+  * Details: [*KillChainPhase* Object](#map4)
 
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
@@ -219,25 +235,25 @@ CTIM schema version for this entity
 
   * Only one of the following schemas will match
 
-<a id="map3-ref"></a>
-* *JudgementSpecification* Object Value
-  * Details: [*JudgementSpecification* Object](#map3)
-
-<a id="map4-ref"></a>
-* *ThreatBrainSpecification* Object Value
-  * Details: [*ThreatBrainSpecification* Object](#map4)
-
 <a id="map5-ref"></a>
-* *SnortSpecification* Object Value
-  * Details: [*SnortSpecification* Object](#map5)
+* *JudgementSpecification* Object Value
+  * Details: [*JudgementSpecification* Object](#map5)
 
 <a id="map6-ref"></a>
-* *SIOCSpecification* Object Value
-  * Details: [*SIOCSpecification* Object](#map6)
+* *ThreatBrainSpecification* Object Value
+  * Details: [*ThreatBrainSpecification* Object](#map6)
 
 <a id="map7-ref"></a>
+* *SnortSpecification* Object Value
+  * Details: [*SnortSpecification* Object](#map7)
+
+<a id="map8-ref"></a>
+* *SIOCSpecification* Object Value
+  * Details: [*SIOCSpecification* Object](#map8)
+
+<a id="map9-ref"></a>
 * *OpenIOCSpecification* Object Value
-  * Details: [*OpenIOCSpecification* Object](#map7)
+  * Details: [*OpenIOCSpecification* Object](#map9)
 
 <a id="propertytags-stringlist"></a>
 ## Property tags ∷  String List
@@ -306,11 +322,73 @@ Test Mechanisms effective at identifying the cyber Observables specified in this
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map1)
+  * Details: [*ValidTime* Object](#map2)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -342,7 +420,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *CompositeIndicatorExpression* Object
 
 | Property | Type | Description | Required? |
@@ -372,7 +450,50 @@ If not present, the valid time position of the indicator does not have an upper 
     * not
     * or
 
-<a id="map3"></a>
+<a id="map4"></a>
+# *KillChainPhase* Object
+
+The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[kill_chain_name](#propertykill_chain_name-string)| String|The name of the kill chain.|&#10003;|
+|[phase_name](#propertyphase_name-string)| String|The name of the phase in the kill chain.|&#10003;|
+
+* Reference: [Kill Chain Phase](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.i4tjv75ce50h)
+
+<a id="propertykill_chain_name-string"></a>
+## Property kill_chain_name ∷  String
+
+The name of the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Must equal: "lockheed-martin-cyber-kill-chain"
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
+
+<a id="propertyphase_name-string"></a>
+## Property phase_name ∷  String
+
+The name of the phase in the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Allowed Values:
+    * actions-on-objective
+    * command-and-control
+    * delivery
+    * exploitation
+    * installation
+    * reconnaissance
+    * weaponization
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
+
+<a id="map5"></a>
 # *JudgementSpecification* Object
 
 An indicator based on a list of judgements.  If any of the Observables in it's judgements are encountered, than it may be matches against.  If there are any required judgements, they all must be matched in order for the indicator to be considered a match.
@@ -400,9 +521,9 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map8-ref"></a>
+<a id="map10-ref"></a>
 * *RelatedJudgement* Object Value
-  * Details: [*RelatedJudgement* Object](#map8)
+  * Details: [*RelatedJudgement* Object](#map10)
 
 <a id="propertytype-judgementspecificationtypestring"></a>
 ## Property type ∷ JudgementSpecificationType String
@@ -412,7 +533,7 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 
   * Must equal: "Judgement"
 
-<a id="map8"></a>
+<a id="map10"></a>
 # *RelatedJudgement* Object
 
 | Property | Type | Description | Required? |
@@ -459,7 +580,7 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 
 
 
-<a id="map4"></a>
+<a id="map6"></a>
 # *ThreatBrainSpecification* Object
 
 An indicator which runs in threatbrain...
@@ -494,7 +615,7 @@ An indicator which runs in threatbrain...
 
 
 
-<a id="map5"></a>
+<a id="map7"></a>
 # *SnortSpecification* Object
 
 An indicator which runs in snort...
@@ -520,7 +641,7 @@ An indicator which runs in snort...
 
   * Must equal: "Snort"
 
-<a id="map6"></a>
+<a id="map8"></a>
 # *SIOCSpecification* Object
 
 An indicator which runs in snort...
@@ -546,7 +667,7 @@ An indicator which runs in snort...
 
   * Must equal: "SIOC"
 
-<a id="map7"></a>
+<a id="map9"></a>
 # *OpenIOCSpecification* Object
 
 An indicator which contains an XML blob of an openIOC indicator..

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -27,6 +27,7 @@ A judgement about the intent or nature of an observable.  For
 |[type](#propertytype-judgementtypeidentifierstring)|JudgementTypeIdentifier String| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[language](#propertylanguage-string)| String| ||
 |[reason](#propertyreason-string)| String| ||
 |[reason_uri](#propertyreason_uri-string)| String| ||
@@ -88,13 +89,26 @@ Matches :disposition_name as in {1 "Clean", 2 "Malicious", 3 "Suspicious", 4 "Co
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
@@ -110,9 +124,9 @@ Matches :disposition_name as in {1 "Clean", 2 "Malicious", 3 "Suspicious", 4 "Co
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map1)
+  * Details: [*Observable* Object](#map2)
 
 <a id="propertypriority-integer"></a>
 ## Property priority ∷ Integer
@@ -222,11 +236,73 @@ CTIM schema version for this entity
 * This entry is required
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map2)
+  * Details: [*ValidTime* Object](#map3)
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -272,7 +348,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.

--- a/doc/structures/malware.md
+++ b/doc/structures/malware.md
@@ -1,31 +1,33 @@
 <a id="top"></a>
-# *Relationship* Object
+# *Malware* Object
 
-Represents a relationship between two entities
+Malware is a type of TTP that is also known as malicious code and malicious software, and refers to a program that is inserted into a system, usually covertly, with the intent of compromising the confidentiality, integrity, or availability of the victim's data, applications, or operating system (OS) or of otherwise annoying or disrupting the victim. Malware such as viruses and worms are usually designed to perform these nefarious functions in such a way that users are unaware of them, at least initially.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[id](#propertyid-string)| String| |&#10003;|
-|[relationship_type](#propertyrelationship_type-relationshiptypestring)|RelationshipType String| |&#10003;|
+|[labels](#propertylabels-malwarelabelstringlist)|MalwareLabel String List|The type of malware being described.|&#10003;|
+|[name](#propertyname-string)| String|A name used to identify the Malware sample.|&#10003;|
 |[schema_version](#propertyschema_version-string)| String|CTIM schema version for this entity|&#10003;|
-|[source_ref](#propertysource_ref-string)| String| |&#10003;|
-|[target_ref](#propertytarget_ref-string)| String| |&#10003;|
-|[type](#propertytype-relationshiptypeidentifierstring)|RelationshipTypeIdentifier String| |&#10003;|
-|[description](#propertydescription-string)| String| ||
+|[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifier String| |&#10003;|
+|[description](#propertydescription-string)| String|A description that provides more details and context about the Malware, potentially including its purpose and its key characteristics.||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
+|[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-string)| String| ||
 |[revision](#propertyrevision-integer)|Integer| ||
-|[short_description](#propertyshort_description-string)| String| ||
 |[source](#propertysource-string)| String| ||
 |[source_uri](#propertysource_uri-string)| String| ||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)| ||
-|[title](#propertytitle-string)| String| ||
 |[tlp](#propertytlp-tlpstring)|TLP String| ||
+|[x_mitre_aliases](#propertyx_mitre_aliases-stringlist)| String List|ATT&CK Software.aliases||
 
+* Reference: [Malware](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.s5l7katgbp09)
 
 <a id="propertydescription-string"></a>
 ## Property description ∷  String
+
+A description that provides more details and context about the Malware, potentially including its purpose and its key characteristics.
 
 * This entry is optional
 
@@ -61,6 +63,49 @@ Specifies a list of external references which refers to non-CTIM information. Th
 
   * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
+<a id="propertykill_chain_phases-killchainphaseobjectlist"></a>
+## Property kill_chain_phases ∷ *KillChainPhase* Object List
+
+The list of Kill Chain Phases for which this Malware can be used.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map2-ref"></a>
+* *KillChainPhase* Object Value
+  * Details: [*KillChainPhase* Object](#map2)
+
+<a id="propertylabels-malwarelabelstringlist"></a>
+## Property labels ∷ MalwareLabel String List
+
+The type of malware being described.
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+  * Malware label is an open vocabulary that represents different types and functions of malware. Malware labels are not mutually exclusive; a malware instance can be both spyware and a screen capture tool.
+  * Allowed Values:
+    * adware
+    * backdoor
+    * bot
+    * ddos
+    * dropper
+    * exploit-kit
+    * keylogger
+    * ransomware
+    * remote-access-trojan
+    * resource-exploitation
+    * rogue-security-software
+    * rootkit
+    * screen-capture
+    * spyware
+    * trojan
+    * virus
+    * worm
+  * Reference: [Malware Label](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.8cyb6e9yqzwr)
+
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
 
@@ -69,27 +114,15 @@ Specifies a list of external references which refers to non-CTIM information. Th
 
   * String with at most 1024 characters
 
-<a id="propertyrelationship_type-relationshiptypestring"></a>
-## Property relationship_type ∷ RelationshipType String
+<a id="propertyname-string"></a>
+## Property name ∷  String
+
+A name used to identify the Malware sample.
 
 * This entry is required
 
 
-  * Allowed Values:
-    * attributed-to
-    * based-on
-    * derived-from
-    * detects
-    * duplicate-of
-    * element-of
-    * exploits
-    * indicates
-    * member-of
-    * mitigates
-    * related-to
-    * targets
-    * uses
-    * variant-of
+  * String with at most 1024 characters
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -109,14 +142,6 @@ CTIM schema version for this entity
 
   * A semantic version matching the CTIM version against which this object should be valid.
 
-<a id="propertyshort_description-string"></a>
-## Property short_description ∷  String
-
-* This entry is optional
-
-
-  * String with at most 2048 characters
-
 <a id="propertysource-string"></a>
 ## Property source ∷  String
 
@@ -124,14 +149,6 @@ CTIM schema version for this entity
 
 
   * String with at most 2048 characters
-
-<a id="propertysource_ref-string"></a>
-## Property source_ref ∷  String
-
-* This entry is required
-
-
-  * A URI leading to an entity
 
 <a id="propertysource_uri-string"></a>
 ## Property source_uri ∷  String
@@ -141,14 +158,6 @@ CTIM schema version for this entity
 
   * A URI
 
-<a id="propertytarget_ref-string"></a>
-## Property target_ref ∷  String
-
-* This entry is required
-
-
-  * A URI leading to an entity
-
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
 
@@ -156,14 +165,6 @@ CTIM schema version for this entity
 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-
-<a id="propertytitle-string"></a>
-## Property title ∷  String
-
-* This entry is optional
-
-
-  * String with at most 1024 characters
 
 <a id="propertytlp-tlpstring"></a>
 ## Property tlp ∷ TLP String
@@ -179,13 +180,24 @@ CTIM schema version for this entity
     * red
     * white
 
-<a id="propertytype-relationshiptypeidentifierstring"></a>
-## Property type ∷ RelationshipTypeIdentifier String
+<a id="propertytype-malwaretypeidentifierstring"></a>
+## Property type ∷ MalwareTypeIdentifier String
 
 * This entry is required
 
 
-  * Must equal: "relationship"
+  * Must equal: "malware"
+
+<a id="propertyx_mitre_aliases-stringlist"></a>
+## Property x_mitre_aliases ∷  String List
+
+ATT&CK Software.aliases
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * String with at most 1024 characters
 
 <a id="map1"></a>
 # *ExternalReference* Object
@@ -248,3 +260,46 @@ A URL reference to an external resource
 
 
   * A URI
+
+<a id="map2"></a>
+# *KillChainPhase* Object
+
+The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[kill_chain_name](#propertykill_chain_name-string)| String|The name of the kill chain.|&#10003;|
+|[phase_name](#propertyphase_name-string)| String|The name of the phase in the kill chain.|&#10003;|
+
+* Reference: [Kill Chain Phase](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.i4tjv75ce50h)
+
+<a id="propertykill_chain_name-string"></a>
+## Property kill_chain_name ∷  String
+
+The name of the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Must equal: "lockheed-martin-cyber-kill-chain"
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
+
+<a id="propertyphase_name-string"></a>
+## Property phase_name ∷  String
+
+The name of the phase in the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Allowed Values:
+    * actions-on-objective
+    * command-and-control
+    * delivery
+    * exploitation
+    * installation
+    * reconnaissance
+    * weaponization
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -13,6 +13,7 @@ A single sighting of an [indicator](indicator.md)
 |[type](#propertytype-sightingtypeidentifierstring)|SightingTypeIdentifier String| |&#10003;|
 |[description](#propertydescription-string)| String| ||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
+|[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[language](#propertylanguage-string)| String| ||
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List|The object(s) of interest||
 |[relations](#propertyrelations-observedrelationobjectlist)|*ObservedRelation* Object List|Provide any context we can about where the observable came from||
@@ -68,13 +69,26 @@ The number of times the sighting was seen
 
 
 
+<a id="propertyexternal_references-externalreferenceobjectlist"></a>
+## Property external_references ∷ *ExternalReference* Object List
+
+Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map1-ref"></a>
+* *ExternalReference* Object Value
+  * Details: [*ExternalReference* Object](#map1)
+
 <a id="propertyid-string"></a>
 ## Property id ∷  String
 
 * This entry is required
 
 
-  * IDs are strings of the form: type-<128bitUUID>, for example `judgment-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field.  The optional STIX _idref_ field is not used.
+  * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
@@ -93,9 +107,9 @@ The object(s) of interest
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map3)
+  * Details: [*Observable* Object](#map4)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -103,9 +117,9 @@ The object(s) of interest
 * This entry is required
 
 
-<a id="map1-ref"></a>
+<a id="map2-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map1)
+  * Details: [*ObservedTime* Object](#map2)
 
 <a id="propertyrelations-observedrelationobjectlist"></a>
 ## Property relations ∷ *ObservedRelation* Object List
@@ -116,9 +130,9 @@ Provide any context we can about where the observable came from
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map4-ref"></a>
+<a id="map5-ref"></a>
 * *ObservedRelation* Object Value
-  * Details: [*ObservedRelation* Object](#map4)
+  * Details: [*ObservedRelation* Object](#map5)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -228,9 +242,9 @@ The target device. Where the sighting came from.
 * This entry is optional
 
 
-<a id="map2-ref"></a>
+<a id="map3-ref"></a>
 * *SightingTarget* Object Value
-  * Details: [*SightingTarget* Object](#map2)
+  * Details: [*SightingTarget* Object](#map3)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -271,6 +285,68 @@ The target device. Where the sighting came from.
   * Must equal: "sighting"
 
 <a id="map1"></a>
+# *ExternalReference* Object
+
+External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[source_name](#propertysource_name-string)| String|The source within which the external-reference is defined (system, registry, organization, etc.)|&#10003;|
+|[description](#propertydescription-string)| String| ||
+|[external_id](#propertyexternal_id-string)| String|An identifier for the external reference content.||
+|[hashes](#propertyhashes-stringlist)| String List|Specifies a dictionary of hashes for the contents of the url.||
+|[url](#propertyurl-string)| String|A URL reference to an external resource||
+
+* Reference: [External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)
+
+<a id="propertydescription-string"></a>
+## Property description ∷  String
+
+* This entry is optional
+
+
+  * Markdown string with at most 5000 characters
+
+<a id="propertyexternal_id-string"></a>
+## Property external_id ∷  String
+
+An identifier for the external reference content.
+
+* This entry is optional
+
+
+
+<a id="propertyhashes-stringlist"></a>
+## Property hashes ∷  String List
+
+Specifies a dictionary of hashes for the contents of the url.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+
+<a id="propertysource_name-string"></a>
+## Property source_name ∷  String
+
+The source within which the external-reference is defined (system, registry, organization, etc.)
+
+* This entry is required
+
+
+  * String with at most 2048 characters
+
+<a id="propertyurl-string"></a>
+## Property url ∷  String
+
+A URL reference to an external resource
+
+* This entry is optional
+
+
+  * A URI
+
+<a id="map2"></a>
 # *ObservedTime* Object
 
 Period of time when a cyber observation is valid.  `start_time` must come before `end_time` (if specified).
@@ -302,7 +378,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map2"></a>
+<a id="map3"></a>
 # *SightingTarget* Object
 
 Describes a target device where a sighting came from.
@@ -322,9 +398,9 @@ Describes a target device where a sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map5-ref"></a>
+<a id="map6-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map5)
+  * Details: [*Observable* Object](#map6)
 
 <a id="propertyos-string"></a>
 ## Property os ∷  String
@@ -397,53 +473,7 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
-<a id="map5"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp-device
-    * amp_computer_guid
-    * device
-    * domain
-    * email
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * pki-serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map3"></a>
+<a id="map6"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -490,6 +520,52 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 <a id="map4"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp-device
+    * amp_computer_guid
+    * device
+    * domain
+    * email
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * pki-serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map5"></a>
 # *ObservedRelation* Object
 
 A relation inside a Sighting.
@@ -525,9 +601,9 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map8-ref"></a>
+<a id="map9-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map8)
+  * Details: [*Observable* Object](#map9)
 
 <a id="propertyrelation-observablerelationtypestring"></a>
 ## Property relation ∷ ObservableRelationType String
@@ -679,9 +755,9 @@ A relation inside a Sighting.
 * This entry is optional
 
 
-<a id="map6-ref"></a>
+<a id="map7-ref"></a>
 * Object Value
-  * Details: [Object](#map6)
+  * Details: [Object](#map7)
 
 <a id="propertysource-observableobject"></a>
 ## Property source ∷ *Observable* Object
@@ -689,9 +765,55 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map7-ref"></a>
+<a id="map8-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map7)
+  * Details: [*Observable* Object](#map8)
+
+<a id="map9"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp-device
+    * amp_computer_guid
+    * device
+    * domain
+    * email
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * pki-serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
 
 <a id="map8"></a>
 # *Observable* Object
@@ -740,52 +862,6 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 <a id="map7"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp-device
-    * amp_computer_guid
-    * device
-    * domain
-    * email
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * pki-serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map6"></a>
 # Object
 
 | Property | Type | Description | Required? |

--- a/doc/structures/tool.md
+++ b/doc/structures/tool.md
@@ -1,31 +1,34 @@
 <a id="top"></a>
-# *Relationship* Object
+# *Tool* Object
 
-Represents a relationship between two entities
+Tools are legitimate software that can be used by threat actors to perform attacks. Knowing how and when threat actors use such tools can be important for understanding how campaigns are executed. Unlike malware, these tools or software packages are often found on a system and have legitimate purposes for power users, system administrators, network administrators, or even normal users. Remote access tools (e.g., RDP) and network scanning tools (e.g., Nmap) are examples of Tools that may be used by a Threat Actor during an attack.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[id](#propertyid-string)| String| |&#10003;|
-|[relationship_type](#propertyrelationship_type-relationshiptypestring)|RelationshipType String| |&#10003;|
+|[labels](#propertylabels-toollabelstringlist)|ToolLabel String List|The kind(s) of tool(s) being described.|&#10003;|
+|[name](#propertyname-string)| String|The name used to identify the Tool.|&#10003;|
 |[schema_version](#propertyschema_version-string)| String|CTIM schema version for this entity|&#10003;|
-|[source_ref](#propertysource_ref-string)| String| |&#10003;|
-|[target_ref](#propertytarget_ref-string)| String| |&#10003;|
-|[type](#propertytype-relationshiptypeidentifierstring)|RelationshipTypeIdentifier String| |&#10003;|
-|[description](#propertydescription-string)| String| ||
+|[type](#propertytype-tooltypeidentifierstring)|ToolTypeIdentifier String| |&#10003;|
+|[description](#propertydescription-string)| String|A description that provides more details and context about the Tool, potentially including its purpose and its key characteristics.||
 |[external_ids](#propertyexternal_ids-stringlist)| String List| ||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
+|[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of kill chain phases for which this Tool can be used.||
 |[language](#propertylanguage-string)| String| ||
 |[revision](#propertyrevision-integer)|Integer| ||
-|[short_description](#propertyshort_description-string)| String| ||
 |[source](#propertysource-string)| String| ||
 |[source_uri](#propertysource_uri-string)| String| ||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)| ||
-|[title](#propertytitle-string)| String| ||
 |[tlp](#propertytlp-tlpstring)|TLP String| ||
+|[tool_version](#propertytool_version-string)| String|The version identifier associated with the Tool.||
+|[x_mitre_aliases](#propertyx_mitre_aliases-stringlist)| String List|ATT&CK Software.aliases||
 
+* Reference: [Tool](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.z4voa9ndw8v)
 
 <a id="propertydescription-string"></a>
 ## Property description ∷  String
+
+A description that provides more details and context about the Tool, potentially including its purpose and its key characteristics.
 
 * This entry is optional
 
@@ -61,6 +64,39 @@ Specifies a list of external references which refers to non-CTIM information. Th
 
   * IDs are URIs, for example `https://www.domain.com/ctia/judgement/judgement-de305d54-75b4-431b-adb2-eb6b9e546014` for a [Judgement](judgement.md). This _ID_ type compares to the STIX _id_ field. The optional STIX _idref_ field is not used.
 
+<a id="propertykill_chain_phases-killchainphaseobjectlist"></a>
+## Property kill_chain_phases ∷ *KillChainPhase* Object List
+
+The list of kill chain phases for which this Tool can be used.
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map2-ref"></a>
+* *KillChainPhase* Object Value
+  * Details: [*KillChainPhase* Object](#map2)
+
+<a id="propertylabels-toollabelstringlist"></a>
+## Property labels ∷ ToolLabel String List
+
+The kind(s) of tool(s) being described.
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+  * Tool labels describe the categories of tools that can be used to perform attacks.
+  * Allowed Values:
+    * credential-exploitation
+    * denial-of-service
+    * exploitation
+    * information-gathering
+    * network-capture
+    * remote-access
+    * vulnerability-scanning
+  * Reference: [Tool Label](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.cozm95emj8qk)
+
 <a id="propertylanguage-string"></a>
 ## Property language ∷  String
 
@@ -69,27 +105,15 @@ Specifies a list of external references which refers to non-CTIM information. Th
 
   * String with at most 1024 characters
 
-<a id="propertyrelationship_type-relationshiptypestring"></a>
-## Property relationship_type ∷ RelationshipType String
+<a id="propertyname-string"></a>
+## Property name ∷  String
+
+The name used to identify the Tool.
 
 * This entry is required
 
 
-  * Allowed Values:
-    * attributed-to
-    * based-on
-    * derived-from
-    * detects
-    * duplicate-of
-    * element-of
-    * exploits
-    * indicates
-    * member-of
-    * mitigates
-    * related-to
-    * targets
-    * uses
-    * variant-of
+  * String with at most 1024 characters
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -109,14 +133,6 @@ CTIM schema version for this entity
 
   * A semantic version matching the CTIM version against which this object should be valid.
 
-<a id="propertyshort_description-string"></a>
-## Property short_description ∷  String
-
-* This entry is optional
-
-
-  * String with at most 2048 characters
-
 <a id="propertysource-string"></a>
 ## Property source ∷  String
 
@@ -124,14 +140,6 @@ CTIM schema version for this entity
 
 
   * String with at most 2048 characters
-
-<a id="propertysource_ref-string"></a>
-## Property source_ref ∷  String
-
-* This entry is required
-
-
-  * A URI leading to an entity
 
 <a id="propertysource_uri-string"></a>
 ## Property source_uri ∷  String
@@ -141,14 +149,6 @@ CTIM schema version for this entity
 
   * A URI
 
-<a id="propertytarget_ref-string"></a>
-## Property target_ref ∷  String
-
-* This entry is required
-
-
-  * A URI leading to an entity
-
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
 
@@ -156,14 +156,6 @@ CTIM schema version for this entity
 
 
   * Schema definition for all date or timestamp values.  Time is stored internally as a java.util.Date object. Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-
-<a id="propertytitle-string"></a>
-## Property title ∷  String
-
-* This entry is optional
-
-
-  * String with at most 1024 characters
 
 <a id="propertytlp-tlpstring"></a>
 ## Property tlp ∷ TLP String
@@ -179,13 +171,34 @@ CTIM schema version for this entity
     * red
     * white
 
-<a id="propertytype-relationshiptypeidentifierstring"></a>
-## Property type ∷ RelationshipTypeIdentifier String
+<a id="propertytool_version-string"></a>
+## Property tool_version ∷  String
+
+The version identifier associated with the Tool.
+
+* This entry is optional
+
+
+  * String with at most 1024 characters
+
+<a id="propertytype-tooltypeidentifierstring"></a>
+## Property type ∷ ToolTypeIdentifier String
 
 * This entry is required
 
 
-  * Must equal: "relationship"
+  * Must equal: "tool"
+
+<a id="propertyx_mitre_aliases-stringlist"></a>
+## Property x_mitre_aliases ∷  String List
+
+ATT&CK Software.aliases
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * String with at most 1024 characters
 
 <a id="map1"></a>
 # *ExternalReference* Object
@@ -248,3 +261,46 @@ A URL reference to an external resource
 
 
   * A URI
+
+<a id="map2"></a>
+# *KillChainPhase* Object
+
+The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[kill_chain_name](#propertykill_chain_name-string)| String|The name of the kill chain.|&#10003;|
+|[phase_name](#propertyphase_name-string)| String|The name of the phase in the kill chain.|&#10003;|
+
+* Reference: [Kill Chain Phase](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.i4tjv75ce50h)
+
+<a id="propertykill_chain_name-string"></a>
+## Property kill_chain_name ∷  String
+
+The name of the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Must equal: "lockheed-martin-cyber-kill-chain"
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
+
+<a id="propertyphase_name-string"></a>
+## Property phase_name ∷  String
+
+The name of the phase in the kill chain.
+
+* This entry is required
+
+
+  * SHOULD be all lowercase (where lowercase is defined by the locality conventions) and SHOULD use hyphens instead of spaces or underscores as word separators.
+  * Allowed Values:
+    * actions-on-objective
+    * command-and-control
+    * delivery
+    * exploitation
+    * installation
+    * reconnaissance
+    * weaponization
+  * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)

--- a/src/ctim/document.clj
+++ b/src/ctim/document.clj
@@ -31,7 +31,7 @@
           [["structures/actor.md" a/Actor ->markdown]
            ["json/actor.json" a/Actor ->json]
            ["structures/attack_pattern.md" attack/AttackPattern ->markdown]
-           ["json/attack_pattern.json" a/AttackPattern ->json]
+           ["json/attack_pattern.json" attack/AttackPattern ->json]
            ["structures/campaign.md" c/Campaign ->markdown]
            ["json/campaign.json" c/Campaign ->json]
            ["structures/coa.md" co/COA ->markdown]

--- a/src/ctim/examples/attack_patterns.cljc
+++ b/src/ctim/examples/attack_patterns.cljc
@@ -17,6 +17,8 @@
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
+   :source "source"
+   :source_uri "http://example.com"
    :name "Bootkit"
    :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"
    :kill_chain_phases [{:kill_chain_name "mitre-attack"

--- a/src/ctim/examples/malwares.cljc
+++ b/src/ctim/examples/malwares.cljc
@@ -17,6 +17,8 @@
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
+   :source "source"
+   :source_uri "http://example.com"
    :name "TinyZBot"
    :labels ["malware"]
    :description "TinyZBot is a bot written in C# that was developed by Cleaver."

--- a/src/ctim/examples/tools.cljc
+++ b/src/ctim/examples/tools.cljc
@@ -17,6 +17,8 @@
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
+   :source "source"
+   :source_uri "http://example.com"
    :name "cmd"
    :labels ["tool"]
    :description "cmd is the Windows command-line interpreter"

--- a/src/ctim/schemas/attack_pattern.cljc
+++ b/src/ctim/schemas/attack_pattern.cljc
@@ -18,6 +18,7 @@
   {:description attack-pattern-desc
    :reference attack-pattern-desc-link}
   c/base-entity-entries
+  c/sourcable-object-entries
   (f/required-entries
    (f/entry :type AttackPatternTypeIdentifier)
    (f/entry :name c/ShortString

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -21,7 +21,7 @@
             [schema.core :as s]
             [clojure.string :as str]))
 
-(def ctim-schema-version "0.4.22")
+(def ctim-schema-version "0.4.23")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 

--- a/src/ctim/schemas/malware.cljc
+++ b/src/ctim/schemas/malware.cljc
@@ -25,6 +25,7 @@
   {:description malware-desc
    :reference malware-desc-link}
   c/base-entity-entries
+  c/sourcable-object-entries
   (f/required-entries
    (f/entry :type MalwareTypeIdentifier)
    (f/entry :name c/ShortString

--- a/src/ctim/schemas/tool.cljc
+++ b/src/ctim/schemas/tool.cljc
@@ -25,6 +25,7 @@
   {:description tool-desc
    :reference tool-desc-link}
   c/base-entity-entries
+  c/sourcable-object-entries
   (f/required-entries
    (f/entry :type ToolTypeIdentifier)
    (f/entry :name c/ShortString

--- a/test/ctim/specs/fields_test.clj
+++ b/test/ctim/specs/fields_test.clj
@@ -858,6 +858,10 @@
 
         (test-long-string :description)
 
+        (test-medium-string :source)
+
+        (test-uri :source_uri)
+
         (test-short-string :language)
 
         (test-pos-int :revision))
@@ -1083,6 +1087,10 @@
 
         (test-long-string :description)
 
+        (test-medium-string :source)
+
+        (test-uri :source_uri)
+
         (test-short-string :language)
 
         (test-pos-int :revision))
@@ -1129,6 +1137,10 @@
         (test-short-string :name)
 
         (test-long-string :description)
+
+        (test-medium-string :source)
+
+        (test-uri :source_uri)
 
         (test-short-string :tool_version)
 


### PR DESCRIPTION
Closes #186 

- [x] Add `source_uri` and `source` fields to the attack pattern, malware and tool schemas
- [x] Doc update