### PR TITLE
add codeowners to avoid changes that can break CTIA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global codeowners
+* @saintx @gbuisson @yogsototh @msprunck @ereteog @frenchy64


### PR DESCRIPTION
The main goal is to automatically add owners as reviewers to prevent breaking changes in CTIA.
I added historical maintainers and main CTIA contibutors.