### PR TITLE
Remove Windows Registry Observable Types

### DIFF
--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -263,8 +263,6 @@
     "email_messageid"
     "email_subject"
     "cisco_mid"
-    "registry_key"
-    "registry_value"
     "mutex"})
 
 (def-enum-type ObservableTypeIdentifier


### PR DESCRIPTION
The "registry_key" and "registry_value" observable types are removed,
pending a more complete and permanent replacement.

Related discussion at https://github.com/threatgrid/ctim/pull/228.