### PR TITLE
make actor, attack-pattern, campaign, malware and tool  described entitties

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.0.24-SNAPSHOT"
+(defproject threatgrid/ctim "1.1.0-SNAPSHOT"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/src/ctim/examples/actors.cljc
+++ b/src/ctim/examples/actors.cljc
@@ -44,8 +44,11 @@
   {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
    :type "actor"
    :schema_version c/ctim-schema-version
-   :actor_type "Hacker",
-   :confidence "High",
+   :title "title"
+   :description "description"
+   :short_description "short description"
+   :actor_type "Hacker"
+   :confidence "High"
    :source "a source"
    :valid_time {}})
 
@@ -53,6 +56,9 @@
   actor-maximal)
 
 (def new-actor-minimal
-  {:actor_type "Hacker",
-   :confidence "High",
+  {:actor_type "Hacker"
+   :title "title"
+   :description "description"
+   :short_description "short description"
+   :confidence "High"
    :source "a source"})

--- a/src/ctim/examples/attack_patterns.cljc
+++ b/src/ctim/examples/attack_patterns.cljc
@@ -19,8 +19,9 @@
    :tlp "green"
    :source "source"
    :source_uri "http://example.com"
-   :name "Bootkit"
+   :title "Bootkit"
    :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"
+   :short_description "A bootkit modifies the boot sectors of a hard drive"
    :abstraction_level "standard"
    :kill_chain_phases [{:kill_chain_name "mitre-attack"
                         :phase_name "persistence"}]
@@ -32,12 +33,14 @@
   {:id "http://ex.tld/ctia/attack-pattern/attack-pattern-6c5a8540-cec7-4647-abb6-84cd2d2fa544"
    :type "attack-pattern"
    :schema_version c/ctim-schema-version
-   :name "Bootkit"
-   :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"})
+   :title "Bootkit"
+   :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"
+   :short_description "A bootkit modifies the boot sectors of a hard drive"})
 
 (def new-attack-pattern-maximal
   attack-pattern-maximal)
 
 (def new-attack-pattern-minimal
-  {:name "Bootkit"
-   :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"})
+  {:title "Bootkit"
+   :description "A bootkit is a malware variant that modifies the boot sectors of a hard drive"
+   :short_description "A bootkit modifies the boot sectors of a hard drive"})

--- a/src/ctim/examples/campaigns.cljc
+++ b/src/ctim/examples/campaigns.cljc
@@ -36,6 +36,9 @@
   {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
    :type "campaign"
    :schema_version c/ctim-schema-version
+   :title "campaign"
+   :description "description"
+   :short_description "short description"
    :campaign_type "anything goes here"
    :valid_time {}})
 
@@ -71,4 +74,7 @@
                :description "activity"}]})
 
 (def new-campaign-minimal
-  {:campaign_type "anything goes here"})
+  {:title "campaign"
+   :description "description"
+   :short_description "short description"
+   :campaign_type "anything goes here"})

--- a/src/ctim/examples/malwares.cljc
+++ b/src/ctim/examples/malwares.cljc
@@ -19,9 +19,10 @@
    :tlp "green"
    :source "source"
    :source_uri "http://example.com"
-   :name "TinyZBot"
    :labels ["malware"]
+   :title "TinyZBot"
    :description "TinyZBot is a bot written in C# that was developed by Cleaver."
+   :short_description "A bot developed by Cleaver."
    :kill_chain_phases [{:kill_chain_name "mitre-attack"
                         :phase_name "persistence"}]
    :x_mitre_aliases ["KleinZBot"]
@@ -31,12 +32,16 @@
   {:id "http://ex.tld/ctia/malware/malware-616608f4-7658-49f1-8728-d9a3dde849d5"
    :type "malware"
    :schema_version c/ctim-schema-version
-   :name "TinyZBot"
+   :title "TinyZBot"
+   :description "TinyZBot is a bot written in C# that was developed by Cleaver."
+   :short_description "A bot developed by Cleaver."
    :labels ["malware"]})
 
 (def new-malware-maximal
   malware-maximal)
 
 (def new-malware-minimal
-  {:name "TinyZBot"
+  {:title "TinyZBot"
+   :description "TinyZBot is a bot written in C# that was developed by Cleaver."
+   :short_description "A bot developed by Cleaver."
    :labels ["malware"]})

--- a/src/ctim/examples/tools.cljc
+++ b/src/ctim/examples/tools.cljc
@@ -19,9 +19,10 @@
    :tlp "green"
    :source "source"
    :source_uri "http://example.com"
-   :name "cmd"
+   :title "cmd"
    :labels ["tool"]
    :description "cmd is the Windows command-line interpreter"
+   :short_description "Windows command-line interpreter"
    :kill_chain_phases [{:kill_chain_name "mitre-attack"
                         :phase_name "persistence"}]
    :tool_version "2.5.3"
@@ -31,12 +32,16 @@
   {:id "http://ex.tld/ctia/tool/tool-0663cefa-c8f0-48c2-aefd-e9fbf84551ce"
    :type "tool"
    :schema_version c/ctim-schema-version
-   :name "cmd"
+   :title "cmd"
+   :description "cmd is the Windows command-line interpreter"
+   :short_description "Windows command-line interpreter"
    :labels ["tool"]})
 
 (def new-tool-maximal
   tool-maximal)
 
 (def new-tool-minimal
-  {:name "cmd"
+  {:title "cmd"
+   :description "cmd is the Windows command-line interpreter"
+   :short_description "Windows command-line interpreter"
    :labels ["tool"]})

--- a/src/ctim/schemas/actor.cljc
+++ b/src/ctim/schemas/actor.cljc
@@ -20,7 +20,7 @@
    :reference actor-desc-link}
   c/base-entity-entries
   c/sourced-object-entries
