### PR TITLE
Deprecate fixture-fast-gen

### DIFF
--- a/test/ctim/generators/actor_test.clj
+++ b/test/ctim/generators/actor_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec actor/Actor
                    "test.actor")

--- a/test/ctim/generators/attack_pattern_test.clj
+++ b/test/ctim/generators/attack_pattern_test.clj
@@ -9,7 +9,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec sut/AttackPattern
                    "test.attack-pattern")

--- a/test/ctim/generators/campaign_test.clj
+++ b/test/ctim/generators/campaign_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec campaign/Campaign
                    "test.campaign")

--- a/test/ctim/generators/casebook_test.clj
+++ b/test/ctim/generators/casebook_test.clj
@@ -9,7 +9,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec sut/Casebook
                    "test.casebook")

--- a/test/ctim/generators/coa_test.clj
+++ b/test/ctim/generators/coa_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec coa/COA
                    "test.coa")

--- a/test/ctim/generators/feedback_test.clj
+++ b/test/ctim/generators/feedback_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec feedback/Feedback
                    "test.feedback")

--- a/test/ctim/generators/identity_assertion_test.clj
+++ b/test/ctim/generators/identity_assertion_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec identity-assertion/IdentityAssertion
                    "test.identity-assertion")

--- a/test/ctim/generators/incident_test.clj
+++ b/test/ctim/generators/incident_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec incident/Incident
                    "test.incident")

--- a/test/ctim/generators/indicator_test.clj
+++ b/test/ctim/generators/indicator_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec indicator/Indicator
                    "test.indicator")

--- a/test/ctim/generators/judgement_test.clj
+++ b/test/ctim/generators/judgement_test.clj
@@ -12,7 +12,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec judgement/Judgement
                    "test.judgement")

--- a/test/ctim/generators/malware_test.clj
+++ b/test/ctim/generators/malware_test.clj
@@ -9,7 +9,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec sut/Malware
                    "test.malware")

--- a/test/ctim/generators/relationship_test.clj
+++ b/test/ctim/generators/relationship_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec relationship/Relationship
                    "test.relationship")

--- a/test/ctim/generators/sighting_test.clj
+++ b/test/ctim/generators/sighting_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec sighting/Sighting
                    "test.sighting")

--- a/test/ctim/generators/tool_test.clj
+++ b/test/ctim/generators/tool_test.clj
@@ -9,7 +9,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec sut/Tool
                    "test.tool")

--- a/test/ctim/generators/verdict_test.clj
+++ b/test/ctim/generators/verdict_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec verdict/Verdict
                    "test.verdict")

--- a/test/ctim/generators/vulnerability_test.clj
+++ b/test/ctim/generators/vulnerability_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec vulnerability/Vulnerability
                    "test.vulnerability")

--- a/test/ctim/generators/weakness_test.clj
+++ b/test/ctim/generators/weakness_test.clj
@@ -10,7 +10,6 @@
 
 (use-fixtures :once
   th/fixture-spec-validation
-  th/fixture-fast-gen
   mth/fixture-schema-validation
   (th/fixture-spec weakness/Weakness
                    "test.weakness")

--- a/test/ctim/test_helpers/core.cljc
+++ b/test/ctim/test_helpers/core.cljc
@@ -26,7 +26,7 @@
 ; this function used to override gen/vector with
 ; a function with different behavior, which broke
 ; internal generator logic in test.check 0.10.0.
-(defn fixture-fast-gen [t]
+(defn ^{:deprecated "1.0.17"} fixture-fast-gen [t]
   (t))
 
 (defn rand-str [len]


### PR DESCRIPTION
Close #270 

This is follow-up work from https://github.com/threatgrid/ctim/pull/269