### PR TITLE
Issue-442: Add ms_machine_id and s1_agent_id observable types

### DIFF
--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4532,6 +4532,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -4543,6 +4544,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5829,6 +5831,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5840,6 +5843,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5892,6 +5896,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5903,6 +5908,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5970,6 +5976,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5981,6 +5988,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -6161,6 +6169,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -6172,6 +6181,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -6309,6 +6319,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -6320,6 +6331,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -6532,7 +6544,7 @@ A URL reference to an external resource
 <a id="map13"></a>
 # *IdentityAssertion* Object
 
-*IdentityAssertion* Context attributes about the target or any of its observables. 
+*IdentityAssertion* Context attributes about the target or any of its observables.
    Providers could provide different types of assertions regarding a target depending on their own capabilities
 
 | Property | Type | Description | Required? |
@@ -6864,6 +6876,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -6875,6 +6888,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -7421,6 +7435,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -7432,6 +7447,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -9372,7 +9388,7 @@ measures the impact to integrity of a successfully exploited vulnerability
 * This entry is optional
 
 
-  * *CVSSv3IntegrityImpact* This metric measures the impact to integrity of a successfully exploited vulnerability. Integrity refers to the trustworthiness and veracity of information. The list of possible values  is: `high`: There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component. `low`: Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is constrained. The data modification does not have a direct, serious impact on the impacted component.`none`: There is no loss of integrity within the impacted component.this metric value increases with the consequence to the impacted component. 
+  * *CVSSv3IntegrityImpact* This metric measures the impact to integrity of a successfully exploited vulnerability. Integrity refers to the trustworthiness and veracity of information. The list of possible values  is: `high`: There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component. `low`: Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is constrained. The data modification does not have a direct, serious impact on the impacted component.`none`: There is no loss of integrity within the impacted component.this metric value increases with the consequence to the impacted component.
   * Allowed Values:
     * high
     * low
@@ -9549,7 +9565,7 @@ Remediation Level of a vulnerability is an important factor for prioritization
 * This entry is optional
 
 
-  * *CVSSv3RemediationLevel* The Remediation Level of a vulnerability is an important factor for prioritization. The typical vulnerability is unpatched when initially published. Workarounds or hotfixes may offer interim remediation until an official patch or upgrade is issued. Each of these respective stages adjusts the temporal score downwards, reflecting the decreasing urgency as remediation becomes final. The list of possible values is: `not_defined`: Assigning this value to the metric will not influence the score. It is a signal to a scoring equation to skip this metric. `unavailable`: There is either no solution available or it is impossible to apply. `workaround`: There is an unofficial, non-vendor solution available. In some cases, users of the affected technology will create a patch of their own or provide steps to work around or otherwise mitigate the vulnerability. `temporary_fix`: There is an official but temporary fix available. This includes instances where the vendor issues a temporary hotfix, tool, or workaround.`official_fix`: A complete vendor solution is available. Either the vendor has issued an official patch, or an upgrade is available. The less official and permanent a fix, the higher the vulnerability score. 
+  * *CVSSv3RemediationLevel* The Remediation Level of a vulnerability is an important factor for prioritization. The typical vulnerability is unpatched when initially published. Workarounds or hotfixes may offer interim remediation until an official patch or upgrade is issued. Each of these respective stages adjusts the temporal score downwards, reflecting the decreasing urgency as remediation becomes final. The list of possible values is: `not_defined`: Assigning this value to the metric will not influence the score. It is a signal to a scoring equation to skip this metric. `unavailable`: There is either no solution available or it is impossible to apply. `workaround`: There is an unofficial, non-vendor solution available. In some cases, users of the affected technology will create a patch of their own or provide steps to work around or otherwise mitigate the vulnerability. `temporary_fix`: There is an official but temporary fix available. This includes instances where the vendor issues a temporary hotfix, tool, or workaround.`official_fix`: A complete vendor solution is available. Either the vendor has issued an official patch, or an upgrade is available. The less official and permanent a fix, the higher the vulnerability score.
   * Allowed Values:
     * high
     * not_defined

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -298,6 +298,7 @@ A URL reference to an external resource
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -309,6 +310,7 @@ A URL reference to an external resource
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -1385,7 +1387,7 @@ measures the impact to integrity of a successfully exploited vulnerability
 * This entry is optional
 
 
