### PR TITLE
fix: bundle schema and example for proper bundle import

### DIFF
--- a/src/ctim/examples/bundles.cljc
+++ b/src/ctim/examples/bundles.cljc
@@ -53,8 +53,11 @@
    :attack_pattern_refs     #{"http://ex.tld/ctia/attack-pattern/attack-pattern-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :attack_patterns         (set-of attack-pattern-maximal)
    :assets                  (set-of asset-maximal)
+   :asset_refs              #{"http://ex.tld/ctia/asset/asset-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :asset_mappings          (set-of asset-mapping-maximal)
+   :asset_mapping_refs      #{"http://ex.tld/ctia/asset-mapping/asset-mapping-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :asset_properties        (set-of asset-properties-maximal)
+   :asset_properties_refs   #{"http://ex.tld/ctia/asset-properties/asset-properties-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :campaign_refs           #{"http://ex.tld/ctia/campaign/campaign-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :campaigns               (set-of campaign-maximal)
    :coa_refs                #{"http://ex.tld/ctia/coa/coa-5023697b-3857-4652-9b53-ccda297f9c3e"}

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -6,9 +6,9 @@
                      NewAttackPattern]]
             [ctim.schemas.campaign
              :refer [Campaign CampaignRef NewCampaign]]
-            [ctim.schemas.asset :refer [Asset]]
-            [ctim.schemas.asset-mapping :refer [AssetMapping]]
-            [ctim.schemas.asset-properties :refer [AssetProperties]]
+            [ctim.schemas.asset :refer [Asset NewAsset AssetRef]]
+            [ctim.schemas.asset-mapping :refer [AssetMapping NewAssetMapping AssetMappingRef]]
+            [ctim.schemas.asset-properties :refer [AssetProperties NewAssetProperties AssetPropertiesRef]]
             [ctim.schemas.coa :refer [COA COARef NewCOA]]
             [ctim.schemas.data-table
              :refer [DataTable DataTableRef NewDataTable]]
@@ -89,11 +89,11 @@
   (f/optional-entries
    (f/entry :actors (f/set-of NewActor)
             :description "a list of `NewActor`")
-   (f/entry :assets (f/set-of Asset)
+   (f/entry :assets (f/set-of NewAsset)
             :description "a list of `Asset`")
-   (f/entry :asset_mappings (f/set-of AssetMapping)
+   (f/entry :asset_mappings (f/set-of NewAssetMapping)
             :description "a list of `AssetMapping`")
-   (f/entry :asset_properties (f/set-of AssetProperties)
+   (f/entry :asset_properties (f/set-of NewAssetProperties)
             :description "`AssetProperties`")
    (f/entry :attack_patterns (f/set-of NewAttackPattern)
             :description "a list of `NewAttackPattern`")
@@ -130,6 +130,9 @@
 
 (def references-entries
   (f/optional-entries
+   (f/entry :asset_refs (f/set-of AssetRef))
+   (f/entry :asset_mapping_refs (f/set-of AssetMappingRef))
+   (f/entry :asset_properties_refs (f/set-of AssetPropertiesRef))
    (f/entry :actor_refs (f/set-of ActorRef))
    (f/entry :attack_pattern_refs (f/set-of AttackPatternRef))
    (f/entry :campaign_refs (f/set-of CampaignRef))


### PR DESCRIPTION
earlier PR https://github.com/threatgrid/ctim/pull/294 included schema that breaks bundle-imports, this is the fix.