### PR TITLE
`sighting-of` valid `relationship_type`

### DIFF
--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -1,7 +1,6 @@
 <a id="top"></a>
 # *Bundle* Object
 
-
 *Bundle* Describes a Bundle of any set of CTIM entities
 
 | Property | Type | Description | Required? |
@@ -6182,6 +6181,7 @@ The human language this object is specified in.
     * member-of
     * mitigates
     * related-to
+    * sighting-of
     * targets
     * uses
     * variant-of

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -6763,6 +6763,7 @@ The human language this object is specified in.
     * member-of
     * mitigates
     * related-to
+    * sighting-of
     * targets
     * uses
     * variant-of

--- a/doc/structures/relationship.md
+++ b/doc/structures/relationship.md
@@ -93,6 +93,7 @@ The human language this object is specified in.
     * member-of
     * mitigates
     * related-to
+    * sighting-of
     * targets
     * uses
     * variant-of

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -415,15 +415,16 @@
 (def relationship-type
   #{"attributed-to"
     "based-on"
-    "duplicate-of"
     "derived-from"
     "detects"
+    "duplicate-of"
     "element-of"
     "exploits"
     "indicates"
     "member-of"
     "mitigates"
     "related-to"
+    "sighting-of"
     "targets"
     "uses"
     "variant-of"})


### PR DESCRIPTION
This PR adds `sighting-of` as a valid `relationship_type` value.  `sighting-of` is mentioned in the [defined_relationships.md](https://github.com/threatgrid/ctim/blob/master/doc/defined_relationships.md) doc but was not included in the list of valid values