### PR TITLE
Issue 336: Adding Kenna Risk Scores to Mitre Attack Patterns

### DIFF
--- a/doc/json/attack_pattern.json
+++ b/doc/json/attack_pattern.json
@@ -16,6 +16,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "risk_score" : 1,
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/structures/attack_pattern.md
+++ b/doc/structures/attack_pattern.md
@@ -24,6 +24,8 @@
 |[x_mitre_contributors](#propertyx_mitre_contributors-shortstringstringlist)|ShortStringString List|ATT&CK Technique.Contributors||
 |[x_mitre_data_sources](#propertyx_mitre_data_sources-shortstringstringlist)|ShortStringString List|ATT&CK Technique.Data Sources||
 |[x_mitre_platforms](#propertyx_mitre_platforms-shortstringstringlist)|ShortStringString List|ATT&CK Technique.Platforms||
+|[risk_score](#propertyrisk_score-integer)|Integer|A 0-100 score determine by Kenna Risk Analysis||
+
 
 * Reference: [Attack Pattern](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.axjijf603msy)
 
@@ -230,6 +232,15 @@ ATT&CK Technique.Platforms
 
 
   * *ShortString* String with at most 1024 characters
+
+<a id="propertyrisk_score-integer"></a>
+## Risk Score ∷ Integer
+
+* This entry is optional
+* A 0-100 score determine by Kenna Risk Analysis.
+
+  * Zero, or a positive integer
+
 
 <a id="map1"></a>
 # *ExternalReference* Object

--- a/src/ctim/schemas/attack_pattern.cljc
+++ b/src/ctim/schemas/attack_pattern.cljc
@@ -41,6 +41,8 @@
             :description "ATT&CK Technique.Platforms")
    (f/entry :x_mitre_contributors [c/ShortString]
             :description "ATT&CK Technique.Contributors")
+   (f/entry :risk_score c/PosInt
+            :description "A 0-100 Integer value from Kenna Risk Assessment")
    (f/entry :abstraction_level v/AttackPatternAbstractions
             :description "The CAPEC abstraction level for patterns describing techniques to attack a system.")))
 


### PR DESCRIPTION
⚠️ Seeking feedback: are there any other places within CTIM that require change for an optional feed addition?

This work adds an optional field of `risk_score` to the
`attack_pattern` schema. Possible values are PosInts.

Resolves #336