### PR TITLE
revert asset related changes to bundle

### DIFF
--- a/src/ctim/examples/bundles.cljc
+++ b/src/ctim/examples/bundles.cljc
@@ -3,9 +3,6 @@
    [ctim.schemas.common :as c]
    [ctim.examples.actors :refer [actor-maximal]]
    [ctim.examples.attack-patterns :refer [attack-pattern-maximal]]
-   [ctim.examples.assets :refer [asset-maximal]]
-   [ctim.examples.asset-mappings :refer [asset-mapping-maximal]]
-   [ctim.examples.asset-properties :refer [asset-properties-maximal]]
    [ctim.examples.campaigns :refer [campaign-maximal]]
    [ctim.examples.coas :refer [coa-maximal]]
    [ctim.examples.data-tables :refer [data-table-maximal]]
@@ -52,18 +49,13 @@
    :actors                  (set-of actor-maximal)
    :attack_pattern_refs     #{"http://ex.tld/ctia/attack-pattern/attack-pattern-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :attack_patterns         (set-of attack-pattern-maximal)
-   :assets                  (set-of asset-maximal)
-   :asset_refs              #{"http://ex.tld/ctia/asset/asset-5023697b-3857-4652-9b53-ccda297f9c3e"}
-   :asset_mappings          (set-of asset-mapping-maximal)
-   :asset_mapping_refs      #{"http://ex.tld/ctia/asset-mapping/asset-mapping-5023697b-3857-4652-9b53-ccda297f9c3e"}
-   :asset_properties        (set-of asset-properties-maximal)
-   :asset_properties_refs   #{"http://ex.tld/ctia/asset-properties/asset-properties-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :campaign_refs           #{"http://ex.tld/ctia/campaign/campaign-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :campaigns               (set-of campaign-maximal)
    :coa_refs                #{"http://ex.tld/ctia/coa/coa-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :coas                    (set-of coa-maximal)
    :data_table_refs         #{"http://ex.tld/ctia/data-table/data-table-5023697b-3857-4652-9b53-ccda297f9c3e"}
-   :data_tables             (set-of data-table-maximal) :feedback_refs #{"http://ex.tld/ctia/feedback/feedback-5023697b-3857-4652-9b53-ccda297f9c3e"}
+   :data_tables             (set-of data-table-maximal)
+   :feedback_refs           #{"http://ex.tld/ctia/feedback/feedback-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :feedbacks               (set-of feedback-maximal)
    :incident_refs           #{"http://ex.tld/ctia/incident/incident-5023697b-3857-4652-9b53-ccda297f9c3e"}
    :incidents               (set-of incident-maximal)

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -6,9 +6,6 @@
                      NewAttackPattern]]
             [ctim.schemas.campaign
              :refer [Campaign CampaignRef NewCampaign]]
-            [ctim.schemas.asset :refer [Asset NewAsset AssetRef]]
-            [ctim.schemas.asset-mapping :refer [AssetMapping NewAssetMapping AssetMappingRef]]
-            [ctim.schemas.asset-properties :refer [AssetProperties NewAssetProperties AssetPropertiesRef]]
             [ctim.schemas.coa :refer [COA COARef NewCOA]]
             [ctim.schemas.data-table
              :refer [DataTable DataTableRef NewDataTable]]
@@ -46,12 +43,6 @@
   (f/optional-entries
    (f/entry :actors (f/set-of Actor)
             :description "a list of `Actor`")
-   (f/entry :assets (f/set-of Asset)
-            :description "a list of `Asset`")
-   (f/entry :asset_mappings (f/set-of AssetMapping)
-            :description "a list of `AssetMapping`")
-   (f/entry :asset_properties (f/set-of AssetProperties)
-            :description "`AssetProperties`")
    (f/entry :attack_patterns (f/set-of AttackPattern)
             :description "a list of `AttackPattern`")
    (f/entry :campaigns (f/set-of Campaign)
@@ -89,12 +80,6 @@
   (f/optional-entries
    (f/entry :actors (f/set-of NewActor)
             :description "a list of `NewActor`")
-   (f/entry :assets (f/set-of NewAsset)
-            :description "a list of `Asset`")
-   (f/entry :asset_mappings (f/set-of NewAssetMapping)
-            :description "a list of `AssetMapping`")
-   (f/entry :asset_properties (f/set-of NewAssetProperties)
-            :description "`AssetProperties`")
    (f/entry :attack_patterns (f/set-of NewAttackPattern)
             :description "a list of `NewAttackPattern`")
    (f/entry :campaigns (f/set-of NewCampaign)
@@ -130,9 +115,6 @@
 
 (def references-entries
   (f/optional-entries
-   (f/entry :asset_refs (f/set-of AssetRef))
-   (f/entry :asset_mapping_refs (f/set-of AssetMappingRef))
-   (f/entry :asset_properties_refs (f/set-of AssetPropertiesRef))
    (f/entry :actor_refs (f/set-of ActorRef))
    (f/entry :attack_pattern_refs (f/set-of AttackPatternRef))
    (f/entry :campaign_refs (f/set-of CampaignRef))


### PR DESCRIPTION
Closes: https://github.com/threatgrid/ctim/issues/305

after a discussion it was decided not to mix bundles and assets, asset mappings,
and asset properties