### PR TITLE
(On Hold) [TravisCI] Auto-deploy Snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ deploy:
     skip_cleanup: true
     script: ./script/ci-release.sh
     jdk: openjdk11
-    if: branch = master
+    if: branch = master && type = push
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ dist: trusty
 
 script: lein do clean, compile :all, test, doo phantom test once
 
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: ./script/ci-release.sh
+    jdk: openjdk11
+    if: branch = master
+
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ deploy:
     skip_cleanup: true
     script: ./script/ci-release.sh
     jdk: openjdk11
-    if: branch = master && type = push
+    if: repo = threatgrid/ctim && branch = master && type = push
 
 cache:
   directories:

--- a/project.clj
+++ b/project.clj
@@ -48,14 +48,25 @@
                                          :pretty-print true}}}}
   :test-selectors {:no-gen #(not (:gen %))}
   :global-vars {*warn-on-reflection* true}
-  :profiles {:deploy {:deploy-repositories [["snapshots" {:url "https://clojars.org/repo"
+  :profiles {;https://www.blog.nodrama.io/travis-continuous-delivery/
+             :deploy {:plugins [[lein-shell "0.5.0"]
+                                [lein-project-version "0.1.0"]]
+                      :deploy-repositories [["snapshots" {:url "https://clojars.org/repo"
                                                           :username :env/clojars_username
                                                           :password :env/clojars_password
                                                           :sign-releases false}]
                                             ["releases"  {:url "https://clojars.org/repo"
                                                           :username :env/clojars_username
                                                           :password :env/clojars_password
-                                                          :sign-releases false}]]}
+                                                          :sign-releases false}]]
+                      :release-tasks [["vcs" "assert-committed"]
+                                      ["change" "version" "leiningen.release/bump-version" "release"]
+                                      ["shell" "git" "commit" "-am" "Version ${:version} [ci skip]"]
+                                      ["vcs" "tag" "v" "--no-sign"]
+                                      ["deploy"]
+                                      ["change" "version" "leiningen.release/bump-version"]
+                                      ["shell" "git" "commit" "-am" "Version ${:version} [ci skip]"]
+                                      ["vcs" "push"]]}
              :provided
              {:dependencies [;https://clojure.atlassian.net/browse/CLJS-3047
                              [com.google.errorprone/error_prone_annotations "2.1.3"]

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,15 @@
                                          :pretty-print true}}}}
   :test-selectors {:no-gen #(not (:gen %))}
   :global-vars {*warn-on-reflection* true}
-  :profiles {:provided
+  :profiles {:deploy {:deploy-repositories [["snapshots" {:url "https://clojars.org/repo"
+                                                          :username :env/clojars_username
+                                                          :password :env/clojars_password
+                                                          :sign-releases false}]
+                                            ["releases"  {:url "https://clojars.org/repo"
+                                                          :username :env/clojars_username
+                                                          :password :env/clojars_password
+                                                          :sign-releases false}]]}
+             :provided
              {:dependencies [;https://clojure.atlassian.net/browse/CLJS-3047
                              [com.google.errorprone/error_prone_annotations "2.1.3"]
                              ;https://clojure.atlassian.net/browse/CLJS-3047

--- a/script/ci-release.sh
+++ b/script/ci-release.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PROJECT_VERSION=$(lein project-version)
+
+if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
+  lein with-profile +deploy deploy
+else
+  lein with-profile +deploy release :patch
+fi

--- a/script/ci-release.sh
+++ b/script/ci-release.sh
@@ -5,5 +5,6 @@ PROJECT_VERSION=$(lein project-version)
 if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
   lein with-profile +deploy deploy
 else
-  lein with-profile +deploy release :patch
+  echo "TravisCI release deployment not yet implemented, doing nothing."
+  #lein with-profile +deploy release :patch
 fi


### PR DESCRIPTION
Close #278 

This PR enables TravisCI to deploy snapshots to clojars.

*On hold*: Experimenting using this approach in https://github.com/threatgrid/flanders/issues/42

TravisCI lein releases are currently disabled because it's unclear how to push changes back to GitHub.

[threatgrid-clojars](https://clojars.org/users/threatgrid-clojars) is configured in the TravisCI build.