### PR TITLE
Fix the temporal_severity field of the Vulnerability entity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: clojure
 lein: lein
+dist: trusty
+
 script: lein do clean, test, doo phantom test once
+
 cache:
   directories:
   - $HOME/.m2
+
 jdk:
   - oraclejdk8

--- a/src/ctim/examples/vulnerabilities.cljc
+++ b/src/ctim/examples/vulnerabilities.cljc
@@ -32,7 +32,7 @@
                       :temporal_score 4.2
                       :environmental_score 4.2
                       :remediation_level "workaround"
-                      :temporal_severity 4.2
+                      :temporal_severity "medium"
                       :integrity_requirement "low"
                       :exploitability_score 0.8
                       :impact_score 5.9}

--- a/src/ctim/schemas/vulnerability.cljc
+++ b/src/ctim/schemas/vulnerability.cljc
@@ -237,7 +237,7 @@
                                "CVSSv3ExploitCodeMaturity × "
                                "CVSSv3RemediationLevel × "
                                "CVSSv3ReportConfidence)"))
-    (f/entry :temporal_severity Score
+    (f/entry :temporal_severity v/CVSSv3Severity
              :description "temporal severity")
 
     ;; requirements


### PR DESCRIPTION
Fix the Vulnerability entity

> Close threatgrid/iroh#2889

This PR sets the `temporal_severity` field as a `CVSSv3Severity`

<a name="qa">[§](#qa)</a> QA
============================

No QA needed

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
internal: Fix a the schema of the Vulnerability entity
```