### PR TITLE
Adding  Sensor Coordinates for Sighting

### DIFF
--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -390,6 +390,14 @@
     "revision" : 10,
     "sensor" : "string",
     "count" : 10,
+    "sensor_coordinates" : {
+      "type" : "string",
+      "observables" : [ {
+        "value" : "string",
+        "type" : "string"
+      } ],
+      "os" : "string"
+    },
     "short_description" : "string",
     "targets" : [ {
       "type" : "string",
@@ -401,8 +409,7 @@
         "start_time" : "2016-01-01T01:01:01.000Z",
         "end_time" : "2016-01-01T01:01:01.000Z"
       },
-      "os" : "string",
-      "properties_data_tables" : "string"
+      "os" : "string"
     } ],
     "schema_version" : "string",
     "title" : "string",

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -404,6 +404,14 @@
       "revision" : 10,
       "sensor" : "string",
       "count" : 10,
+      "sensor_coordinates" : {
+        "type" : "string",
+        "observables" : [ {
+          "value" : "string",
+          "type" : "string"
+        } ],
+        "os" : "string"
+      },
       "short_description" : "string",
       "targets" : [ {
         "type" : "string",
@@ -415,8 +423,7 @@
           "start_time" : "2016-01-01T01:01:01.000Z",
           "end_time" : "2016-01-01T01:01:01.000Z"
         },
-        "os" : "string",
-        "properties_data_tables" : "string"
+        "os" : "string"
       } ],
       "schema_version" : "string",
       "title" : "string",

--- a/doc/json/sighting.json
+++ b/doc/json/sighting.json
@@ -29,6 +29,14 @@
   "revision" : 10,
   "sensor" : "string",
   "count" : 10,
