### PR TITLE
Adding new  indicator type for custom feed indicators

### DIFF
--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -111,7 +111,8 @@
     "Compromised PKI Certificate"
     "Login Name"
     "IMEI Watchlist"
-    "IMSI Watchlist"})
+    "IMSI Watchlist"
+    "PrivateThreatFeed"})
 
 (def-enum-type IndicatorType
   indicator-type


### PR DESCRIPTION
Adding a new indicator type called "PrivateThreatFeed" for custom feed indicators.