### PR TITLE
Issue-2446: Mutex, Registry Observable Types

### DIFF
--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -262,7 +262,10 @@
     "odns_identity_label"
     "email_messageid"
     "email_subject"
-    "cisco_mid"})
+    "cisco_mid"
+    "registry_key"
+    "registry_value"
+    "mutex"})
 
 (def-enum-type ObservableTypeIdentifier
   observable-type-identifier


### PR DESCRIPTION
This adds support for `registry_key`, `registry_value`, and `mutex` observable types.

Resolves https://github.com/threatgrid/iroh/issues/2446