### PR TITLE
Issue-2288: Distinct v2 & v3 Impact Scores

### DIFF
--- a/src/ctim/examples/vulnerabilities.cljc
+++ b/src/ctim/examples/vulnerabilities.cljc
@@ -33,7 +33,9 @@
                       :environmental_score 4.2
                       :remediation_level "workaround"
                       :temporal_severity 4.2
-                      :integrity_requirement "low"}
+                      :integrity_requirement "low"
+                      :exploitability_score 0.8
+                      :impact_score 5.9}
             :cvss_v2 {:vector_string "(AV:L/AC:L/Au:N/C:C/I:C/A:C)"
                       :base_score 7.2
                       :base_severity "High"
@@ -56,9 +58,9 @@
                       :obtain_all_privilege true
                       :obtain_user_privilege false
                       :obtain_other_privilege false
-                      :user_interaction_required true}
-            :exploitability_score 0.8
-            :impact_score 5.9}
+                      :user_interaction_required true
+                      :exploitability_score 3.9
+                      :impact_score 10.0}}
    :schema_version c/ctim-schema-version
    :revision 1
    :type "vulnerability"

--- a/src/ctim/schemas/vulnerability.cljc
+++ b/src/ctim/schemas/vulnerability.cljc
@@ -18,9 +18,9 @@
   "[Vulnerability](http://docs.oasis-open.org/cti/stix/v2.0/cs01/part2-stix-objects/stix-v2.0-cs01-part2-stix-objects.html#_Toc496714334)")
 
 (defn valid-score?
-  "check that a score is above 0 and below 10"
+  "check that a score is no less than 0 and no greater than 10"
   [score]
-  (< 0 score 10))
+  (<= 0 score 10))
 
 (def Score
   (f/num
@@ -130,6 +130,8 @@
     (f/entry :base_score Score)
     (f/entry :base_severity v/HighMedLow))
    (f/optional-entries
+    (f/entry :impact_score Score)
+    (f/entry :exploitability_score Score)
     (f/entry :access_vector v/CVSSv2AccessVector)
     (f/entry :access_complexity v/CVSSv2AccessComplexity)
     (f/entry :authentication v/CVSSv2Authentication)
@@ -164,6 +166,8 @@
     (f/entry :base_score Score)
     (f/entry :base_severity v/CVSSv3Severity))
    (f/optional-entries
+    (f/entry :impact_score Score)
+    (f/entry :exploitability_score Score)
     (f/entry :attack_vector v/CVSSv3AttackVector
              :description (str "Reflects the context by which "
                                "vulnerability exploitation is possible"))
@@ -247,10 +251,8 @@
 
 (def-map-type VulnerabilityImpact
   (f/optional-entries
-   (f/entry :cvss_v3 CVSSv3)
    (f/entry :cvss_v2 CVSSv2)
-   (f/entry :impact_score Score)
-   (f/entry :exploitability_score Score)))
+   (f/entry :cvss_v3 CVSSv3)))
 
 ;; CVE Metadata (ID Assigner), description, references, v3 impact data published_date, lastmodified_date
 


### PR DESCRIPTION
This allows us to provide distinct :impact_score and :exploitability_score
data for version 2 and version 3 of the CVSS impact metrics.

Resolves https://github.com/threatgrid/iroh/issues/2288