### PR TITLE
Add new observable types used by the SMA module

### DIFF
--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -259,7 +259,10 @@
     "file_name"
     "file_path"
     "odns_identity"
-    "odns_identity_label"})
+    "odns_identity_label"
+    "email_messageid"
+    "email_subject"
+    "cisco_mid"})
 
 (def-enum-type ObservableTypeIdentifier
   observable-type-identifier


### PR DESCRIPTION
Connected to threatgrid/iroh#2242

Add the following observable types:
- `email_messageid`: Email message ID header
- `email_subject`: Email subject
- `cisco_mid`: Cisco message ID