### PR TITLE
Add odns_identity_label observable type

### DIFF
--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -21,7 +21,7 @@
             [schema.core :as s]
             [clojure.string :as str]))
 
-(def ctim-schema-version "1.0.5")
+(def ctim-schema-version "1.0.6")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -258,7 +258,8 @@
     "mac_address"
     "file_name"
     "file_path"
-    "odns_identity"})
+    "odns_identity"
+    "odns_identity_label"})
 
 (def-enum-type ObservableTypeIdentifier
   observable-type-identifier


### PR DESCRIPTION
Connected to threatgrid/iroh#2162

Add `odns_identity_label` observable type that matches the `originLabel` field in the Umbrella Reporting API reponses.