-  * *CVSSv3IntegrityImpact* This metric measures the impact to integrity of a successfully exploited vulnerability. Integrity refers to the trustworthiness and veracity of information. The list of possible values  is: `high`: There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component. `low`: Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is constrained. The data modification does not have a direct, serious impact on the impacted component.`none`: There is no loss of integrity within the impacted component.this metric value increases with the consequence to the impacted component. 
+  * *CVSSv3IntegrityImpact* This metric measures the impact to integrity of a successfully exploited vulnerability. Integrity refers to the trustworthiness and veracity of information. The list of possible values  is: `high`: There is a total loss of integrity, or a complete loss of protection. For example, the attacker is able to modify any/all files protected by the impacted component. Alternatively, only some files can be modified, but malicious modification would present a direct, serious consequence to the impacted component. `low`: Modification of data is possible, but the attacker does not have control over the consequence of a modification, or the amount of modification is constrained. The data modification does not have a direct, serious impact on the impacted component.`none`: There is no loss of integrity within the impacted component.this metric value increases with the consequence to the impacted component.
   * Allowed Values:
     * high
     * low
@@ -1562,7 +1564,7 @@ Remediation Level of a vulnerability is an important factor for prioritization
 * This entry is optional
 
 
-  * *CVSSv3RemediationLevel* The Remediation Level of a vulnerability is an important factor for prioritization. The typical vulnerability is unpatched when initially published. Workarounds or hotfixes may offer interim remediation until an official patch or upgrade is issued. Each of these respective stages adjusts the temporal score downwards, reflecting the decreasing urgency as remediation becomes final. The list of possible values is: `not_defined`: Assigning this value to the metric will not influence the score. It is a signal to a scoring equation to skip this metric. `unavailable`: There is either no solution available or it is impossible to apply. `workaround`: There is an unofficial, non-vendor solution available. In some cases, users of the affected technology will create a patch of their own or provide steps to work around or otherwise mitigate the vulnerability. `temporary_fix`: There is an official but temporary fix available. This includes instances where the vendor issues a temporary hotfix, tool, or workaround.`official_fix`: A complete vendor solution is available. Either the vendor has issued an official patch, or an upgrade is available. The less official and permanent a fix, the higher the vulnerability score. 
+  * *CVSSv3RemediationLevel* The Remediation Level of a vulnerability is an important factor for prioritization. The typical vulnerability is unpatched when initially published. Workarounds or hotfixes may offer interim remediation until an official patch or upgrade is issued. Each of these respective stages adjusts the temporal score downwards, reflecting the decreasing urgency as remediation becomes final. The list of possible values is: `not_defined`: Assigning this value to the metric will not influence the score. It is a signal to a scoring equation to skip this metric. `unavailable`: There is either no solution available or it is impossible to apply. `workaround`: There is an unofficial, non-vendor solution available. In some cases, users of the affected technology will create a patch of their own or provide steps to work around or otherwise mitigate the vulnerability. `temporary_fix`: There is an official but temporary fix available. This includes instances where the vendor issues a temporary hotfix, tool, or workaround.`official_fix`: A complete vendor solution is available. Either the vendor has issued an official patch, or an upgrade is available. The less official and permanent a fix, the higher the vulnerability score.
   * Allowed Values:
     * high
     * not_defined
@@ -3718,6 +3720,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -3729,6 +3732,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -4063,7 +4067,7 @@ A URL reference to an external resource
 <a id="map17"></a>
 # *IdentityAssertion* Object
 
-*IdentityAssertion* Context attributes about the target or any of its observables. 
+*IdentityAssertion* Context attributes about the target or any of its observables.
    Providers could provide different types of assertions regarding a target depending on their own capabilities
 
 | Property | Type | Description | Required? |
@@ -4395,6 +4399,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -4406,6 +4411,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5094,6 +5100,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5105,6 +5112,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5157,6 +5165,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5168,6 +5177,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5235,6 +5245,7 @@ Specification for how, and to whom, this object can be shared.
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5246,6 +5257,7 @@ Specification for how, and to whom, this object can be shared.
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5426,6 +5438,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5437,6 +5450,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -5574,6 +5588,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -5585,6 +5600,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -6716,6 +6732,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -6727,6 +6744,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -10449,5 +10467,3 @@ A URL reference to an external resource
 ## Property type ∷ String
 
 * This entry is required