-  c/describable-entity-entries
+  c/described-entity-entries
   (f/required-entries
    (f/entry :type ActorTypeIdentifier)
    (f/entry :valid_time c/ValidTime)

--- a/src/ctim/schemas/attack_pattern.cljc
+++ b/src/ctim/schemas/attack_pattern.cljc
@@ -20,14 +20,9 @@
    :reference attack-pattern-desc-link}
   c/base-entity-entries
   c/sourcable-object-entries
+  c/described-entity-entries
   (f/required-entries
-   (f/entry :type AttackPatternTypeIdentifier)
-   (f/entry :name c/ShortString
-            :description "A name used to identify the Attack Pattern.")
-   (f/entry :description c/Markdown
-            :description (str "A description that provides more details and "
-                              "context about the Attack Pattern, potentially "
-                              "including its purpose and its key characteristics.")))
+   (f/entry :type AttackPatternTypeIdentifier))
   (f/optional-entries
    (f/entry :external_references [c/ExternalReference]
             :description (str "A list of external references which refer to "

--- a/src/ctim/schemas/campaign.cljc
+++ b/src/ctim/schemas/campaign.cljc
@@ -19,7 +19,7 @@
   {:description campaign-desc
    :reference campaign-desc-link}
   c/base-entity-entries
-  c/describable-entity-entries
+  c/described-entity-entries
   c/sourcable-object-entries
   (f/required-entries
    (f/entry :type CampaignTypeIdentifier)

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -20,7 +20,7 @@
             [flanders.predicates :as fp]
             [clojure.string :as str]))
 
-(def ctim-schema-version "1.0.24")
+(def ctim-schema-version "1.1.0")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 
@@ -221,6 +221,15 @@
              :description "A valid entity type identifer")
     (f/entry :schema_version CTIMSchemaVersion
              :description "CTIM schema version for this entity"))))
+
+(def described-entity-entries
+  "Fields for described entities"
+  [(f/entry :title ShortString
+           :description "A short title for this object, used as primary display and reference value")
+  (f/entry :description Markdown
+           :description "A description of object, which may be detailed.")
+  (f/entry :short_description MedString
+           :description "A single line, short summary of the object.")])
 
 (def describable-entity-entries
   "These fields for describable entities"

--- a/src/ctim/schemas/malware.cljc
+++ b/src/ctim/schemas/malware.cljc
@@ -26,17 +26,12 @@
    :reference malware-desc-link}
   c/base-entity-entries
   c/sourcable-object-entries
+  c/describable-entity-entries
   (f/required-entries
    (f/entry :type MalwareTypeIdentifier)
-   (f/entry :name c/ShortString
-            :description "A name used to identify the Malware sample.")
    (f/entry :labels [v/MalwareLabel]
             :description "The type of malware being described."))
   (f/optional-entries
-   (f/entry :description c/Markdown
-            :description (str "A description that provides more details and "
-                              "context about the Malware, potentially including "
-                              "its purpose and its key characteristics."))
    (f/entry :kill_chain_phases [c/KillChainPhase]
             :description (str "The list of Kill Chain Phases for which this "
                               "Malware can be used."))

--- a/src/ctim/schemas/tool.cljc
+++ b/src/ctim/schemas/tool.cljc
@@ -26,17 +26,12 @@
    :reference tool-desc-link}
   c/base-entity-entries
   c/sourcable-object-entries
+  c/described-entity-entries
   (f/required-entries
    (f/entry :type ToolTypeIdentifier)
-   (f/entry :name c/ShortString
-            :description "The name used to identify the Tool.")
    (f/entry :labels [v/ToolLabel]
             :description "The kind(s) of tool(s) being described."))
   (f/optional-entries
-   (f/entry :description c/Markdown
-            :description (str "A description that provides more details and "
-                              "context about the Tool, potentially including "
-                              "its purpose and its key characteristics."))
    (f/entry :kill_chain_phases [c/KillChainPhase]
             :description (str "The list of kill chain phases for which this "
                               "Tool can be used."))


### PR DESCRIPTION
> related #https://github.com/threatgrid/iroh/issues/4058

Adds `described-entity-entries`, the required fields couterpart of `describable-entity-entries`.
Make `described-entity-entries` to `malware`, `tool` and `attack-pattern` entities, by replacing `name` by `title`.
Replace `describable-entity-entries` by `described-entity-entries` in `campaign` and `actor`, which makes `title`, `description` and `short_description` required.

A PR is coming in CTIA with corresponding migration (concerned indices are small).