### PR TITLE
Add tactics/techniques field to incident

### DIFF
--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -32,10 +32,12 @@
   "incidents" : [ {
     "confidence" : "string",
     "tlp" : "string",
+    "techniques" : [ "string" ],
     "id" : "string",
     "timestamp" : "2016-01-01T01:01:01.000Z",
     "revision" : 10,
     "categories" : [ "string" ],
+    "tactics" : [ "string" ],
     "assignees" : [ "string" ],
     "incident_time" : {
       "opened" : "2016-01-01T01:01:01.000Z",

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -46,10 +46,12 @@
     "incidents" : [ {
       "confidence" : "string",
       "tlp" : "string",
+      "techniques" : [ "string" ],
       "id" : "string",
       "timestamp" : "2016-01-01T01:01:01.000Z",
       "revision" : 10,
       "categories" : [ "string" ],
+      "tactics" : [ "string" ],
       "assignees" : [ "string" ],
       "incident_time" : {
         "opened" : "2016-01-01T01:01:01.000Z",

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -1,10 +1,12 @@
 {
   "confidence" : "string",
   "tlp" : "string",
+  "techniques" : [ "string" ],
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
   "revision" : 10,
   "categories" : [ "string" ],
+  "tactics" : [ "string" ],
   "assignees" : [ "string" ],
   "incident_time" : {
     "opened" : "2016-01-01T01:01:01.000Z",

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4145,6 +4145,8 @@ A URL reference to an external resource
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
 |[source_uri](#propertysource_uri-string)|String| ||
+|[tactics](#propertytactics-shortstringstringlist)|ShortStringString List|specifies the list of tactic ids (ex: mitre tactic id) of an Incident||
+|[techniques](#propertytechniques-shortstringstringlist)|ShortStringString List|specifies the list of technique ids (ex: mitre technique id) of an Incident||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
@@ -4414,6 +4416,28 @@ current status of the incident
     * Rejected
     * Restoration Achieved
     * Stalled
+
+<a id="propertytactics-shortstringstringlist"></a>
+## Property tactics ∷ ShortStringString List
+
+specifies the list of tactic ids (ex: mitre tactic id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
+
+<a id="propertytechniques-shortstringstringlist"></a>
+## Property techniques ∷ ShortStringString List
+
+specifies the list of technique ids (ex: mitre technique id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -8459,6 +8459,8 @@ A URL reference to an external resource
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
 |[source_uri](#propertysource_uri-string)|String| ||
+|[tactics](#propertytactics-shortstringstringlist)|ShortStringString List|specifies the list of tactic ids (ex: mitre tactic id) of an Incident||
+|[techniques](#propertytechniques-shortstringstringlist)|ShortStringString List|specifies the list of technique ids (ex: mitre technique id) of an Incident||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
@@ -8728,6 +8730,28 @@ current status of the incident
     * Rejected
     * Restoration Achieved
     * Stalled
+
+<a id="propertytactics-shortstringstringlist"></a>
+## Property tactics ∷ ShortStringString List
+
+specifies the list of tactic ids (ex: mitre tactic id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
+
+<a id="propertytechniques-shortstringstringlist"></a>
+## Property techniques ∷ ShortStringString List
+
+specifies the list of technique ids (ex: mitre technique id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -29,6 +29,8 @@
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
 |[source_uri](#propertysource_uri-string)|String| ||
+|[tactics](#propertytactics-shortstringstringlist)|ShortStringString List|specifies the list of tactic ids (ex: mitre tactic id) of an Incident||
+|[techniques](#propertytechniques-shortstringstringlist)|ShortStringString List|specifies the list of technique ids (ex: mitre technique id) of an Incident||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value||
 |[tlp](#propertytlp-tlpstring)|TLPString|Specification for how, and to whom, this object can be shared.||
@@ -298,6 +300,28 @@ current status of the incident
     * Rejected
     * Restoration Achieved
     * Stalled
+
+<a id="propertytactics-shortstringstringlist"></a>
+## Property tactics ∷ ShortStringString List
+
+specifies the list of tactic ids (ex: mitre tactic id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
+
+<a id="propertytechniques-shortstringstringlist"></a>
+## Property techniques ∷ ShortStringString List
+
+specifies the list of technique ids (ex: mitre technique id) of an Incident
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+  * *ShortString* String with at most 1024 characters
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -23,6 +23,8 @@
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :severity "High"
+   :tactics ["TA0011"],
+   :techniques ["T1095", "T1001"]
    :source "source"
    :source_uri "http://example.com"
    :confidence "High"

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -63,7 +63,11 @@
    (f/entry :promotion_method v/PromotionMethod
             :description "identifies how the incident was promoted")
    (f/entry :severity v/Severity
-            :description "specifies the severity level of an Incident")))
+            :description "specifies the severity level of an Incident")
+   (f/entry :tactics [c/ShortString]
+            :description "specifies the list of tactic ids (ex: mitre tactic id) of an Incident")
+   (f/entry :techniques [c/ShortString]
+            :description "specifies the list of technique ids (ex: mitre technique id) of an Incident")))
 
 (def-entity-type NewIncident
   "For submitting a new Incident"


### PR DESCRIPTION
https://github.com/advthreat/iroh/issues/6972

We want ES to index these fields for sorting/filtering purposes. I think we need to run the ES update-mappings task after we bump CTIA.

Used in https://github.com/threatgrid/ctia/pull/1294