### PR TITLE
asset_mapping: align enums with existing vocabulary

### DIFF
--- a/src/ctim/examples/asset_mappings.cljc
+++ b/src/ctim/examples/asset_mappings.cljc
@@ -19,14 +19,13 @@
    :language            "language"
    :tlp                 "green"
 
-   :confidence  "high"
-   :specificity "unique"
-   :stability   "managed"
+   :confidence  "High"
+   :specificity "Unique"
+   :stability   "Managed"
    :valid_time  {:start_time #inst "2020-01-11T00:40:48.212-00:00"
                  :end_time   #inst "2525-01-01T00:00:00.000-00:00"}
    :observable  {:type "ip" :value "100.213.110.122"}
-   :asset_ref   "http://ex.tld/ctia/asset/asset-61884b14-e273-4930-a5ff-dcce69207724"
-   })
+   :asset_ref   "http://ex.tld/ctia/asset/asset-61884b14-e273-4930-a5ff-dcce69207724"})
 
 (def asset-mapping-minimal
   {:id             "http://ex.tld/ctia/asset-mapping/asset-mapping-668d86a2-02c1-499f-b953-5383be954aa6"
@@ -35,11 +34,10 @@
    :source         "cisco:unified_connect"
    :valid_time     {}
    :observable     {:type "ip" :value "100.213.110.122"}
-   :confidence     "high"
-   :specificity    "unique"
-   :stability      "managed"
-   :asset_ref      "http://ex.tld/ctia/asset/asset-61884b14-e273-4930-a5ff-dcce69207724"
-   })
+   :confidence     "High"
+   :specificity    "Unique"
+   :stability      "Managed"
+   :asset_ref      "http://ex.tld/ctia/asset/asset-61884b14-e273-4930-a5ff-dcce69207724"})
 
 (def new-asset-mapping-maximal asset-mapping-maximal)
 

--- a/src/ctim/schemas/asset_mapping.cljc
+++ b/src/ctim/schemas/asset_mapping.cljc
@@ -3,19 +3,17 @@
                :cljs [flanders.core :as f :refer-macros [def-entity-type def-eq def-enum-type]])
             [clojure.spec.alpha :as cs]
             [ctim.schemas.common :as c]
+            [ctim.schemas.vocabularies :as v]
             [ctim.schemas.asset :as asset]))
 
 (def ^:private mapping-type-identifier "asset-mapping")
 
 (def-eq AssetMappingTypeIdentifier mapping-type-identifier)
 
-(def confidence #{"high" "medium" "low"})
-(def-enum-type Confidence confidence :gen (cs/gen confidence))
-
-(def specificity #{"unique" "medium" "low"})
+(def specificity #{"Unique" "Medium" "Low"})
 (def-enum-type Specificity specificity :gen (cs/gen specificity))
 
-(def stability #{"managed" "physical" "temporary"})
+(def stability #{"Managed" "Physical" "Temporary"})
 (def-enum-type Stability stability :gen (cs/gen stability))
 
 (def ^:private mapping-desc "a record that a specific Observable maps to an Asset for a specific time period.")
@@ -29,7 +27,7 @@
   (f/required-entries
    (f/entry :type AssetMappingTypeIdentifier)
    (f/entry :valid_time c/ValidTime)
-   (f/entry :confidence Confidence)
+   (f/entry :confidence v/HighMedLow)
    (f/entry :specificity Specificity)
    (f/entry :stability Stability)
    (f/entry :observable c/Observable)


### PR DESCRIPTION
This PR proposes a slight modification of the vocabulary for `confidence`, `specificity` and `stability`:
- there is an existing vocabulary for `confidence` which, in addition of `High`/ `Medium` / `Low`, also contains `Unique`, `Info` and `Unknow`. This PR proposes to reuse it and to preserve the existing case: https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/vocabularies.cljc#L73
- existing vocabularies like `confidence` use a capitalized first letter, this PR proposes to follow this "convention".