### PR TITLE
Clarify relationship-type from sightings to indicators

### DIFF
--- a/doc/defined_relationships.md
+++ b/doc/defined_relationships.md
@@ -19,7 +19,8 @@ These relationship types can be made between any entities in the CTIM.
 
 * Sighting
   * based-on - Judgement
-  * indicates - Indicator
+  * sighting-of - Indicator, for pattern based indicators or engines
+  * member-of - Indicator, for observable based indicators and feeds
   * member-of - Incident
 
 * Indicators
@@ -41,7 +42,7 @@ These relationship types can be made between any entities in the CTIM.
   * uses - Malware
   * uses - Tool
   * attributed-to - Actor
-  
+
 * COA
   * mitigates - Attack Pattern
   * mitigates - ExploitTarget


### PR DESCRIPTION
The STIX 2.0 specification [recommends](http://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part2-stix-objects.html) using the `sighting_of_ref` relationship type
be the sole relationship type between sighting entities and other STIX object types:

```
  {
    "type": "sighting",
    "id": "sighting--ee20065d-2555-424f-ad9e-0f8428623c75",
    "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
    "created": "2016-04-06T20:08:31.000Z",
    "modified": "2016-04-06T20:08:31.000Z",
    "first_seen": "2015-12-21T19:00:00Z",
    "last_seen": "2015-12-21T19:00:00Z",
    "count": 50,
    "sighting_of_ref": "indicator--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
    "observed_data_refs": ["observed-data--b67d30ff-02ac-498a-92f9-32f845f448cf"],
    "where_sighted_refs": ["identity--b67d30ff-02ac-498a-92f9-32f845f448ff"]
  },
```

However, we distinguish between two different kinds of Indicators:
1. Pattern-based indicators or engines (such as Snort rules or TG Indicators)
2. Observable-based indicators and feeds (such as IP blacklists, domain watchlists, etc.)

As the STIX 2.0 spec defines the `indicates` relationship type as something that only
*Indicators* do, and as we also follow this in ALL of our other data sources and importers,
I strongly recommend that we revise our docs to bring the standard, recommended
`relationship-types` for sightings into alignment with judgements.

`sighting-of` is a reasonable substitute for STIX's more verbose `sighting_of_ref`,
for pattern and rule-based indicators, such as Snort rules. 

Related to https://github.com/threatgrid/iroh-ui/pull/1353