### PR TITLE
Vulnerability CVSSv3 Update

### DIFF
--- a/src/ctim/schemas/vulnerability.cljc
+++ b/src/ctim/schemas/vulnerability.cljc
@@ -37,7 +37,7 @@
    #?(:clj gen/score)))
 
 (def cvss-v3-vector-string-exp
-  (re-pattern "^CVSS:3.0/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"))
+  (re-pattern "^CVSS:(3.0|3.1)/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"))
 
 
 (comment


### PR DESCRIPTION
CVSS Version 3 Strings are now formatted as follows-
'CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H'
resulting in failures in the validation of this string during
vulnerability posting via hydrant importers.

Current validation expects exclusivly 'CVSS:3.0...'. This work
allows for either `3.0` or `3.1` for the version and adds an
example.

Hydrant Issue 536
IROH Issue 4729