### PR TITLE
release 1.0.17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [prismatic/schema "1.1.12"]
                  [com.google.protobuf/protobuf-java "3.7.1"] ;clj-momo > org.clojure/clojurescript
                  [instaparse "1.4.8"] ;clj-momo > com.gfredericks/test.chuck
-                 [threatgrid/clj-momo "0.3.4"]
+                 [threatgrid/clj-momo "0.3.5"]
                  [org.mozilla/rhino "1.7.7.1"] ;threatgrid/flanders > kovacnica/clojure.network.ip
                  [threatgrid/flanders "0.1.23"]
                  [metosin/ring-swagger "0.26.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.0.17-SNAPSHOT"
+(defproject threatgrid/ctim "1.0.17"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Before merging this, waiting for a new version of clj-momo https://github.com/threatgrid/clj-momo/pull/69

This is part of https://github.com/threatgrid/ctia/pull/885 which uses both an updated ctim and clj-momo.

I will manually push a version to clojars once this is released.