+  "sensor_coordinates" : {
+    "type" : "string",
+    "observables" : [ {
+      "value" : "string",
+      "type" : "string"
+    } ],
+    "os" : "string"
+  },
   "short_description" : "string",
   "targets" : [ {
     "type" : "string",
@@ -40,8 +48,7 @@
       "start_time" : "2016-01-01T01:01:01.000Z",
       "end_time" : "2016-01-01T01:01:01.000Z"
     },
-    "os" : "string",
-    "properties_data_tables" : "string"
+    "os" : "string"
   } ],
   "schema_version" : "string",
   "title" : "string",

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4492,6 +4492,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -5190,11 +5193,12 @@ A single sighting of an [indicator](indicator.md)
 |[resolution](#propertyresolution-resolutionstring)|Resolution String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[sensor](#propertysensor-sensorstring)|Sensor String|The OpenC2 Actuator name that best fits the device that is creating this sighting (e.g. network.firewall)||
+|[sensor_coordinates](#propertysensor_coordinates-sensorcoordinatesobject)|*SensorCoordinates* Object| ||
 |[severity](#propertyseverity-highmedlowstring)|HighMedLow String| ||
 |[short_description](#propertyshort_description-medstringstring)|MedString String|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedString String| ||
 |[source_uri](#propertysource_uri-string)| String| ||
-|[targets](#propertytargets-sightingtargetobjectlist)|*SightingTarget* Object List|The target device. Where the sighting came from.||
+|[targets](#propertytargets-targetcoordinatesobjectlist)|*TargetCoordinates* Object List|The target device. Where the sighting came from.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortString String|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLP String|Specification for how, and to whom, this object can be shared.||
@@ -5295,9 +5299,9 @@ The object(s) of interest
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map61-ref"></a>
+<a id="map62-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map61)
+  * Details: [*Observable* Object](#map62)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -5318,9 +5322,9 @@ Provide any context we can about where the observable came from
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map62-ref"></a>
+<a id="map63-ref"></a>
 * *ObservedRelation* Object Value
-  * Details: [*ObservedRelation* Object](#map62)
+  * Details: [*ObservedRelation* Object](#map63)
 
 <a id="propertyresolution-resolutionstring"></a>
 ## Property resolution ∷ Resolution String
@@ -5414,6 +5418,16 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
+<a id="propertysensor_coordinates-sensorcoordinatesobject"></a>
+## Property sensor_coordinates ∷ *SensorCoordinates* Object
+
+* This entry is optional
+
+
+<a id="map60-ref"></a>
+* *SensorCoordinates* Object Value
+  * Details: [*SensorCoordinates* Object](#map60)
+
 <a id="propertyseverity-highmedlowstring"></a>
 ## Property severity ∷ HighMedLow String
 
@@ -5455,8 +5469,8 @@ A single line, short summary of the object.
 
   * A URI
 
-<a id="propertytargets-sightingtargetobjectlist"></a>
-## Property targets ∷ *SightingTarget* Object List
+<a id="propertytargets-targetcoordinatesobjectlist"></a>
+## Property targets ∷ *TargetCoordinates* Object List
 
 The target device. Where the sighting came from.
 
@@ -5464,9 +5478,9 @@ The target device. Where the sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map60-ref"></a>
-* *SightingTarget* Object Value
-  * Details: [*SightingTarget* Object](#map60)
+<a id="map61-ref"></a>
+* *TargetCoordinates* Object Value
+  * Details: [*TargetCoordinates* Object](#map61)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -5512,7 +5526,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "sighting"
 
-<a id="map62"></a>
+<a id="map63"></a>
 # *ObservedRelation* Object
 
 A relation inside a Sighting.
@@ -5548,9 +5562,9 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map65-ref"></a>
+<a id="map66-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map65)
+  * Details: [*Observable* Object](#map66)
 
 <a id="propertyrelation-observablerelationtypestring"></a>
 ## Property relation ∷ ObservableRelationType String
@@ -5704,9 +5718,9 @@ A relation inside a Sighting.
 * This entry is optional
 
 
-<a id="map63-ref"></a>
+<a id="map64-ref"></a>
 * Object Value
-  * Details: [Object](#map63)
+  * Details: [Object](#map64)
 
 <a id="propertysource-observableobject"></a>
 ## Property source ∷ *Observable* Object
@@ -5714,9 +5728,62 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map64-ref"></a>
+<a id="map65-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map64)
+  * Details: [*Observable* Object](#map65)
+
+<a id="map66"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
 
 <a id="map65"></a>
 # *Observable* Object
@@ -5753,6 +5820,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -5769,56 +5839,6 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 <a id="map64"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * cisco_mid
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * odns_identity
-    * odns_identity_label
-    * pki_serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map63"></a>
 # Object
 
 | Property | Type | Description | Required? |
@@ -5833,7 +5853,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map61"></a>
+<a id="map62"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -5868,6 +5888,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -5883,10 +5906,10 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map60"></a>
-# *SightingTarget* Object
+<a id="map61"></a>
+# *TargetCoordinates* Object
 
-Describes a target device where a sighting came from.
+Describes the target of the sighting and contains identifying observables for the target.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
@@ -5894,7 +5917,6 @@ Describes a target device where a sighting came from.
 |[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
 |[os](#propertyos-string)| String| ||
-|[properties_data_tables](#propertyproperties_data_tables-string)| String| ||
 
 
 <a id="propertyobservables-observableobjectlist"></a>
@@ -5904,9 +5926,9 @@ Describes a target device where a sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map66-ref"></a>
+<a id="map67-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map66)
+  * Details: [*Observable* Object](#map67)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -5914,9 +5936,9 @@ Describes a target device where a sighting came from.
 * This entry is required
 
 
-<a id="map67-ref"></a>
+<a id="map68-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map67)
+  * Details: [*ObservedTime* Object](#map68)
 
 <a id="propertyos-string"></a>
 ## Property os ∷  String
@@ -5924,14 +5946,6 @@ Describes a target device where a sighting came from.
 * This entry is optional
 
 
-
-<a id="propertyproperties_data_tables-string"></a>
-## Property properties_data_tables ∷  String
-
-* This entry is optional
-
-
-  * A URI leading to a data table
 
 <a id="propertytype-sensorstring"></a>
 ## Property type ∷ Sensor String
@@ -5989,7 +6003,7 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
-<a id="map67"></a>
+<a id="map68"></a>
 # *ObservedTime* Object
 
 Period of time when a cyber observation is valid.  `start_time` must come before `end_time` (if specified).
@@ -6021,7 +6035,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map66"></a>
+<a id="map67"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -6056,6 +6070,148 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map60"></a>
+# *SensorCoordinates* Object
+
+Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
+|[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
+|[os](#propertyos-string)| String| ||
+
+
+<a id="propertyobservables-observableobjectlist"></a>
+## Property observables ∷ *Observable* Object List
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map69-ref"></a>
+* *Observable* Object Value
+  * Details: [*Observable* Object](#map69)
+
+<a id="propertyos-string"></a>
+## Property os ∷  String
+
+* This entry is optional
+
+
+
+<a id="propertytype-sensorstring"></a>
+## Property type ∷ Sensor String
+
+* This entry is required
+
+
+  * The openC2 Actuator name that best fits a device
+See also the Open C2 Language Description, Actuator Vocabulary, page 24.
+  * Allowed Values:
+    * endpoint
+    * endpoint.digital-telephone-handset
+    * endpoint.laptop
+    * endpoint.pos-terminal
+    * endpoint.printer
+    * endpoint.sensor
+    * endpoint.server
+    * endpoint.smart-meter
+    * endpoint.smart-phone
+    * endpoint.tablet
+    * endpoint.workstation
+    * network
+    * network.bridge
+    * network.firewall
+    * network.gateway
+    * network.guard
+    * network.hips
+    * network.hub
+    * network.ids
+    * network.ips
+    * network.modem
+    * network.nic
+    * network.proxy
+    * network.router
+    * network.security_manager
+    * network.sense_making
+    * network.sensor
+    * network.switch
+    * network.vpn
+    * network.wap
+    * process
+    * process.aaa-server
+    * process.anti-virus-scanner
+    * process.connection-scanner
+    * process.directory-service
+    * process.dns-server
+    * process.email-service
+    * process.file-scanner
+    * process.location-service
+    * process.network-scanner
+    * process.remediation-service
+    * process.reputation-service
+    * process.sandbox
+    * process.virtualization-service
+    * process.vulnerability-scanner
+  * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
+
+<a id="map69"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -6219,9 +6375,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map68-ref"></a>
+<a id="map70-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map68)
+  * Details: [*ExternalReference* Object](#map70)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -6242,9 +6398,9 @@ The list of kill chain phases for which this Tool can be used.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map69-ref"></a>
+<a id="map71-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map69)
+  * Details: [*KillChainPhase* Object](#map71)
 
 <a id="propertylabels-toollabelstringlist"></a>
 ## Property labels ∷ ToolLabel String List
@@ -6377,7 +6533,7 @@ ATT&CK Software.aliases
 
   * String with at most 1024 characters
 
-<a id="map69"></a>
+<a id="map71"></a>
 # *KillChainPhase* Object
 
 The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -6420,7 +6576,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map68"></a>
+<a id="map70"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6543,9 +6699,9 @@ The disposition_name field is optional, but is intended to be shown to a user.  
 * This entry is required
 
 
-<a id="map70-ref"></a>
+<a id="map72-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map70)
+  * Details: [*Observable* Object](#map72)
 
 <a id="propertytype-verdicttypeidentifierstring"></a>
 ## Property type ∷ VerdictTypeIdentifier String
@@ -6561,11 +6717,11 @@ The disposition_name field is optional, but is intended to be shown to a user.  
 * This entry is required
 
 
-<a id="map71-ref"></a>
+<a id="map73-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map71)
+  * Details: [*ValidTime* Object](#map73)
 
-<a id="map71"></a>
+<a id="map73"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -6597,7 +6753,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map70"></a>
+<a id="map72"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -6632,6 +6788,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -6684,9 +6843,9 @@ an ordered list of column definitions
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map73-ref"></a>
+<a id="map75-ref"></a>
 * *ColumnDefinition* Object Value
-  * Details: [*ColumnDefinition* Object](#map73)
+  * Details: [*ColumnDefinition* Object](#map75)
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ Markdown String
@@ -6715,9 +6874,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map72-ref"></a>
+<a id="map74-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map72)
+  * Details: [*ExternalReference* Object](#map74)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -6854,11 +7013,11 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map74-ref"></a>
+<a id="map76-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map74)
+  * Details: [*ValidTime* Object](#map76)
 
-<a id="map74"></a>
+<a id="map76"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -6890,7 +7049,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map73"></a>
+<a id="map75"></a>
 # *ColumnDefinition* Object
 
 | Property | Type | Description | Required? |
@@ -6947,7 +7106,7 @@ If true, the row entries for this column cannot contain nulls. Defaults to true
     * string
     * url
 
-<a id="map72"></a>
+<a id="map74"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -7093,9 +7252,9 @@ indicates one or more other names used to describe this weakness
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map81-ref"></a>
+<a id="map83-ref"></a>
 * *AlternateTerm* Object Value
-  * Details: [*AlternateTerm* Object](#map81)
+  * Details: [*AlternateTerm* Object](#map83)
 
 <a id="propertyarchitectures-architectureobjectlist"></a>
 ## Property architectures ∷ *Architecture* Object List
@@ -7106,9 +7265,9 @@ Applicable architectures
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map78-ref"></a>
+<a id="map80-ref"></a>
 * *Architecture* Object Value
-  * Details: [*Architecture* Object](#map78)
+  * Details: [*Architecture* Object](#map80)
 
 <a id="propertybackground_details-markdownstring"></a>
 ## Property background_details ∷ Markdown String
@@ -7129,9 +7288,9 @@ specify individual consequences associated with a weakness
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map83-ref"></a>
+<a id="map85-ref"></a>
 * *Consequence* Object Value
-  * Details: [*Consequence* Object](#map83)
+  * Details: [*Consequence* Object](#map85)
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ Markdown String
@@ -7152,9 +7311,9 @@ identify methods that may be employed to detect this weakness, including their s
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map84-ref"></a>
+<a id="map86-ref"></a>
 * *DetectionMethod* Object Value
-  * Details: [*DetectionMethod* Object](#map84)
+  * Details: [*DetectionMethod* Object](#map86)
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷  String List
@@ -7173,9 +7332,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map75-ref"></a>
+<a id="map77-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map75)
+  * Details: [*ExternalReference* Object](#map77)
 
 <a id="propertyfunctional_areas-functionalareastringlist"></a>
 ## Property functional_areas ∷ FunctionalArea String List
@@ -7237,9 +7396,9 @@ Applicable Languages
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map76-ref"></a>
+<a id="map78-ref"></a>
 * *Language* Object Value
-  * Details: [*Language* Object](#map76)
+  * Details: [*Language* Object](#map78)
 
 <a id="propertylikelihood-highmedlowstring"></a>
 ## Property likelihood ∷ HighMedLow String
@@ -7267,9 +7426,9 @@ information about how and when a given weakness may be introduced
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map82-ref"></a>
+<a id="map84-ref"></a>
 * *ModeOfIntroduction* Object Value
-  * Details: [*ModeOfIntroduction* Object](#map82)
+  * Details: [*ModeOfIntroduction* Object](#map84)
 
 <a id="propertynotes-noteobjectlist"></a>
 ## Property notes ∷ *Note* Object List
@@ -7280,9 +7439,9 @@ provide any additional comments about the weakness
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map86-ref"></a>
+<a id="map88-ref"></a>
 * *Note* Object Value
-  * Details: [*Note* Object](#map86)
+  * Details: [*Note* Object](#map88)
 
 <a id="propertyoperating_systems-operatingsystemobjectlist"></a>
 ## Property operating_systems ∷ *OperatingSystem* Object List
@@ -7293,9 +7452,9 @@ Applicable operating systems
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map77-ref"></a>
+<a id="map79-ref"></a>
 * *OperatingSystem* Object Value
-  * Details: [*OperatingSystem* Object](#map77)
+  * Details: [*OperatingSystem* Object](#map79)
 
 <a id="propertyparadigms-paradigmobjectlist"></a>
 ## Property paradigms ∷ *Paradigm* Object List
@@ -7306,9 +7465,9 @@ Applicable paradigms
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map79-ref"></a>
+<a id="map81-ref"></a>
 * *Paradigm* Object Value
-  * Details: [*Paradigm* Object](#map79)
+  * Details: [*Paradigm* Object](#map81)
 
 <a id="propertypotential_mitigations-mitigationobjectlist"></a>
 ## Property potential_mitigations ∷ *Mitigation* Object List
@@ -7319,9 +7478,9 @@ describe potential mitigations associated with a weakness
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map85-ref"></a>
+<a id="map87-ref"></a>
 * *Mitigation* Object Value
-  * Details: [*Mitigation* Object](#map85)
+  * Details: [*Mitigation* Object](#map87)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -7393,9 +7552,9 @@ Applicable technologies
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map80-ref"></a>
+<a id="map82-ref"></a>
 * *Technology* Object Value
-  * Details: [*Technology* Object](#map80)
+  * Details: [*Technology* Object](#map82)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -7444,7 +7603,7 @@ The fixed value weakness
   * The fixed value "weakness"
   * Must equal: "weakness"
 
-<a id="map86"></a>
+<a id="map88"></a>
 # *Note* Object
 
 | Property | Type | Description | Required? |
@@ -7477,7 +7636,7 @@ The fixed value weakness
     * Theoretical
   * Reference: [NoteTypeEnumeration] (https://cwe.mitre.org/documents/schema/#NoteTypeEnumeration)
 
-<a id="map85"></a>
+<a id="map87"></a>
 # *Mitigation* Object
 
 | Property | Type | Description | Required? |
@@ -7579,7 +7738,7 @@ a general strategy for protecting a system to which this mitigation contributes
     * Separation of Privilege
   * Reference: [MitigationStrategyEnumeration](https://cwe.mitre.org/documents/schema/#MitigationStrategyEnumeration)
 
-<a id="map84"></a>
+<a id="map86"></a>
 # *DetectionMethod* Object
 
 | Property | Type | Description | Required? |
@@ -7658,7 +7817,7 @@ identifies the particular detection method being described
     * White Box
   * Reference: [DetectionMethodEnumeration](https://cwe.mitre.org/documents/schema/#DetectionMethodEnumeration)
 
-<a id="map83"></a>
+<a id="map85"></a>
 # *Consequence* Object
 
 | Property | Type | Description | Required? |
@@ -7750,7 +7909,7 @@ identifies the security property that is violated
     * Non-Repudiation
   * Reference: [ScopeEnumeration](https://cwe.mitre.org/documents/schema/#ScopeEnumeration)
 
-<a id="map82"></a>
+<a id="map84"></a>
 # *ModeOfIntroduction* Object
 
 | Property | Type | Description | Required? |
@@ -7796,7 +7955,7 @@ identifies the point in the software life cycle at which the weakness may be int
     * Testing
   * Reference: [PhaseEnumeration](https://cwe.mitre.org/documents/schema/#PhaseEnumeration)
 
-<a id="map81"></a>
+<a id="map83"></a>
 # *AlternateTerm* Object
 
 | Property | Type | Description | Required? |
@@ -7825,7 +7984,7 @@ the actual alternate term
 
   * String with at most 1024 characters
 
-<a id="map80"></a>
+<a id="map82"></a>
 # *Technology* Object
 
 | Property | Type | Description | Required? |
@@ -7860,7 +8019,7 @@ defines the different regularities that guide the applicability of platforms
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map79"></a>
+<a id="map81"></a>
 # *Paradigm* Object
 
 | Property | Type | Description | Required? |
@@ -7895,7 +8054,7 @@ defines the different regularities that guide the applicability of platforms
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map78"></a>
+<a id="map80"></a>
 # *Architecture* Object
 
 | Property | Type | Description | Required? |
@@ -7945,7 +8104,7 @@ defines the different regularities that guide the applicability of platforms
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map77"></a>
+<a id="map79"></a>
 # *OperatingSystem* Object
 
 | Property | Type | Description | Required? |
@@ -8014,7 +8173,7 @@ defines the different regularities that guide the applicability of platforms
 
   * String with at most 1024 characters
 
-<a id="map76"></a>
+<a id="map78"></a>
 # *Language* Object
 
 | Property | Type | Description | Required? |
@@ -8065,7 +8224,7 @@ defines the different regularities that guide the applicability of platforms
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map75"></a>
+<a id="map77"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -8161,9 +8320,9 @@ a mistake in software that can be directly used by a hacker to gain access to a 
 * This entry is optional
 
 
-<a id="map88-ref"></a>
+<a id="map90-ref"></a>
 * *CVE* Object Value
-  * Details: [*CVE* Object](#map88)
+  * Details: [*CVE* Object](#map90)
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ Markdown String
@@ -8192,9 +8351,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map87-ref"></a>
+<a id="map89-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map87)
+  * Details: [*ExternalReference* Object](#map89)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -8212,9 +8371,9 @@ Globally unique URI identifying this object.
 * This entry is optional
 
 
-<a id="map89-ref"></a>
+<a id="map91-ref"></a>
 * *VulnerabilityImpact* Object Value
-  * Details: [*VulnerabilityImpact* Object](#map89)
+  * Details: [*VulnerabilityImpact* Object](#map91)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortString String
@@ -8335,7 +8494,7 @@ The fixed value vulnerability
   * The fixed value "vulnerability"
   * Must equal: "vulnerability"
 
-<a id="map89"></a>
+<a id="map91"></a>
 # *VulnerabilityImpact* Object
 
 | Property | Type | Description | Required? |
@@ -8350,9 +8509,9 @@ The fixed value vulnerability
 * This entry is optional
 
 
-<a id="map90-ref"></a>
+<a id="map92-ref"></a>
 * *CVSSv2* Object Value
-  * Details: [*CVSSv2* Object](#map90)
+  * Details: [*CVSSv2* Object](#map92)
 
 <a id="propertycvss_v3-cvssv3object"></a>
 ## Property cvss_v3 ∷ *CVSSv3* Object
@@ -8360,11 +8519,11 @@ The fixed value vulnerability
 * This entry is optional
 
 
-<a id="map91-ref"></a>
+<a id="map93-ref"></a>
 * *CVSSv3* Object Value
-  * Details: [*CVSSv3* Object](#map91)
+  * Details: [*CVSSv3* Object](#map93)
 
-<a id="map91"></a>
+<a id="map93"></a>
 # *CVSSv3* Object
 
 | Property | Type | Description | Required? |
@@ -8831,7 +8990,7 @@ captures the requirement for a user, other than the attacker, to participate in 
 
   * a text representation of a set of CVSSv3 metrics.It is commonly used to record or transfer CVSSv3 metric information in a concise form
 
-<a id="map90"></a>
+<a id="map92"></a>
 # *CVSSv2* Object
 
 | Property | Type | Description | Required? |
@@ -9163,7 +9322,7 @@ captures the requirement for a user, other than the attacker, to participate in 
 
   * a text representation of a set of CVSSv2 metrics.It is commonly used to record or transfer CVSSv2 metric information in a concise form
 
-<a id="map88"></a>
+<a id="map90"></a>
 # *CVE* Object
 
 | Property | Type | Description | Required? |
@@ -9177,11 +9336,11 @@ captures the requirement for a user, other than the attacker, to participate in 
 * This entry is required
 
 
-<a id="map92-ref"></a>
+<a id="map94-ref"></a>
 * *CVEDataMeta* Object Value
-  * Details: [*CVEDataMeta* Object](#map92)
+  * Details: [*CVEDataMeta* Object](#map94)
 
-<a id="map92"></a>
+<a id="map94"></a>
 # *CVEDataMeta* Object
 
 | Property | Type | Description | Required? |
@@ -9206,7 +9365,7 @@ captures the requirement for a user, other than the attacker, to participate in 
 
   * String with at most 1024 characters
 
-<a id="map87"></a>
+<a id="map89"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -295,6 +295,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -3673,6 +3676,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -4028,11 +4034,12 @@ A single sighting of an [indicator](indicator.md)
 |[resolution](#propertyresolution-resolutionstring)|Resolution String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[sensor](#propertysensor-sensorstring)|Sensor String|The OpenC2 Actuator name that best fits the device that is creating this sighting (e.g. network.firewall)||
+|[sensor_coordinates](#propertysensor_coordinates-sensorcoordinatesobject)|*SensorCoordinates* Object| ||
 |[severity](#propertyseverity-highmedlowstring)|HighMedLow String| ||
 |[short_description](#propertyshort_description-medstringstring)|MedString String|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedString String| ||
 |[source_uri](#propertysource_uri-string)| String| ||
-|[targets](#propertytargets-sightingtargetobjectlist)|*SightingTarget* Object List|The target device. Where the sighting came from.||
+|[targets](#propertytargets-targetcoordinatesobjectlist)|*TargetCoordinates* Object List|The target device. Where the sighting came from.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortString String|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLP String|Specification for how, and to whom, this object can be shared.||
@@ -4133,9 +4140,9 @@ The object(s) of interest
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map51-ref"></a>
+<a id="map52-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map51)
+  * Details: [*Observable* Object](#map52)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -4156,9 +4163,9 @@ Provide any context we can about where the observable came from
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map52-ref"></a>
+<a id="map53-ref"></a>
 * *ObservedRelation* Object Value
-  * Details: [*ObservedRelation* Object](#map52)
+  * Details: [*ObservedRelation* Object](#map53)
 
 <a id="propertyresolution-resolutionstring"></a>
 ## Property resolution ∷ Resolution String
@@ -4252,6 +4259,16 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
+<a id="propertysensor_coordinates-sensorcoordinatesobject"></a>
+## Property sensor_coordinates ∷ *SensorCoordinates* Object
+
+* This entry is optional
+
+
+<a id="map50-ref"></a>
+* *SensorCoordinates* Object Value
+  * Details: [*SensorCoordinates* Object](#map50)
+
 <a id="propertyseverity-highmedlowstring"></a>
 ## Property severity ∷ HighMedLow String
 
@@ -4293,8 +4310,8 @@ A single line, short summary of the object.
 
   * A URI
 
-<a id="propertytargets-sightingtargetobjectlist"></a>
-## Property targets ∷ *SightingTarget* Object List
+<a id="propertytargets-targetcoordinatesobjectlist"></a>
+## Property targets ∷ *TargetCoordinates* Object List
 
 The target device. Where the sighting came from.
 
@@ -4302,9 +4319,9 @@ The target device. Where the sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map50-ref"></a>
-* *SightingTarget* Object Value
-  * Details: [*SightingTarget* Object](#map50)
+<a id="map51-ref"></a>
+* *TargetCoordinates* Object Value
+  * Details: [*TargetCoordinates* Object](#map51)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -4350,7 +4367,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "sighting"
 
-<a id="map52"></a>
+<a id="map53"></a>
 # *ObservedRelation* Object
 
 A relation inside a Sighting.
@@ -4386,9 +4403,9 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map55-ref"></a>
+<a id="map56-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map55)
+  * Details: [*Observable* Object](#map56)
 
 <a id="propertyrelation-observablerelationtypestring"></a>
 ## Property relation ∷ ObservableRelationType String
@@ -4542,9 +4559,9 @@ A relation inside a Sighting.
 * This entry is optional
 
 
-<a id="map53-ref"></a>
+<a id="map54-ref"></a>
 * Object Value
-  * Details: [Object](#map53)
+  * Details: [Object](#map54)
 
 <a id="propertysource-observableobject"></a>
 ## Property source ∷ *Observable* Object
@@ -4552,9 +4569,62 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map54-ref"></a>
+<a id="map55-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map54)
+  * Details: [*Observable* Object](#map55)
+
+<a id="map56"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
 
 <a id="map55"></a>
 # *Observable* Object
@@ -4591,6 +4661,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -4607,56 +4680,6 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 <a id="map54"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * cisco_mid
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * odns_identity
-    * odns_identity_label
-    * pki_serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map53"></a>
 # Object
 
 | Property | Type | Description | Required? |
@@ -4671,7 +4694,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map51"></a>
+<a id="map52"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -4706,6 +4729,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -4721,10 +4747,10 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map50"></a>
-# *SightingTarget* Object
+<a id="map51"></a>
+# *TargetCoordinates* Object
 
-Describes a target device where a sighting came from.
+Describes the target of the sighting and contains identifying observables for the target.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
@@ -4732,7 +4758,6 @@ Describes a target device where a sighting came from.
 |[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
 |[os](#propertyos-string)| String| ||
-|[properties_data_tables](#propertyproperties_data_tables-string)| String| ||
 
 
 <a id="propertyobservables-observableobjectlist"></a>
@@ -4742,9 +4767,9 @@ Describes a target device where a sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map56-ref"></a>
+<a id="map57-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map56)
+  * Details: [*Observable* Object](#map57)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -4752,9 +4777,9 @@ Describes a target device where a sighting came from.
 * This entry is required
 
 
-<a id="map57-ref"></a>
+<a id="map58-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map57)
+  * Details: [*ObservedTime* Object](#map58)
 
 <a id="propertyos-string"></a>
 ## Property os ∷  String
@@ -4762,14 +4787,6 @@ Describes a target device where a sighting came from.
 * This entry is optional
 
 
-
-<a id="propertyproperties_data_tables-string"></a>
-## Property properties_data_tables ∷  String
-
-* This entry is optional
-
-
-  * A URI leading to a data table
 
 <a id="propertytype-sensorstring"></a>
 ## Property type ∷ Sensor String
@@ -4827,7 +4844,7 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
-<a id="map57"></a>
+<a id="map58"></a>
 # *ObservedTime* Object
 
 Period of time when a cyber observation is valid.  `start_time` must come before `end_time` (if specified).
@@ -4859,7 +4876,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map56"></a>
+<a id="map57"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -4894,6 +4911,148 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map50"></a>
+# *SensorCoordinates* Object
+
+Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
+|[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
+|[os](#propertyos-string)| String| ||
+
+
+<a id="propertyobservables-observableobjectlist"></a>
+## Property observables ∷ *Observable* Object List
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map59-ref"></a>
+* *Observable* Object Value
+  * Details: [*Observable* Object](#map59)
+
+<a id="propertyos-string"></a>
+## Property os ∷  String
+
+* This entry is optional
+
+
+
+<a id="propertytype-sensorstring"></a>
+## Property type ∷ Sensor String
+
+* This entry is required
+
+
+  * The openC2 Actuator name that best fits a device
+See also the Open C2 Language Description, Actuator Vocabulary, page 24.
+  * Allowed Values:
+    * endpoint
+    * endpoint.digital-telephone-handset
+    * endpoint.laptop
+    * endpoint.pos-terminal
+    * endpoint.printer
+    * endpoint.sensor
+    * endpoint.server
+    * endpoint.smart-meter
+    * endpoint.smart-phone
+    * endpoint.tablet
+    * endpoint.workstation
+    * network
+    * network.bridge
+    * network.firewall
+    * network.gateway
+    * network.guard
+    * network.hips
+    * network.hub
+    * network.ids
+    * network.ips
+    * network.modem
+    * network.nic
+    * network.proxy
+    * network.router
+    * network.security_manager
+    * network.sense_making
+    * network.sensor
+    * network.switch
+    * network.vpn
+    * network.wap
+    * process
+    * process.aaa-server
+    * process.anti-virus-scanner
+    * process.connection-scanner
+    * process.directory-service
+    * process.dns-server
+    * process.email-service
+    * process.file-scanner
+    * process.location-service
+    * process.network-scanner
+    * process.remediation-service
+    * process.reputation-service
+    * process.sandbox
+    * process.virtualization-service
+    * process.vulnerability-scanner
+  * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
+
+<a id="map59"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -5056,9 +5215,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map58-ref"></a>
+<a id="map60-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map58)
+  * Details: [*ExternalReference* Object](#map60)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -5208,7 +5367,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "relationship"
 
-<a id="map58"></a>
+<a id="map60"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -5338,9 +5497,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map59-ref"></a>
+<a id="map61-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map59)
+  * Details: [*ExternalReference* Object](#map61)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -5361,9 +5520,9 @@ The list of Kill Chain Phases for which this Malware can be used.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map60-ref"></a>
+<a id="map62-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map60)
+  * Details: [*KillChainPhase* Object](#map62)
 
 <a id="propertylabels-malwarelabelstringlist"></a>
 ## Property labels ∷ MalwareLabel String List
@@ -5496,7 +5655,7 @@ ATT&CK Software.aliases
 
   * String with at most 1024 characters
 
-<a id="map60"></a>
+<a id="map62"></a>
 # *KillChainPhase* Object
 
 The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -5539,7 +5698,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map59"></a>
+<a id="map61"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -5702,9 +5861,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map61-ref"></a>
+<a id="map63-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map61)
+  * Details: [*ExternalReference* Object](#map63)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -5732,9 +5891,9 @@ The human language this object is specified in.
 * This entry is required
 
 
-<a id="map62-ref"></a>
+<a id="map64-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map62)
+  * Details: [*Observable* Object](#map64)
 
 <a id="propertypriority-integer"></a>
 ## Property priority ∷ Integer
@@ -5851,11 +6010,11 @@ Specification for how, and to whom, this object can be shared.
 * This entry is required
 
 
-<a id="map63-ref"></a>
+<a id="map65-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map63)
+  * Details: [*ValidTime* Object](#map65)
 
-<a id="map63"></a>
+<a id="map65"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -5887,7 +6046,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map62"></a>
+<a id="map64"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -5922,6 +6081,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -5937,7 +6099,7 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 
-<a id="map61"></a>
+<a id="map63"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6054,9 +6216,9 @@ _specification_ value.
 * This entry is optional
 
 
-<a id="map66-ref"></a>
+<a id="map68-ref"></a>
 * *CompositeIndicatorExpression* Object Value
-  * Details: [*CompositeIndicatorExpression* Object](#map66)
+  * Details: [*CompositeIndicatorExpression* Object](#map68)
 
 <a id="propertyconfidence-highmedlowstring"></a>
 ## Property confidence ∷ HighMedLow String
@@ -6102,9 +6264,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map64-ref"></a>
+<a id="map66-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map64)
+  * Details: [*ExternalReference* Object](#map66)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -6152,9 +6314,9 @@ relevant kill chain phases indicated by this Indicator
 * Dev Notes: simplified
 
 
-<a id="map67-ref"></a>
+<a id="map69-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map67)
+  * Details: [*KillChainPhase* Object](#map69)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortString String
@@ -6263,25 +6425,25 @@ A single line, short summary of the object.
 
   * Only one of the following schemas will match
 
-<a id="map68-ref"></a>
-* *JudgementSpecification* Object Value
-  * Details: [*JudgementSpecification* Object](#map68)
-
-<a id="map69-ref"></a>
-* *ThreatBrainSpecification* Object Value
-  * Details: [*ThreatBrainSpecification* Object](#map69)
-
 <a id="map70-ref"></a>
-* *SnortSpecification* Object Value
-  * Details: [*SnortSpecification* Object](#map70)
+* *JudgementSpecification* Object Value
+  * Details: [*JudgementSpecification* Object](#map70)
 
 <a id="map71-ref"></a>
-* *SIOCSpecification* Object Value
-  * Details: [*SIOCSpecification* Object](#map71)
+* *ThreatBrainSpecification* Object Value
+  * Details: [*ThreatBrainSpecification* Object](#map71)
 
 <a id="map72-ref"></a>
+* *SnortSpecification* Object Value
+  * Details: [*SnortSpecification* Object](#map72)
+
+<a id="map73-ref"></a>
+* *SIOCSpecification* Object Value
+  * Details: [*SIOCSpecification* Object](#map73)
+
+<a id="map74-ref"></a>
 * *OpenIOCSpecification* Object Value
-  * Details: [*OpenIOCSpecification* Object](#map72)
+  * Details: [*OpenIOCSpecification* Object](#map74)
 
 <a id="propertytags-shortstringstringlist"></a>
 ## Property tags ∷ ShortString String List
@@ -6361,11 +6523,11 @@ The time range during which this Indicator is considered valid.
 * This entry is required
 
 
-<a id="map65-ref"></a>
+<a id="map67-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map65)
+  * Details: [*ValidTime* Object](#map67)
 
-<a id="map72"></a>
+<a id="map74"></a>
 # *OpenIOCSpecification* Object
 
 An indicator which contains an XML blob of an openIOC indicator..
@@ -6391,7 +6553,7 @@ An indicator which contains an XML blob of an openIOC indicator..
 
   * Must equal: "OpenIOC"
 
-<a id="map71"></a>
+<a id="map73"></a>
 # *SIOCSpecification* Object
 
 An indicator which runs in snort...
@@ -6417,7 +6579,7 @@ An indicator which runs in snort...
 
   * Must equal: "SIOC"
 
-<a id="map70"></a>
+<a id="map72"></a>
 # *SnortSpecification* Object
 
 An indicator which runs in snort...
@@ -6443,7 +6605,7 @@ An indicator which runs in snort...
 
   * Must equal: "Snort"
 
-<a id="map69"></a>
+<a id="map71"></a>
 # *ThreatBrainSpecification* Object
 
 An indicator which runs in threatbrain...
@@ -6478,7 +6640,7 @@ An indicator which runs in threatbrain...
 
 
 
-<a id="map68"></a>
+<a id="map70"></a>
 # *JudgementSpecification* Object
 
 An indicator based on a list of judgements.  If any of the Observables in it's judgements are encountered, than it may be matches against.  If there are any required judgements, they all must be matched in order for the indicator to be considered a match.
@@ -6506,9 +6668,9 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map73-ref"></a>
+<a id="map75-ref"></a>
 * *RelatedJudgement* Object Value
-  * Details: [*RelatedJudgement* Object](#map73)
+  * Details: [*RelatedJudgement* Object](#map75)
 
 <a id="propertytype-judgementspecificationtypestring"></a>
 ## Property type ∷ JudgementSpecificationType String
@@ -6518,7 +6680,7 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 
   * Must equal: "Judgement"
 
-<a id="map73"></a>
+<a id="map75"></a>
 # *RelatedJudgement* Object
 
 | Property | Type | Description | Required? |
@@ -6566,7 +6728,7 @@ An indicator based on a list of judgements.  If any of the Observables in it's j
 
 
 
-<a id="map67"></a>
+<a id="map69"></a>
 # *KillChainPhase* Object
 
 The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -6609,7 +6771,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map66"></a>
+<a id="map68"></a>
 # *CompositeIndicatorExpression* Object
 
 | Property | Type | Description | Required? |
@@ -6639,7 +6801,7 @@ The name of the phase in the kill chain.
     * not
     * or
 
-<a id="map65"></a>
+<a id="map67"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -6671,7 +6833,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map64"></a>
+<a id="map66"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6853,9 +7015,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map74-ref"></a>
+<a id="map76-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map74)
+  * Details: [*ExternalReference* Object](#map76)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -6876,9 +7038,9 @@ relevant time values associated with this Incident
 * Dev Notes: Was 'time'; renamed for clarity
 
 
-<a id="map75-ref"></a>
+<a id="map77-ref"></a>
 * *IncidentTime* Object Value
-  * Details: [*IncidentTime* Object](#map75)
+  * Details: [*IncidentTime* Object](#map77)
 
 <a id="propertyintended_effect-intendedeffectstring"></a>
 ## Property intended_effect ∷ IntendedEffect String
@@ -7032,7 +7194,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "incident"
 
-<a id="map75"></a>
+<a id="map77"></a>
 # *IncidentTime* Object
 
 | Property | Type | Description | Required? |
@@ -7093,7 +7255,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map74"></a>
+<a id="map76"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -7204,9 +7366,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map76-ref"></a>
+<a id="map78-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map76)
+  * Details: [*ExternalReference* Object](#map78)
 
 <a id="propertyfeedback-integer"></a>
 ## Property feedback ∷ Integer
@@ -7316,7 +7478,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "feedback"
 
-<a id="map76"></a>
+<a id="map78"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -7500,9 +7662,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map77-ref"></a>
+<a id="map79-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map77)
+  * Details: [*ExternalReference* Object](#map79)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -7552,9 +7714,9 @@ Characterizes the objective of this course of action
 * This entry is optional
 
 
-<a id="map80-ref"></a>
+<a id="map82-ref"></a>
 * *OpenC2COA* Object Value
-  * Details: [*OpenC2COA* Object](#map80)
+  * Details: [*OpenC2COA* Object](#map82)
 
 <a id="propertyrelated_coas-relatedcoaobjectlist"></a>
 ## Property related_COAs ∷ *RelatedCOA* Object List
@@ -7565,9 +7727,9 @@ Identifies or characterizes relationships to one or more related courses of acti
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map79-ref"></a>
+<a id="map81-ref"></a>
 * *RelatedCOA* Object Value
-  * Details: [*RelatedCOA* Object](#map79)
+  * Details: [*RelatedCOA* Object](#map81)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -7686,11 +7848,11 @@ Specification for how, and to whom, this object can be shared.
 * This entry is required
 
 
-<a id="map78-ref"></a>
+<a id="map80-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map78)
+  * Details: [*ValidTime* Object](#map80)
 
-<a id="map80"></a>
+<a id="map82"></a>
 # *OpenC2COA* Object
 
 | Property | Type | Description | Required? |
@@ -7709,9 +7871,9 @@ Specification for how, and to whom, this object can be shared.
 * This entry is required
 
 
-<a id="map81-ref"></a>
+<a id="map83-ref"></a>
 * *ActionType* Object Value
-  * Details: [*ActionType* Object](#map81)
+  * Details: [*ActionType* Object](#map83)
 
 <a id="propertyactuator-actuatortypeobject"></a>
 ## Property actuator ∷ *ActuatorType* Object
@@ -7719,9 +7881,9 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map83-ref"></a>
+<a id="map85-ref"></a>
 * *ActuatorType* Object Value
-  * Details: [*ActuatorType* Object](#map83)
+  * Details: [*ActuatorType* Object](#map85)
 
 <a id="propertyid-shortstringstring"></a>
 ## Property id ∷ ShortString String
@@ -7737,9 +7899,9 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map84-ref"></a>
+<a id="map86-ref"></a>
 * *ModifierType* Object Value
-  * Details: [*ModifierType* Object](#map84)
+  * Details: [*ModifierType* Object](#map86)
 
 <a id="propertytarget-targettypeobject"></a>
 ## Property target ∷ *TargetType* Object
@@ -7747,9 +7909,9 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map82-ref"></a>
+<a id="map84-ref"></a>
 * *TargetType* Object Value
-  * Details: [*TargetType* Object](#map82)
+  * Details: [*TargetType* Object](#map84)
 
 <a id="propertytype-structuredcoatypestring"></a>
 ## Property type ∷ StructuredCOAType String
@@ -7759,7 +7921,7 @@ Specification for how, and to whom, this object can be shared.
 
   * Must equal: "structured_coa"
 
-<a id="map84"></a>
+<a id="map86"></a>
 # *ModifierType* Object
 
 | Property | Type | Description | Required? |
@@ -7785,9 +7947,9 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map86-ref"></a>
+<a id="map88-ref"></a>
 * *AdditionalProperties* Object Value
-  * Details: [*AdditionalProperties* Object](#map86)
+  * Details: [*AdditionalProperties* Object](#map88)
 
 <a id="propertydelay-instdate"></a>
 ## Property delay ∷ Inst (Date)
@@ -7914,11 +8076,11 @@ Specification for how, and to whom, this object can be shared.
 * This entry is optional
 
 
-<a id="map85-ref"></a>
+<a id="map87-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map85)
+  * Details: [*ValidTime* Object](#map87)
 
-<a id="map86"></a>
+<a id="map88"></a>
 # *AdditionalProperties* Object
 
 | Property | Type | Description | Required? |
@@ -7934,7 +8096,7 @@ Specification for how, and to whom, this object can be shared.
 
   * String with at most 1024 characters
 
-<a id="map85"></a>
+<a id="map87"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -7966,7 +8128,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map83"></a>
+<a id="map85"></a>
 # *ActuatorType* Object
 
 | Property | Type | Description | Required? |
@@ -8040,7 +8202,7 @@ list of additional properties describing the actuator
     * process.virtualization-service
     * process.vulnerability-scanner
 
-<a id="map82"></a>
+<a id="map84"></a>
 # *TargetType* Object
 
 | Property | Type | Description | Required? |
@@ -8067,7 +8229,7 @@ Cybox object representing the target
 
   * String with at most 1024 characters
 
-<a id="map81"></a>
+<a id="map83"></a>
 # *ActionType* Object
 
 | Property | Type | Description | Required? |
@@ -8119,7 +8281,7 @@ Cybox object representing the target
     * update
   * Reference: [OpenC2/STIX COA XML schema](https://github.com/OpenC2-org/subgroup-stix/blob/master/schema/openc2_stix_coa.xsd)
 
-<a id="map79"></a>
+<a id="map81"></a>
 # *RelatedCOA* Object
 
 | Property | Type | Description | Required? |
@@ -8167,7 +8329,7 @@ Cybox object representing the target
 
 
 
-<a id="map78"></a>
+<a id="map80"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -8199,7 +8361,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map77"></a>
+<a id="map79"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -8301,9 +8463,9 @@ Actions taken in regards to this Campaign
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map89-ref"></a>
+<a id="map91-ref"></a>
 * *Activity* Object Value
-  * Details: [*Activity* Object](#map89)
+  * Details: [*Activity* Object](#map91)
 
 <a id="propertycampaign_type-shortstringstring"></a>
 ## Property campaign_type ∷ ShortString String
@@ -8358,9 +8520,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map87-ref"></a>
+<a id="map89-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map87)
+  * Details: [*ExternalReference* Object](#map89)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -8539,11 +8701,11 @@ Timestamp for the definition of a specific version of a campaign
 * This entry is required
 
 
-<a id="map88-ref"></a>
+<a id="map90-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map88)
+  * Details: [*ValidTime* Object](#map90)
 
-<a id="map89"></a>
+<a id="map91"></a>
 # *Activity* Object
 
 What happend, when?
@@ -8575,7 +8737,7 @@ A description of the activity
 
   * Markdown string with at most 5000 characters
 
-<a id="map88"></a>
+<a id="map90"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -8607,7 +8769,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map87"></a>
+<a id="map89"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -8741,9 +8903,9 @@ A list of external references which refer to non-STIX information. This property
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map91-ref"></a>
+<a id="map93-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map91)
+  * Details: [*ExternalReference* Object](#map93)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -8764,9 +8926,9 @@ The list of Kill Chain Phases for which this Attack Pattern is used.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map92-ref"></a>
+<a id="map94-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map92)
+  * Details: [*KillChainPhase* Object](#map94)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortString String
@@ -8891,7 +9053,7 @@ ATT&CK Technique.Platforms
 
   * String with at most 1024 characters
 
-<a id="map92"></a>
+<a id="map94"></a>
 # *KillChainPhase* Object
 
 The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -8934,7 +9096,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map91"></a>
+<a id="map93"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -8996,7 +9158,7 @@ A URL reference to an external resource
 
   * A URI
 
-<a id="map90"></a>
+<a id="map92"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -9157,9 +9319,9 @@ Specifies a list of external references which refers to non-CTIM information. Th
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map93-ref"></a>
+<a id="map95-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map93)
+  * Details: [*ExternalReference* Object](#map95)
 
 <a id="propertyid-string"></a>
 ## Property id ∷  String
@@ -9177,9 +9339,9 @@ Globally unique URI identifying this object.
 * This entry is optional
 
 
-<a id="map95-ref"></a>
+<a id="map97-ref"></a>
 * *Identity* Object Value
-  * Details: [*Identity* Object](#map95)
+  * Details: [*Identity* Object](#map97)
 
 <a id="propertyintended_effect-intendedeffectstring"></a>
 ## Property intended_effect ∷ IntendedEffect String
@@ -9362,11 +9524,11 @@ Specification for how, and to whom, this object can be shared.
 * This entry is required
 
 
-<a id="map94-ref"></a>
+<a id="map96-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map94)
+  * Details: [*ValidTime* Object](#map96)
 
-<a id="map95"></a>
+<a id="map97"></a>
 # *Identity* Object
 
 Describes a person or an organization
@@ -9395,11 +9557,11 @@ Identifies other entity Identities related to this Identity
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map96-ref"></a>
+<a id="map98-ref"></a>
 * *RelatedIdentity* Object Value
-  * Details: [*RelatedIdentity* Object](#map96)
+  * Details: [*RelatedIdentity* Object](#map98)
 
-<a id="map96"></a>
+<a id="map98"></a>
 # *RelatedIdentity* Object
 
 Describes a related Identity
@@ -9456,7 +9618,7 @@ Specifies the source of the information about the relationship between the two c
 
 
 
-<a id="map94"></a>
+<a id="map96"></a>
 # *ValidTime* Object
 
 Period of time when a cyber observation is valid.
@@ -9488,7 +9650,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map93"></a>
+<a id="map95"></a>
 # *ExternalReference* Object
 
 External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -349,6 +349,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -21,11 +21,12 @@ A single sighting of an [indicator](indicator.md)
 |[resolution](#propertyresolution-resolutionstring)|Resolution String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[sensor](#propertysensor-sensorstring)|Sensor String|The OpenC2 Actuator name that best fits the device that is creating this sighting (e.g. network.firewall)||
+|[sensor_coordinates](#propertysensor_coordinates-sensorcoordinatesobject)|*SensorCoordinates* Object| ||
 |[severity](#propertyseverity-highmedlowstring)|HighMedLow String| ||
 |[short_description](#propertyshort_description-medstringstring)|MedString String|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedString String| ||
 |[source_uri](#propertysource_uri-string)| String| ||
-|[targets](#propertytargets-sightingtargetobjectlist)|*SightingTarget* Object List|The target device. Where the sighting came from.||
+|[targets](#propertytargets-targetcoordinatesobjectlist)|*TargetCoordinates* Object List|The target device. Where the sighting came from.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortString String|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLP String|Specification for how, and to whom, this object can be shared.||
@@ -126,9 +127,9 @@ The object(s) of interest
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map4-ref"></a>
+<a id="map5-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map4)
+  * Details: [*Observable* Object](#map5)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -149,9 +150,9 @@ Provide any context we can about where the observable came from
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map5-ref"></a>
+<a id="map6-ref"></a>
 * *ObservedRelation* Object Value
-  * Details: [*ObservedRelation* Object](#map5)
+  * Details: [*ObservedRelation* Object](#map6)
 
 <a id="propertyresolution-resolutionstring"></a>
 ## Property resolution ∷ Resolution String
@@ -245,6 +246,16 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.vulnerability-scanner
   * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
+<a id="propertysensor_coordinates-sensorcoordinatesobject"></a>
+## Property sensor_coordinates ∷ *SensorCoordinates* Object
+
+* This entry is optional
+
+
+<a id="map3-ref"></a>
+* *SensorCoordinates* Object Value
+  * Details: [*SensorCoordinates* Object](#map3)
+
 <a id="propertyseverity-highmedlowstring"></a>
 ## Property severity ∷ HighMedLow String
 
@@ -286,8 +297,8 @@ A single line, short summary of the object.
 
   * A URI
 
-<a id="propertytargets-sightingtargetobjectlist"></a>
-## Property targets ∷ *SightingTarget* Object List
+<a id="propertytargets-targetcoordinatesobjectlist"></a>
+## Property targets ∷ *TargetCoordinates* Object List
 
 The target device. Where the sighting came from.
 
@@ -295,9 +306,9 @@ The target device. Where the sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map3-ref"></a>
-* *SightingTarget* Object Value
-  * Details: [*SightingTarget* Object](#map3)
+<a id="map4-ref"></a>
+* *TargetCoordinates* Object Value
+  * Details: [*TargetCoordinates* Object](#map4)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -438,17 +449,15 @@ Time of the observation.  If the observation was made over a period of time, tha
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="map3"></a>
-# *SightingTarget* Object
+# *SensorCoordinates* Object
 
-Describes a target device where a sighting came from.
+Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
-|[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
 |[os](#propertyos-string)| String| ||
-|[properties_data_tables](#propertyproperties_data_tables-string)| String| ||
 
 
 <a id="propertyobservables-observableobjectlist"></a>
@@ -458,19 +467,9 @@ Describes a target device where a sighting came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map6-ref"></a>
-* *Observable* Object Value
-  * Details: [*Observable* Object](#map6)
-
-<a id="propertyobserved_time-observedtimeobject"></a>
-## Property observed_time ∷ *ObservedTime* Object
-
-* This entry is required
-
-
 <a id="map7-ref"></a>
-* *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map7)
+* *Observable* Object Value
+  * Details: [*Observable* Object](#map7)
 
 <a id="propertyos-string"></a>
 ## Property os ∷  String
@@ -478,14 +477,6 @@ Describes a target device where a sighting came from.
 * This entry is optional
 
 
-
-<a id="propertyproperties_data_tables-string"></a>
-## Property properties_data_tables ∷  String
-
-* This entry is optional
-
-
-  * A URI leading to a data table
 
 <a id="propertytype-sensorstring"></a>
 ## Property type ∷ Sensor String
@@ -541,9 +532,159 @@ See also the Open C2 Language Description, Actuator Vocabulary, page 24.
     * process.sandbox
     * process.virtualization-service
     * process.vulnerability-scanner
-  * Reference: [OpenC2 Language Description](http://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html)
+  * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
 
 <a id="map7"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map4"></a>
+# *TargetCoordinates* Object
+
+Describes the target of the sighting and contains identifying observables for the target.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
+|[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
+|[type](#propertytype-sensorstring)|Sensor String| |&#10003;|
+|[os](#propertyos-string)| String| ||
+
+
+<a id="propertyobservables-observableobjectlist"></a>
+## Property observables ∷ *Observable* Object List
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map8-ref"></a>
+* *Observable* Object Value
+  * Details: [*Observable* Object](#map8)
+
+<a id="propertyobserved_time-observedtimeobject"></a>
+## Property observed_time ∷ *ObservedTime* Object
+
+* This entry is required
+
+
+<a id="map9-ref"></a>
+* *ObservedTime* Object Value
+  * Details: [*ObservedTime* Object](#map9)
+
+<a id="propertyos-string"></a>
+## Property os ∷  String
+
+* This entry is optional
+
+
+
+<a id="propertytype-sensorstring"></a>
+## Property type ∷ Sensor String
+
+* This entry is required
+
+
+  * The openC2 Actuator name that best fits a device
+See also the Open C2 Language Description, Actuator Vocabulary, page 24.
+  * Allowed Values:
+    * endpoint
+    * endpoint.digital-telephone-handset
+    * endpoint.laptop
+    * endpoint.pos-terminal
+    * endpoint.printer
+    * endpoint.sensor
+    * endpoint.server
+    * endpoint.smart-meter
+    * endpoint.smart-phone
+    * endpoint.tablet
+    * endpoint.workstation
+    * network
+    * network.bridge
+    * network.firewall
+    * network.gateway
+    * network.guard
+    * network.hips
+    * network.hub
+    * network.ids
+    * network.ips
+    * network.modem
+    * network.nic
+    * network.proxy
+    * network.router
+    * network.security_manager
+    * network.sense_making
+    * network.sensor
+    * network.switch
+    * network.vpn
+    * network.wap
+    * process
+    * process.aaa-server
+    * process.anti-virus-scanner
+    * process.connection-scanner
+    * process.directory-service
+    * process.dns-server
+    * process.email-service
+    * process.file-scanner
+    * process.location-service
+    * process.network-scanner
+    * process.remediation-service
+    * process.reputation-service
+    * process.sandbox
+    * process.virtualization-service
+    * process.vulnerability-scanner
+  * Reference: [OpenC2 Language Description](HTTP://openc2.org/docs/OpenC2%20%20Language%20Descrip%20Doc%20Draft%20%28Rev%200%206f%29%2003012016.pdf)
+
+<a id="map9"></a>
 # *ObservedTime* Object
 
 Period of time when a cyber observation is valid.  `start_time` must come before `end_time` (if specified).
@@ -575,7 +716,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 
   * Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map6"></a>
+<a id="map8"></a>
 # *Observable* Object
 
 A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -610,56 +751,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
-    * odns_identity
-    * odns_identity_label
-    * pki_serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map4"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * cisco_mid
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial
@@ -676,6 +770,59 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
 
 
 <a id="map5"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map6"></a>
 # *ObservedRelation* Object
 
 A relation inside a Sighting.
@@ -711,9 +858,9 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map10-ref"></a>
+<a id="map12-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map10)
+  * Details: [*Observable* Object](#map12)
 
 <a id="propertyrelation-observablerelationtypestring"></a>
 ## Property relation ∷ ObservableRelationType String
@@ -867,9 +1014,9 @@ A relation inside a Sighting.
 * This entry is optional
 
 
-<a id="map8-ref"></a>
+<a id="map10-ref"></a>
 * Object Value
-  * Details: [Object](#map8)
+  * Details: [Object](#map10)
 
 <a id="propertysource-observableobject"></a>
 ## Property source ∷ *Observable* Object
@@ -877,111 +1024,117 @@ A relation inside a Sighting.
 * This entry is required
 
 
-<a id="map9-ref"></a>
+<a id="map11-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map9)
+  * Details: [*Observable* Object](#map11)
+
+<a id="map12"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
+
+<a id="map11"></a>
+# *Observable* Object
+
+A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
+|[value](#propertyvalue-string)| String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifier String
+
+* This entry is required
+
+
+  * Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * cisco_mid
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * pki_serial
+    * sha1
+    * sha256
+    * url
+    * user
+
+<a id="propertyvalue-string"></a>
+## Property value ∷  String
+
+* This entry is required
+
+
 
 <a id="map10"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * cisco_mid
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * odns_identity
-    * odns_identity_label
-    * pki_serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map9"></a>
-# *Observable* Object
-
-A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifier String| |&#10003;|
-|[value](#propertyvalue-string)| String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifier String
-
-* This entry is required
-
-
-  * Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * cisco_mid
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * odns_identity
-    * odns_identity_label
-    * pki_serial
-    * sha1
-    * sha256
-    * url
-    * user
-
-<a id="propertyvalue-string"></a>
-## Property value ∷  String
-
-* This entry is required
-
-
-
-<a id="map8"></a>
 # Object
 
 | Property | Type | Description | Required? |

--- a/doc/structures/verdict.md
+++ b/doc/structures/verdict.md
@@ -116,6 +116,9 @@ A simple, atomic value which has a consistent identity, and is stable enough to 
     * ipv6
     * mac_address
     * md5
+    * mutex
+    * ngfw_id
+    * ngfw_name
     * odns_identity
     * odns_identity_label
     * pki_serial

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -20,6 +20,12 @@
    :source "source"
    :source_uri "http://example.com"
    :sensor "endpoint.sensor"
+   :sensor_coordinates {:type "network.firewall"
+                        :observables [{:type "ip" :value "192.168.20.1"}
+                                      {:type "ngfw_id" :value "21bb0010-4a42-430a-a5dd-27876041f41f"}
+                                      {:type "ngfw_name" :value "cssp-stage-61"}
+                                      {:type "mac_address" :value "85:28:cb:6a:21:41"}]
+                        :os "Cisco Firepower Management Center for VMWare"}
    :targets [{:type "endpoint"
               :os "Windows 95"
               :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
@@ -28,8 +34,7 @@
                             {:type "amp_computer_guid" :value "68e94bf7-e239-4821-90d6-b7eaa0233443"}
                             {:type "ip" :value "100.213.110.122"}
                             {:type "ip" :value "136.184.130.98"}
-                            {:type "mac_address" :value "85:28:cb:6a:21:41"}]
-              :properties_data_tables "http://example.com/ctia/data-table/data-table-6e279a0d-6788-4cdf-957f-4e4b73823d6c"}]
+                            {:type "mac_address" :value "85:28:cb:6a:21:41"}]}]
    :confidence "High"
    :type "sighting"
    :schema_version c/ctim-schema-version

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -17,15 +17,23 @@
       :refer-macros
       [def-entity-type def-eq def-map-type]])]))
 
-(def-map-type SightingTarget
+(def-map-type TargetCoordinates
   (concat
    (f/required-entries
     (f/entry :type v/Sensor)
     (f/entry :observables [c/Observable])
     (f/entry :observed_time c/ObservedTime))
    (f/optional-entries
-    (f/entry :os f/any-str)
-    (f/entry :properties_data_tables rel/DataTableReference)))
+    (f/entry :os f/any-str)))
+  :description "Describes a target device where a sighting came from.")
+
+(def-map-type SensorCoordinates
+  (concat
+   (f/required-entries
+    (f/entry :type v/Sensor)
+    (f/entry :observables [c/Observable]))
+   (f/optional-entries
+    (f/entry :os f/any-str)))
   :description "Describes a target device where a sighting came from.")
 
 (def type-identifier "sighting")
@@ -59,7 +67,8 @@
             :description (str "The OpenC2 Actuator name that best fits the "
                               "device that is creating this sighting (e.g. "
                               "network.firewall)"))
-   (f/entry :targets (f/seq-of SightingTarget)
+   (f/entry :sensor_coordinates SensorCoordinates)
+   (f/entry :targets (f/seq-of TargetCoordinates)
             :description (str "The target device. Where the sighting came from."))
    (f/entry :observables [c/Observable]
             :description "The object(s) of interest")

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -25,7 +25,7 @@
     (f/entry :observed_time c/ObservedTime))
    (f/optional-entries
     (f/entry :os f/any-str)))
-  :description "Describes a target device where a sighting came from.")
+  :description "Describes the target of the sighting and contains identifying observables for the target.")
 
 (def-map-type SensorCoordinates
   (concat
@@ -34,7 +34,7 @@
     (f/entry :observables [c/Observable]))
    (f/optional-entries
     (f/entry :os f/any-str)))
-  :description "Describes a target device where a sighting came from.")
+  :description "Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.")
 
 (def type-identifier "sighting")
 

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -260,6 +260,8 @@
     "file_path"
     "odns_identity"
     "odns_identity_label"
+    "ngfw_id"
+    "ngfw_name"
     "email_messageid"
     "email_subject"
     "cisco_mid"


### PR DESCRIPTION
1. Added Sensor Coordinates in Sighting to hold details about the sensor that made the sighting such as ip, mac address etc. 
2. Added ngfw_id, ngfw_name to ObservableType vocabulary
3. Renamed SightingTarget to TargetCoordinates

No QA required