### PR TITLE
Issue-2441: CVSSv2 vector strings have no parens

### DIFF
--- a/src/ctim/examples/vulnerabilities.cljc
+++ b/src/ctim/examples/vulnerabilities.cljc
@@ -36,7 +36,7 @@
                       :integrity_requirement "low"
                       :exploitability_score 0.8
                       :impact_score 5.9}
-            :cvss_v2 {:vector_string "(AV:L/AC:L/Au:N/C:C/I:C/A:C)"
+            :cvss_v2 {:vector_string "AV:L/AC:L/Au:N/C:C/I:C/A:C"
                       :base_score 7.2
                       :base_severity "High"
                       :access_vector "local"
@@ -48,13 +48,13 @@
                       :exploitability "unproven"
                       :remediation_level "workaround"
                       :report_confidence "unconfirmed"
-                      :temporal_vector_string "(E:U/RL:W/RC:UC)"
+                      :temporal_vector_string "E:U/RL:W/RC:UC"
                       :collateral_damage_potential "low"
                       :target_distribution "low"
                       :confidentiality_requirement "low"
                       :integrity_requirement "low"
                       :availability_requirement "high"
-                      :environmental_vector_string "(CDP:L/TD:L/CR:L/IR:L/AR:H)"
+                      :environmental_vector_string "CDP:L/TD:L/CR:L/IR:L/AR:H"
                       :obtain_all_privilege true
                       :obtain_user_privilege false
                       :obtain_other_privilege false

--- a/src/ctim/lib/generators.clj
+++ b/src/ctim/lib/generators.clj
@@ -98,7 +98,7 @@
 
 (def cvss-v2-vector-string
   (gen/fmap (fn [[av ac au c i a]]
-              (format "(AV:%s/AC:%s/Au:%s/C:%s/I:%s/A:%s)"
+              (format "AV:%s/AC:%s/Au:%s/C:%s/I:%s/A:%s"
                       av ac au c i a))
             (gen/tuple (gen/elements cvss-v2-access-vectors)
                        (gen/elements cvss-v2-access-complexities)
@@ -109,7 +109,7 @@
 
 (def cvss-v2-temporal-vector-string
   (gen/fmap (fn [[e rl rc]]
-              (format "(E:%s/RL:%s/RC:%s)"
+              (format "E:%s/RL:%s/RC:%s"
                       e rl rc))
             (gen/tuple (gen/elements cvss-v2-exploitabilities)
                        (gen/elements cvss-v2-remediation-levels)
@@ -117,7 +117,7 @@
 
 (def cvss-v2-environmental-vector-string
   (gen/fmap (fn [[cdp td cr ir ar]]
-              (format "(CDP:%s/TD:%s/CR:%s/IR:%s/AR:%s)"
+              (format "CDP:%s/TD:%s/CR:%s/IR:%s/AR:%s"
                       cdp td cr ir ar))
             (gen/tuple (gen/elements cvss-v2-collateral-damage-potentials)
                        (gen/elements cvss-v2-target-distributions)

--- a/src/ctim/schemas/vulnerability.cljc
+++ b/src/ctim/schemas/vulnerability.cljc
@@ -43,17 +43,17 @@
    Environmental   CDP:[N,L,LM,MH,H,ND]/TD:[N,L,M,H,ND]/CR:[L,M,H,ND]/IR:[L,M,H,ND]/AR:[L,M,H,ND]")
 
 
-;; example: (AV:N/AC:M/Au:N/C:C/I:C/A:C)
+;; example: "AV:N/AC:M/Au:N/C:C/I:C/A:C"
 (def cvss-v2-vector-string-exp
-  #"^\(AV:[LAN]/AC:[HML]/Au:[NSM]/C:[NPC]/I:[NPC]/A:[NPC]\)$")
+  #"^AV:[LAN]/AC:[HML]/Au:[NSM]/C:[NPC]/I:[NPC]/A:[NPC]$")
 
-;; example: (E:U/RL:OF/RC:C)
+;; example: "E:U/RL:OF/RC:C"
 (def cvss-v2-temporal-vector-string-exp
-  #"^\(E:(U|POC|F|H|ND)/RL:(OF|TF|W|U|ND)/RC:(UC|UR|C|ND)\)$")
+  #"^E:(U|POC|F|H|ND)/RL:(OF|TF|W|U|ND)/RC:(UC|UR|C|ND)$")
 
-;; example: (CDP:N/TD:L/CR:L/IR:ND/AR:ND)
+;; example: "CDP:N/TD:L/CR:L/IR:ND/AR:ND"
 (def cvss-v2-environmental-vector-string-exp
-  #"^\(CDP:(N|L|LM|MH|H|ND)/TD:(N|L|M|H|ND)/CR:(L|M|H|ND)/IR:(L|M|H|ND)/AR:(L|M|H|ND)\)$")
+  #"^CDP:(N|L|LM|MH|H|ND)/TD:(N|L|M|H|ND)/CR:(L|M|H|ND)/IR:(L|M|H|ND)/AR:(L|M|H|ND)$")
 
 (defn cvss-v2-vector-string?
   "validate a v2 vector string using a regexp"


### PR DESCRIPTION
This updates the regex for properly formatted CVSSv2 vector strings, which have
no parentheses, similar to v3 vector strings.

Progress toward https://github.com/threatgrid/iroh/issues/2441
Does not resolve the issue around spec enforcement upon entity creation identified in 2441.