### PR TITLE
Issue-338: Add promotion_method field to indicent model

### DIFF
--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -48,6 +48,7 @@
     "discovery_method" : "string",
     "status" : "string",
     "short_description" : "string",
+    "promotion_method" : "string",
     "schema_version" : "string",
     "title" : "string",
     "source" : "string",

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -62,6 +62,7 @@
       "discovery_method" : "string",
       "status" : "string",
       "short_description" : "string",
+      "promotion_method" : "string",
       "schema_version" : "string",
       "title" : "string",
       "source" : "string",

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -17,6 +17,7 @@
   "discovery_method" : "string",
   "status" : "string",
   "short_description" : "string",
+  "promotion_method" : "string",
   "schema_version" : "string",
   "title" : "string",
   "source" : "string",

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4135,6 +4135,7 @@ A URL reference to an external resource
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
+|[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -4315,6 +4316,18 @@ The human language this object is specified in.
 
 
   * *ShortString* String with at most 1024 characters
+
+<a id="propertypromotion_method-promotionmethodstring"></a>
+## Property promotion_method ∷ PromotionMethodString
+
+identifies how the incident was promoted
+
+* This entry is optional
+
+
+  * Allowed Values:
+    * automated
+    * manual
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -5703,22 +5716,22 @@ A URL reference to an external resource
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
+|[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.|&#10003;|
 |[id](#propertyid-string)|String|Globally unique URI identifying this object.|&#10003;|
 |[labels](#propertylabels-malwarelabelstringlist)|MalwareLabelString List|The type of malware being described.|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity|&#10003;|
+|[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.|&#10003;|
+|[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value|&#10003;|
 |[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-malwareabstractionsstring)|MalwareAbstractionsString|Malware abstraction level||
-|[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List| ||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
-|[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
 |[source_uri](#propertysource_uri-string)|String| ||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
-|[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
 |[x_mitre_aliases](#propertyx_mitre_aliases-shortstringstringlist)|ShortStringString List|ATT&CK Software.aliases||
 
@@ -5743,7 +5756,7 @@ Malware abstraction level
 
 A description of object, which may be detailed.
 
-* This entry is optional
+* This entry is required
 
 
   * *Markdown* Markdown string with at most 5000 characters
@@ -5857,7 +5870,7 @@ CTIM schema version for this entity
 
 A single line, short summary of the object.
 
-* This entry is optional
+* This entry is required
 
 
   * *MedString* String with at most 2048 characters
@@ -5893,7 +5906,7 @@ The time this object was created at, or last modified.
 
 A short title for this object, used as primary display and reference value
 
-* This entry is optional
+* This entry is required
 
 
   * *ShortString* String with at most 1024 characters

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -6933,22 +6933,22 @@ A URL reference to an external resource
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
+|[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.|&#10003;|
 |[id](#propertyid-string)|String|Globally unique URI identifying this object.|&#10003;|
 |[labels](#propertylabels-malwarelabelstringlist)|MalwareLabelString List|The type of malware being described.|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity|&#10003;|
+|[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.|&#10003;|
+|[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value|&#10003;|
 |[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-malwareabstractionsstring)|MalwareAbstractionsString|Malware abstraction level||
-|[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List| ||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
-|[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
 |[source_uri](#propertysource_uri-string)|String| ||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
-|[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
 |[x_mitre_aliases](#propertyx_mitre_aliases-shortstringstringlist)|ShortStringString List|ATT&CK Software.aliases||
 
@@ -6973,7 +6973,7 @@ Malware abstraction level
 
 A description of object, which may be detailed.
 
-* This entry is optional
+* This entry is required
 
 
   * *Markdown* Markdown string with at most 5000 characters
@@ -7087,7 +7087,7 @@ CTIM schema version for this entity
 
 A single line, short summary of the object.
 
-* This entry is optional
+* This entry is required
 
 
   * *MedString* String with at most 2048 characters
@@ -7123,7 +7123,7 @@ The time this object was created at, or last modified.
 
 A short title for this object, used as primary display and reference value
 
-* This entry is optional
+* This entry is required
 
 
   * *ShortString* String with at most 1024 characters
@@ -8439,6 +8439,7 @@ A URL reference to an external resource
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
+|[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -8619,6 +8620,18 @@ The human language this object is specified in.
 
 
   * *ShortString* String with at most 1024 characters
+
+<a id="propertypromotion_method-promotionmethodstring"></a>
+## Property promotion_method ∷ PromotionMethodString
+
+identifies how the incident was promoted
+
+* This entry is optional
+
+
+  * Allowed Values:
+    * automated
+    * manual
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -20,6 +20,7 @@
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
+|[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -200,6 +201,18 @@ The human language this object is specified in.
 
 
   * *ShortString* String with at most 1024 characters
+
+<a id="propertypromotion_method-promotionmethodstring"></a>
+## Property promotion_method ∷ PromotionMethodString
+
+identifies how the incident was promoted
+
+* This entry is optional
+
+
+  * Allowed Values:
+    * automated
+    * manual
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -35,6 +35,7 @@
                    :closed #inst "2016-02-11T00:40:48.212-00:00"
                    :rejected #inst "2016-02-11T00:40:48.212-00:00"}
    :discovery_method "Log Review"
+   :promotion_method "Manual"
    :intended_effect "Extortion"})
 
 (def incident-minimal

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -47,7 +47,9 @@
    (f/entry :intended_effect v/IntendedEffect
             :description "specifies the suspected intended effect of this incident")
    (f/entry :assignees [c/ShortString]
-            :description "a set of owners assigned to this incident")))
+            :description "a set of owners assigned to this incident")
+   (f/entry :promotion_method v/PromotionMethod
+            :description "identifies how the incident was promoted")))
 
 (def-entity-type NewIncident
   "For submitting a new Incident"

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -81,7 +81,7 @@
 (def-enum-type HighMedLow
   high-med-low
   :reference (str "[HighMedLowVocab](http://stixproject.github.io/"
-                           "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)"))
+                  "data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)"))
 
 (def incident-category
   #{"Exercise/Network Defense Testing"
@@ -1487,3 +1487,9 @@
        "three possible values: low, medium, or high.")
   :default "not_defined"
   :reference "https://www.first.org/cvss/v2/guide#2-3-3-Security-Requirements-CR-IR-AR")
+
+(def promotion-method #{"Manual" "Automated"})
+
+(def-enum-type PromotionMethod promotion-method
+  :open? false
+  :gen (cs/gen promotion-method))


### PR DESCRIPTION
Adds the promotion_method field to the incident model. The
values for the field are a closed vocabulary of either `manual`
or `automated`.