### PR TITLE
Fix JS warnings produced by flanders and remove deps warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: clojure
 lein: lein
+dist: trusty
+
 script: lein do clean, test, doo phantom test once
+
 cache:
   directories:
   - $HOME/.m2
-jdk:
+
+  jdk:
   - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
   :resource-paths ["doc"]
 
   :plugins [[lein-cljsbuild "1.1.7"]
-            [lein-doo "0.1.10"]]
+            [lein-doo "0.1.10" :exclusions [org.clojure/clojure]]]
 
   :aliases  {"doc" ^{:doc "Generate documentation"} ["run" "-m" "ctim.document"]
              "gen" ^{:doc "Generate an example"} ["run" "-m" "ctim.generate"]}
@@ -59,6 +59,7 @@
 
                        :test {:source-paths ["src" "test"]
                               :compiler {:output-to "target/tests.js"
+                                         :language-in  :ecmascript5
                                          :optimizations :whitespace
                                          :main ctim.runner
                                          :pretty-print true}}}}


### PR DESCRIPTION
Fix warnings displayed when running the unit tests with `lein doo phantom test once` and some other deps warnings

> Close https://github.com/threatgrid/iroh/issues/2065

<a name="qa">[§](#qa)</a> QA
============================

No QA needed

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
internal: Remove warnings displayed when running then unit tests
```

