### PR TITLE
Add an observable type for ODNS identities

### DIFF
--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4489,6 +4489,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -5743,6 +5744,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -5788,6 +5790,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -5848,6 +5851,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -6031,6 +6035,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -6602,6 +6607,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -292,6 +292,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -3322,6 +3323,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -4233,6 +4235,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -4278,6 +4281,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -4338,6 +4342,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -4521,6 +4526,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -5544,6 +5550,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -346,6 +346,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -607,6 +607,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -652,6 +653,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -901,6 +903,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256
@@ -946,6 +949,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256

--- a/doc/structures/verdict.md
+++ b/doc/structures/verdict.md
@@ -113,6 +113,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * odns_identity
     * pki_serial
     * sha1
     * sha256

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -21,7 +21,7 @@
             [schema.core :as s]
             [clojure.string :as str]))
 
-(def ctim-schema-version "1.0.3")
+(def ctim-schema-version "1.0.4")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -257,7 +257,8 @@
     "hostname"
     "mac_address"
     "file_name"
-    "file_path"})
+    "file_path"
+    "odns_identity"})
 
 (def-enum-type ObservableTypeIdentifier
   observable-type-identifier


### PR DESCRIPTION
Connected to threatgrid/iroh#2100

This PR adds the `odns_identity` observable type. In the odns context, it's an origin ID.

ex:

```json
{"type": "odns_identity", "value": "42573640"}
```