### PR TITLE
Release 1.1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.4-SNAPSHOT"
+(defproject threatgrid/ctim "1.1.4"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.3"
+(defproject threatgrid/ctim "1.1.4-SNAPSHOT"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.3-SNAPSHOT"
+(defproject threatgrid/ctim "1.1.3"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/ctim "1.1.4"
+(defproject threatgrid/ctim "1.1.5-SNAPSHOT"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
> #related https://github.com/threatgrid/iroh/issues/4058
> #related https://github.com/threatgrid/ctia/pull/1065#issuecomment-778367584

Release [malware schema](https://github.com/threatgrid/ctim/pull/330) and fix CTIM version bump.

I messed this one, I pushed the release before the rebase and I did not have the proper changes. So 4 commits and 2 releases.