### PR TITLE
Bump `ctim-schema-version` to 1.1.3

### DIFF
--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -20,7 +20,7 @@
             [flanders.predicates :as fp]
             [clojure.string :as str]))
 
-(def ctim-schema-version "1.1.0")
+(def ctim-schema-version "1.1.3")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 

--- a/src/ctim/schemas/malware.cljc
+++ b/src/ctim/schemas/malware.cljc
@@ -26,7 +26,7 @@
    :reference malware-desc-link}
   c/base-entity-entries
   c/sourcable-object-entries
-  c/describable-entity-entries
+  c/described-entity-entries
   (f/required-entries
    (f/entry :type MalwareTypeIdentifier)
    (f/entry :labels [v/MalwareLabel]


### PR DESCRIPTION
- Bump `ctim-schema-version` to 1.1.3 
- fix malware schema: `describable` -> `described`.