### PR TITLE
Allow any string for transient IDs

### DIFF
--- a/src/ctim/domain/id.cljc
+++ b/src/ctim/domain/id.cljc
@@ -22,7 +22,7 @@
   (str "(([a-z][-a-z]+)-" uuid-pattern ")"))
 
 (def transient-id-pattern
-  (str "transient:" uuid-pattern))
+  "transient:.*")
 
 (def url-pattern
   "(https?):\\/\\/([-\\da-zA-Z][-\\da-zA-Z.]*)(:(\\d+))?((\\/[-\\w.]+)*)\\/ctia\\/([a-z][-a-z]+)\\/")

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -21,7 +21,7 @@
             [schema.core :as s]
             [clojure.string :as str]))
 
-(def ctim-schema-version "0.4.23")
+(def ctim-schema-version "0.4.24")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 
@@ -36,6 +36,7 @@
 (def Reference
   (f/str :description "A URI leading to an entity"
          :spec (cs/and string?
+                       (pred/max-len 2048)
                        (cs/or :long-id :ctim.domain.id/long-id
                               :transient-id :ctim.domain.id/transient-id))
          :gen gen-id/gen-url-id))
@@ -43,7 +44,9 @@
 (def StoredReference
   (assoc Reference
          :description "Like a Reference within a stored entity"
-         :spec (cs/and string? :ctim.domain.id/long-id)))
+         :spec (cs/and string?
+                       (pred/max-len 2048)
+                       :ctim.domain.id/long-id)))
 
 (defn ref
   "Make a custom Reference"
@@ -72,6 +75,7 @@
               "for a [Judgement](judgement.md). This _ID_ type compares to the "
               "STIX _id_ field. The optional STIX _idref_ field is not used.")
          :spec (cs/and string?
+                       (pred/max-len 2048)
                        (cs/or :long-id :ctim.domain.id/long-id
                               :transient-id :ctim.domain.id/transient-id))
          :loc-gen id-generator))
@@ -80,6 +84,7 @@
   (assoc ID
          :description "Like an ID within a stored entity"
          :spec (cs/and string?
+                       (pred/max-len 2048)
                        (cs/or :long-id :ctim.domain.id/long-id
                               ;; short-id is supported for backward compatibility
                               :short-id :ctim.domain.id/short-id))))

--- a/test/ctim/specs/fields_test.clj
+++ b/test/ctim/specs/fields_test.clj
@@ -93,8 +93,8 @@
     :refer [long-id-str
             rand-openvocab
             rand-str
-            short-id-str
-            transient-id-str]]))
+            rand-transient-id-str
+            short-id-str]]))
 
 (use-fixtures :once
   th/fixture-spec-validation
@@ -764,18 +764,25 @@
           (= expected
              (spec/valid? spec
                           (assoc entity :id (value-fn entity))))
-        false (constantly nil)   plain-kw  plain-ex
-        false (constantly nil)   new-kw    new-ex
-        false (constantly nil)   stored-kw stored-ex
-        true  long-id-str        plain-kw  plain-ex
-        true  long-id-str        new-kw    new-ex
-        true  long-id-str        stored-kw stored-ex
-        false short-id-str       plain-kw  plain-ex
-        false short-id-str       new-kw    new-ex
-        true  short-id-str       stored-kw stored-ex
-        true  transient-id-str   plain-kw  plain-ex
-        true  transient-id-str   new-kw    new-ex
-        false transient-id-str   stored-kw stored-ex))))
+        false (constantly nil)              plain-kw  plain-ex
+        false (constantly nil)              new-kw    new-ex
+        false (constantly nil)              stored-kw stored-ex
+        true  long-id-str                   plain-kw  plain-ex
+        true  long-id-str                   new-kw    new-ex
+        true  long-id-str                   stored-kw stored-ex
+        false short-id-str                  plain-kw  plain-ex
+        false short-id-str                  new-kw    new-ex
+        true  short-id-str                  stored-kw stored-ex
+        true  (constantly
+               (rand-transient-id-str 2048)) plain-kw  plain-ex
+        true  (constantly
+               (rand-transient-id-str 2048)) new-kw    new-ex
+        false (constantly
+               (rand-transient-id-str 2048)) stored-kw stored-ex
+        false (constantly
+               (rand-transient-id-str 2049)) plain-kw  plain-ex
+        false (constantly
+               (rand-transient-id-str 2049)) new-kw    new-ex))))
 
 (defn test-reference [kw]
   (let [plain-kw  (get-type-kw 'plain)
@@ -790,18 +797,25 @@
           (= expected
              (spec/valid? spec
                           (assoc entity kw (value-fn entity))))
-        false (constantly nil)   plain-kw  plain-ex
-        false (constantly nil)   new-kw    new-ex
-        false (constantly nil)   stored-kw stored-ex
-        true  long-id-str        plain-kw  plain-ex
-        true  long-id-str        new-kw    new-ex
-        true  long-id-str        stored-kw stored-ex
-        false short-id-str       plain-kw  plain-ex
-        false short-id-str       new-kw    new-ex
-        false  short-id-str       stored-kw stored-ex
-        true  transient-id-str   plain-kw  plain-ex
-        true  transient-id-str   new-kw    new-ex
-        false transient-id-str   stored-kw stored-ex))))
+        false (constantly nil)               plain-kw  plain-ex
+        false (constantly nil)               new-kw    new-ex
+        false (constantly nil)               stored-kw stored-ex
+        true  long-id-str                    plain-kw  plain-ex
+        true  long-id-str                    new-kw    new-ex
+        true  long-id-str                    stored-kw stored-ex
+        false short-id-str                   plain-kw  plain-ex
+        false short-id-str                   new-kw    new-ex
+        false short-id-str                   stored-kw stored-ex
+        true  (constantly
+               (rand-transient-id-str 2048)) plain-kw  plain-ex
+        true  (constantly
+               (rand-transient-id-str 2048)) new-kw    new-ex
+        false (constantly
+               (rand-transient-id-str 2048)) stored-kw stored-ex
+        false (constantly
+               (rand-transient-id-str 2049)) plain-kw  plain-ex
+        false (constantly
+               (rand-transient-id-str 2049)) new-kw    new-ex))))
 
 (defn test-kill-chain-phases
   [key-path]

--- a/test/ctim/test_helpers/core.clj
+++ b/test/ctim/test_helpers/core.clj
@@ -48,9 +48,11 @@
                           :protocol "https"
                           :type entity-type})))
 
-(defn transient-id-str
-  [entity]
-  (id/make-transient-id (:type entity)))
+(defn rand-transient-id-str
+  [len]
+  (let [prefix "transient:"
+        length (max 0 (- len (count prefix)))]
+    (str prefix (rand-str length))))
 
 (defn rand-openvocab [len]
   (apply str (repeatedly


### PR DESCRIPTION
With this PR transient IDs can use any string after the `transient:` prefix (ex: `transient:malware-AEF567`).