### PR TITLE
Issue-190: Add attack pattern abstraction levels

### DIFF
--- a/src/ctim/examples/attack_patterns.cljc
+++ b/src/ctim/examples/attack_patterns.cljc
@@ -21,6 +21,7 @@
    :source_uri "http://example.com"
    :name "Bootkit"
    :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"
+   :abstraction_level "standard"
    :kill_chain_phases [{:kill_chain_name "mitre-attack"
                         :phase_name "persistence"}]
    :x_mitre_data_sources ["API monitoring" "MBR" "VBR"]

--- a/src/ctim/schemas/attack_pattern.cljc
+++ b/src/ctim/schemas/attack_pattern.cljc
@@ -1,7 +1,8 @@
 (ns ctim.schemas.attack-pattern
   (:require #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])
-            [ctim.schemas.common :as c]))
+            [ctim.schemas.common :as c]
+            [ctim.schemas.vocabularies :as v]))
 
 (def type-identifier "attack-pattern")
 
@@ -44,7 +45,9 @@
    (f/entry :x_mitre_platforms [c/ShortString]
             :description "ATT&CK Technique.Platforms")
    (f/entry :x_mitre_contributors [c/ShortString]
-            :description "ATT&CK Technique.Contributors")))
+            :description "ATT&CK Technique.Contributors")
+   (f/entry :abstraction_level v/AttackPatternAbstractions
+            :description "The CAPEC abstraction level for patterns describing techniques to attack a system.")))
 
 (def-entity-type NewAttackPattern
   "For submitting a new AttackPattern"

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -455,3 +455,15 @@
   :description (str "Tool labels describe the categories of tools that can be "
                     "used to perform attacks.")
   :reference "[Tool Label](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.cozm95emj8qk)")
+
+(def attack-pattern-abstraction-labels
+  #{"category"
+    "meta"
+    "standard"
+    "detailed"
+    "aggregate"})
+
+(def-enum-type AttackPatternAbstractions
+  attack-pattern-abstraction-labels
+  :description "Abstraction levels corresponding to CAPEC data describing attack-pattern objects."
+  :reference "[Common Attack Pattern Enumeration and Classification](https://capec.mitre.org)")


### PR DESCRIPTION
This adds support for an optional `abstraction_level` entry in attack patterns,
which can be used to define attack patten categories, meta attack patterns,
aggregate attack patterns, and detailed attack patterns in addition to the
standard ones found in data sets like MITRE CAPEC & ATT&CK.

Closes #190