### PR TITLE
Iroh 3272 add assignees to incident

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -14,7 +14,7 @@ a few simplifications:
   * It's built on top of a "verdict service" so we simplify
   Observables into their most commonly observed properties.  You no
   longer have to say, "a file, with the sha256 checksum equal to X"
-  you would simply say, "a sha256 checksum".  We cross index
+  you would simple say, "a sha256 checksum".  We cross index
   everything on these observables, and distill the indicators down
   into verdicts that allow quick looking to see if an observable is
   of interest.

--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -8,6 +8,7 @@
     "timestamp" : "2016-01-01T01:01:01.000Z",
     "revision" : 10,
     "categories" : [ "string" ],
+    "assignees" : [ "string" ],
     "incident_time" : {
       "opened" : "2016-01-01T01:01:01.000Z",
       "discovered" : "2016-01-01T01:01:01.000Z",

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -22,6 +22,7 @@
       "timestamp" : "2016-01-01T01:01:01.000Z",
       "revision" : 10,
       "categories" : [ "string" ],
+      "assignees" : [ "string" ],
       "incident_time" : {
         "opened" : "2016-01-01T01:01:01.000Z",
         "discovered" : "2016-01-01T01:01:01.000Z",

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -5,6 +5,7 @@
   "timestamp" : "2016-01-01T01:01:01.000Z",
   "revision" : 10,
   "categories" : [ "string" ],
+  "assignees" : [ "string" ],
   "incident_time" : {
     "opened" : "2016-01-01T01:01:01.000Z",
     "discovered" : "2016-01-01T01:01:01.000Z",

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -3053,6 +3053,7 @@ A URL reference to an external resource
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity|&#10003;|
 |[status](#propertystatus-statusstring)|StatusString|current status of the incident|&#10003;|
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
+|[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|a set of owners assigned to this incident||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|a set of categories for this incident||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|identifies how the incident was discovered||
@@ -3068,6 +3069,17 @@ A URL reference to an external resource
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
 
+
+<a id="propertyassignees-shortstringstringlist"></a>
+## Property assignees ∷ ShortStringString List
+
+a set of owners assigned to this incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertycategories-incidentcategorystringlist"></a>
 ## Property categories ∷ IncidentCategoryString List

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -7543,6 +7543,7 @@ A URL reference to an external resource
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity|&#10003;|
 |[status](#propertystatus-statusstring)|StatusString|current status of the incident|&#10003;|
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
+|[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|a set of owners assigned to this incident||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|a set of categories for this incident||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|identifies how the incident was discovered||
@@ -7558,6 +7559,17 @@ A URL reference to an external resource
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
 
+
+<a id="propertyassignees-shortstringstringlist"></a>
+## Property assignees ∷ ShortStringString List
+
+a set of owners assigned to this incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertycategories-incidentcategorystringlist"></a>
 ## Property categories ∷ IncidentCategoryString List

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -12,6 +12,7 @@
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity|&#10003;|
 |[status](#propertystatus-statusstring)|StatusString|current status of the incident|&#10003;|
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
+|[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|a set of owners assigned to this incident||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|a set of categories for this incident||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|identifies how the incident was discovered||
@@ -27,6 +28,17 @@
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
 
+
+<a id="propertyassignees-shortstringstringlist"></a>
+## Property assignees ∷ ShortStringString List
+
+a set of owners assigned to this incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertycategories-incidentcategorystringlist"></a>
 ## Property categories ∷ IncidentCategoryString List

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [org.mozilla/rhino "1.7.7.1"] ;threatgrid/flanders > kovacnica/clojure.network.ip
                  [threatgrid/flanders "0.1.23"]
                  [metosin/ring-swagger "0.26.2"]
-                 [org.clojure/test.check "1.0.0"]
+                 [org.clojure/test.check "0.10.0"]
                  [com.gfredericks/test.chuck "0.2.10"]
                  [prismatic/schema-generators "0.1.3"]
                  [kovacnica/clojure.network.ip "0.1.3"]]
@@ -46,7 +46,7 @@
                                          :optimizations :whitespace
                                          :main ctim.runner
                                          :pretty-print true}}}}
-  :test-selectors {:no-gen (complement :gen)}
+  :test-selectors {:no-gen #(not (:gen %))}
   :global-vars {*warn-on-reflection* true}
   :profiles {:provided
              {:dependencies [;https://clojure.atlassian.net/browse/CLJS-3047

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -3,6 +3,7 @@
 
 (def incident-maximal
   {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+   :assignees ["fred@hogwarts.io" "fred@hogwarts.io"]
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :external_references

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -3,7 +3,7 @@
 
 (def incident-maximal
   {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
-   :assignees ["fred@hogwarts.io" "fred@hogwarts.io"]
+   :assignees ["fred@hogwarts.io" "george@hogwarts.io"]
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :external_references

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -3,7 +3,8 @@
 
 (def incident-maximal
   {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
-   :assignees ["fred@hogwarts.io" "george@hogwarts.io"]
+   :assignees ["84991efc-c4fd-4428-a4b6-6d841db76853"
+               "691858cd-8df6-4590-8452-8e23f65c6a16"]
    :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
                   "http://ex.tld/ctia/incident/incident-456"]
    :external_references

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -45,7 +45,9 @@
    (f/entry :discovery_method v/DiscoveryMethod
             :description "identifies how the incident was discovered")
    (f/entry :intended_effect v/IntendedEffect
-            :description "specifies the suspected intended effect of this incident")))
+            :description "specifies the suspected intended effect of this incident")
+   (f/entry :assignees [c/ShortString]
+            :description "a set of owners assigned to this incident")))
 
 (def-entity-type NewIncident
   "For submitting a new Incident"


### PR DESCRIPTION
Related threatgrid/iroh#3272

Used by ctia PR https://github.com/threatgrid/ctia/pull/885

- [x] run `lein doc` in this PR once https://github.com/threatgrid/ctim/pull/276 is merged.
- [x] change example owners to UUIDs

TODO: gen docs, merge into master, deploy snapshot