-
-

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -352,6 +352,7 @@ A URL reference to an external resource
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -363,6 +364,7 @@ A URL reference to an external resource
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -683,6 +683,7 @@ If true, the row entries for this column cannot contain nulls. Defaults to true
     * ip
     * ipv6
     * mac_address
+    * ms_machine_id
     * md5
     * mutex
     * ngfw_id
@@ -695,6 +696,7 @@ If true, the row entries for this column cannot contain nulls. Defaults to true
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -875,6 +877,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -886,6 +889,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -938,6 +942,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -949,6 +954,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -1207,6 +1213,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -1218,6 +1225,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -1270,6 +1278,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -1281,6 +1290,7 @@ Time of the observation.  If the observation was made over a period of time, tha
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id
@@ -1307,5 +1317,3 @@ Time of the observation.  If the observation was made over a period of time, tha
 ## Property Keyword ∷ Anything
 
 * This entry is required
-
-

--- a/doc/structures/verdict.md
+++ b/doc/structures/verdict.md
@@ -119,6 +119,7 @@ The disposition_name field is optional, but is intended to be shown to a user.  
     * ipv6
     * mac_address
     * md5
+    * ms_machine_id
     * mutex
     * ngfw_id
     * ngfw_name
@@ -130,6 +131,7 @@ The disposition_name field is optional, but is intended to be shown to a user.  
     * registry_key
     * registry_name
     * registry_path
+    * s1_agent_id
     * sha1
     * sha256
     * swc_device_id

--- a/src/ctim/examples/casebooks.cljc
+++ b/src/ctim/examples/casebooks.cljc
@@ -5,6 +5,8 @@
 
 (def observables [{:type "hostname" :value "Demo_Cta"}
                   {:type "amp_computer_guid" :value "68e94bf7-e239-4821-90d6-b7eaa0233443"}
+                  {:type "ms_machine_id" :value "19de2b42b3ab0df8c15d117b7760ffa40da59d31"}
+                  {:type "s1_agent_id" :value "897194377714833828"}
                   {:type "ip" :value "100.213.110.122"}
                   {:type "ip" :value "136.184.130.98"}
                   {:type "mac_address" :value "85:28:cb:6a:21:41"}])

--- a/src/ctim/examples/identity_assertions.cljc
+++ b/src/ctim/examples/identity_assertions.cljc
@@ -20,6 +20,8 @@
    :source "source"
    :source_uri "http://example.com"
    :identity {:observables [{:type "amp_computer_guid" :value "68e94bf7-e239-4821-90d6-b7eaa0233443"}
+                            {:type "ms_machine_id" :value "19de2b42b3ab0df8c15d117b7760ffa40da59d31"}
+                            {:type "s1_agent_id" :value "897194377714833828"}
                             {:type "ip" :value "1.2.3.4"}]}
    :assertions [{:name "cisco:ctr:device:security_group" :value "employees"}
                 {:name "cisco:ctr:device:connector_version" :value "1.12.0 Mac Connector"}]

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -32,6 +32,8 @@
                               :end_time #inst "2016-02-11T00:40:48.212-00:00"}
               :observables [{:type "hostname" :value "Demo_Cta"}
                             {:type "amp_computer_guid" :value "68e94bf7-e239-4821-90d6-b7eaa0233443"}
+                            {:type "ms_machine_id" :value "19de2b42b3ab0df8c15d117b7760ffa40da59d31"}
+                            {:type "s1_agent_id" :value "897194377714833828"}
                             {:type "ip" :value "100.213.110.122"}
                             {:type "ip" :value "136.184.130.98"}
                             {:type "mac_address" :value "85:28:cb:6a:21:41"}]}]

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -255,6 +255,8 @@
     "imei"
     "imsi"
     "amp_computer_guid"
+    "ms_machine_id" ;; Microsoft Windows Defender Machine ID
+    "s1_agent_id" ;; Sentinel One Agent ID
     "orbital_node_id"
     "hostname"
     "mac_address"


### PR DESCRIPTION
Necessary to add support for third party host ID observables - https://github.com/threatgrid/hydrant/issues/442

This `adds ms_machine_id` and `s1_agent_id` observable types. 