### PR TITLE
Release 1.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.0"
+(defproject threatgrid/ctim "1.1.1-SNAPSHOT"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.0-SNAPSHOT"
+(defproject threatgrid/ctim "1.1.0"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
bump version.
2 commits: [1.1.0](https://github.com/threatgrid/ctim/commit/92d9142e85f1ec0f6bfdc961f60a17fd9ec1494d) and [1.1.1-SNAPSHOT](https://github.com/threatgrid/ctim/commit/482e30f9a085db7ffc55a1b3b87d6cb5581c2d84).