### PR TITLE
Change incident score structure

### DIFF
--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -69,7 +69,7 @@
     "description" : "string",
     "external_ids" : [ "string" ],
     "scores" : {
-      "string" : 10.0
+      "keyword" : 10.0
     }
   } ],
   "vulnerability_refs" : [ "string" ],

--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -69,7 +69,7 @@
     "description" : "string",
     "external_ids" : [ "string" ],
     "scores" : {
-      "{:anything \"anything\"}" : 10.0
+      "string" : 10.0
     }
   } ],
   "vulnerability_refs" : [ "string" ],

--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -68,10 +68,9 @@
     "severity" : "string",
     "description" : "string",
     "external_ids" : [ "string" ],
-    "scores" : [ {
-      "score" : 10.0,
-      "type" : "string"
-    } ]
+    "scores" : {
+      "{:anything \"anything\"}" : 10.0
+    }
   } ],
   "vulnerability_refs" : [ "string" ],
   "tools" : [ {

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -83,7 +83,7 @@
       "description" : "string",
       "external_ids" : [ "string" ],
       "scores" : {
-        "{:anything \"anything\"}" : 10.0
+        "string" : 10.0
       }
     } ],
     "vulnerability_refs" : [ "string" ],

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -83,7 +83,7 @@
       "description" : "string",
       "external_ids" : [ "string" ],
       "scores" : {
-        "string" : 10.0
+        "keyword" : 10.0
       }
     } ],
     "vulnerability_refs" : [ "string" ],

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -82,10 +82,9 @@
       "severity" : "string",
       "description" : "string",
       "external_ids" : [ "string" ],
-      "scores" : [ {
-        "score" : 10.0,
-        "type" : "string"
-      } ]
+      "scores" : {
+        "{:anything \"anything\"}" : 10.0
+      }
     } ],
     "vulnerability_refs" : [ "string" ],
     "tools" : [ {

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -38,6 +38,6 @@
   "description" : "string",
   "external_ids" : [ "string" ],
   "scores" : {
-    "string" : 10.0
+    "keyword" : 10.0
   }
 }

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -38,6 +38,6 @@
   "description" : "string",
   "external_ids" : [ "string" ],
   "scores" : {
-    "{:anything \"anything\"}" : 10.0
+    "string" : 10.0
   }
 }

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -37,8 +37,7 @@
   "severity" : "string",
   "description" : "string",
   "external_ids" : [ "string" ],
-  "scores" : [ {
-    "score" : 10.0,
-    "type" : "string"
-  } ]
+  "scores" : {
+    "{:anything \"anything\"}" : 10.0
+  }
 }

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4550,7 +4550,7 @@ A map of scores.
 * This entry is optional
 
 
-  * a positive score number
+  * a non-negative score number
 
 <a id="map55"></a>
 # *IncidentTime* Object

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4539,17 +4539,16 @@ Specification for how, and to whom, this object can be shared.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
+|[Keyword](#propertykeyword-number)|Number|A map of scores.||
 
 
-<a id="propertyshortstringstring-number"></a>
-## Property ShortStringString ∷ Number
+<a id="propertykeyword-number"></a>
+## Property Keyword ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
-  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number
 

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4179,7 +4179,7 @@ A URL reference to an external resource
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
-|[scores](#propertyscores-scoreobjectlist)|*Score* Object List|the scores associated to the incident||
+|[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|the scores associated to the incident||
 |[severity](#propertyseverity-severitystring)|SeverityString|specifies the severity level of an Incident||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -4395,18 +4395,17 @@ CTIM schema version for this entity
 
   * A semantic version matching the CTIM version against which this object should be valid.
 
-<a id="propertyscores-scoreobjectlist"></a>
-## Property scores ∷ *Score* Object List
+<a id="propertyscores-incidentscoresobject"></a>
+## Property scores ∷ *IncidentScores* Object
 
 the scores associated to the incident
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 
 <a id="map56-ref"></a>
-* *Score* Object Value
-  * Details: [*Score* Object](#map56)
+* *IncidentScores* Object Value
+  * Details: [*IncidentScores* Object](#map56)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -4536,33 +4535,22 @@ Specification for how, and to whom, this object can be shared.
   * Must equal: "incident"
 
 <a id="map56"></a>
-# *Score* Object
-
-*Score* A score that is assigned to an incident.
+# *IncidentScores* Object
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[score](#propertyscore-number)|Number|a numeric score|&#10003;|
-|[type](#propertytype-string)|String|a label representing the type of score|&#10003;|
+|[Any](#propertyanything-number)|Number|A map of scores.||
 
 
-<a id="propertyscore-number"></a>
-## Property score ∷ Number
+<a id="propertyanything-number"></a>
+## Property Anything ∷ Number
 
-a numeric score
+A map of scores.
 
-* This entry is required
-
-
-
-<a id="propertytype-string"></a>
-## Property type ∷ String
-
-a label representing the type of score
-
-* This entry is required
+* This entry is optional
 
 
+  * a positive score number
 
 <a id="map55"></a>
 # *IncidentTime* Object

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -4539,16 +4539,17 @@ Specification for how, and to whom, this object can be shared.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Any](#propertyanything-number)|Number|A map of scores.||
+|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
 
 
-<a id="propertyanything-number"></a>
-## Property Anything ∷ Number
+<a id="propertyshortstringstring-number"></a>
+## Property ShortStringString ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
+  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -9082,7 +9082,7 @@ A map of scores.
 * This entry is optional
 
 
-  * a positive score number
+  * a non-negative score number
 
 <a id="map100"></a>
 # *IncidentTime* Object

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -9071,17 +9071,16 @@ Specification for how, and to whom, this object can be shared.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
+|[Keyword](#propertykeyword-number)|Number|A map of scores.||
 
 
-<a id="propertyshortstringstring-number"></a>
-## Property ShortStringString ∷ Number
+<a id="propertykeyword-number"></a>
+## Property Keyword ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
-  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -8711,7 +8711,7 @@ A URL reference to an external resource
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
-|[scores](#propertyscores-scoreobjectlist)|*Score* Object List|the scores associated to the incident||
+|[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|the scores associated to the incident||
 |[severity](#propertyseverity-severitystring)|SeverityString|specifies the severity level of an Incident||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -8927,18 +8927,17 @@ CTIM schema version for this entity
 
   * A semantic version matching the CTIM version against which this object should be valid.
 
-<a id="propertyscores-scoreobjectlist"></a>
-## Property scores ∷ *Score* Object List
+<a id="propertyscores-incidentscoresobject"></a>
+## Property scores ∷ *IncidentScores* Object
 
 the scores associated to the incident
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 
 <a id="map101-ref"></a>
-* *Score* Object Value
-  * Details: [*Score* Object](#map101)
+* *IncidentScores* Object Value
+  * Details: [*IncidentScores* Object](#map101)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -9068,33 +9067,22 @@ Specification for how, and to whom, this object can be shared.
   * Must equal: "incident"
 
 <a id="map101"></a>
-# *Score* Object
-
-*Score* A score that is assigned to an incident.
+# *IncidentScores* Object
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[score](#propertyscore-number)|Number|a numeric score|&#10003;|
-|[type](#propertytype-string)|String|a label representing the type of score|&#10003;|
+|[Any](#propertyanything-number)|Number|A map of scores.||
 
 
-<a id="propertyscore-number"></a>
-## Property score ∷ Number
+<a id="propertyanything-number"></a>
+## Property Anything ∷ Number
 
-a numeric score
+A map of scores.
 
-* This entry is required
-
-
-
-<a id="propertytype-string"></a>
-## Property type ∷ String
-
-a label representing the type of score
-
-* This entry is required
+* This entry is optional
 
 
+  * a positive score number
 
 <a id="map100"></a>
 # *IncidentTime* Object

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -9071,16 +9071,17 @@ Specification for how, and to whom, this object can be shared.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Any](#propertyanything-number)|Number|A map of scores.||
+|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
 
 
-<a id="propertyanything-number"></a>
-## Property Anything ∷ Number
+<a id="propertyshortstringstring-number"></a>
+## Property ShortStringString ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
+  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number
 

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -25,7 +25,7 @@
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The human language this object is specified in.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|identifies how the incident was promoted||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
-|[scores](#propertyscores-scoreobjectlist)|*Score* Object List|the scores associated to the incident||
+|[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|the scores associated to the incident||
 |[severity](#propertyseverity-severitystring)|SeverityString|specifies the severity level of an Incident||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString| ||
@@ -241,18 +241,17 @@ CTIM schema version for this entity
 
   * A semantic version matching the CTIM version against which this object should be valid.
 
-<a id="propertyscores-scoreobjectlist"></a>
-## Property scores ∷ *Score* Object List
+<a id="propertyscores-incidentscoresobject"></a>
+## Property scores ∷ *IncidentScores* Object
 
 the scores associated to the incident
 
 * This entry is optional
-* This entry's type is sequential (allows zero or more values)
 
 
 <a id="map3-ref"></a>
-* *Score* Object Value
-  * Details: [*Score* Object](#map3)
+* *IncidentScores* Object Value
+  * Details: [*IncidentScores* Object](#map3)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -517,30 +516,19 @@ Time the incident was first reported.
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="map3"></a>
-# *Score* Object
-
-*Score* A score that is assigned to an incident.
+# *IncidentScores* Object
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[score](#propertyscore-number)|Number|a numeric score|&#10003;|
-|[type](#propertytype-string)|String|a label representing the type of score|&#10003;|
+|[Any](#propertyanything-number)|Number|A map of scores.||
 
 
-<a id="propertyscore-number"></a>
-## Property score ∷ Number
+<a id="propertyanything-number"></a>
+## Property Anything ∷ Number
 
-a numeric score
+A map of scores.
 
-* This entry is required
-
-
-
-<a id="propertytype-string"></a>
-## Property type ∷ String
-
-a label representing the type of score
-
-* This entry is required
+* This entry is optional
 
 
+  * a positive score number

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -531,4 +531,4 @@ A map of scores.
 * This entry is optional
 
 
-  * a positive score number
+  * a non-negative score number

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -520,16 +520,15 @@ Time the incident was first reported.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
+|[Keyword](#propertykeyword-number)|Number|A map of scores.||
 
 
-<a id="propertyshortstringstring-number"></a>
-## Property ShortStringString ∷ Number
+<a id="propertykeyword-number"></a>
+## Property Keyword ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
-  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -520,15 +520,16 @@ Time the incident was first reported.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Any](#propertyanything-number)|Number|A map of scores.||
+|[Str](#propertyshortstringstring-number)|Number|A map of scores.||
 
 
-<a id="propertyanything-number"></a>
-## Property Anything ∷ Number
+<a id="propertyshortstringstring-number"></a>
+## Property ShortStringString ∷ Number
 
 A map of scores.
 
 * This entry is optional
 
+  * *ShortString* String with at most 1024 characters
 
   * a non-negative score number

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -40,8 +40,8 @@
    :discovery_method "Log Review"
    :promotion_method "Manual"
    :intended_effect "Extortion"
-   :scores {"asset" 5
-            "ttp" 98}})
+   :scores {:asset 5
+            :ttp 98}})
 
 (def incident-minimal
   {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -40,8 +40,8 @@
    :discovery_method "Log Review"
    :promotion_method "Manual"
    :intended_effect "Extortion"
-   :scores [{:type "asset", :score 5}
-            {:type "ttp", :score 98}]})
+   :scores {"asset" 5
+            "ttp" 98}})
 
 (def incident-minimal
   {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -48,7 +48,7 @@
 
 (def Score
   (f/num
-   :description "a positive score number"
+   :description "a non-negative score number"
    :spec valid-score?
    #?@(:clj [:gen (gen/double* {:min 0 :NaN? false :infinite? false})])))
 

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -38,13 +38,17 @@
   "[NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf)")
 
 (def sample-score-types
-  #{"ttp"
-    "global"
-    "asset"})
+  #{:ttp
+    :global
+    :asset})
 
 (defn valid-score?
   [score]
   (<= 0 score))
+
+(def ScoreType
+  (f/enum sample-score-types
+          :open? true))
 
 (def Score
   (f/num
@@ -54,7 +58,7 @@
 
 (def-map-type IncidentScores
   (f/optional-entries
-   (f/entry f/any-keyword Score
+   (f/entry ScoreType Score
             :description "A map of scores.")))
 
 (def-entity-type Incident

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -54,7 +54,7 @@
 
 (def-map-type IncidentScores
   (f/optional-entries
-   (f/entry c/ShortString Score
+   (f/entry f/any-keyword Score
             :description "A map of scores.")))
 
 (def-entity-type Incident

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -54,7 +54,7 @@
 
 (def-map-type IncidentScores
   (f/optional-entries
-   (f/entry f/any Score
+   (f/entry c/ShortString Score
             :description "A map of scores.")))
 
 (def-entity-type Incident

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -3,7 +3,8 @@
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
             #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
-               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
+               :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])
+            #?(:clj [clojure.test.check.generators :as gen])))
 
 (def-map-type IncidentTime
   (concat
@@ -36,13 +37,25 @@
 (def incident-desc-link
   "[NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf)")
 
-(def-map-type Score
-  (f/required-entries
-   (f/entry :score f/any-num
-            :description "a numeric score")
-   (f/entry :type f/any-str
-            :description "a label representing the type of score"))
-  :description "A score that is assigned to an incident.")
+(def sample-score-types
+  #{"ttp"
+    "global"
+    "asset"})
+
+(defn valid-score?
+  [score]
+  (<= 0 score))
+
+(def Score
+  (f/num
+   :description "a positive score number"
+   :spec valid-score?
+   #?@(:clj [:gen (gen/double* {:min 0 :NaN? false :infinite? false})])))
+
+(def-map-type IncidentScores
+  (f/optional-entries
+   (f/entry f/any Score
+            :description "A map of scores.")))
 
 (def-entity-type Incident
   {:description incident-desc}
@@ -60,7 +73,7 @@
             :comment "Was 'time'; renamed for clarity"
             :description "relevant time values associated with this Incident"))
   (f/optional-entries
-   (f/entry :scores [Score]
+   (f/entry :scores IncidentScores
             :description "the scores associated to the incident")
    (f/entry :categories [v/IncidentCategory]
             :description "a set of categories for this incident")


### PR DESCRIPTION
Related: https://github.com/threatgrid/ctia/pull/1340

The current `scores` structure requires convoluted ES features to fully support. We decided this to avoid migrations every time we add a new score type. But now we're going to change `scores` to be more intuitive because we will use [dynamic mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-mapping.html) to maintain flexibility of adding score types.

This will require a migration (of some kind) on INT. But in exchange it's much simpler to implement this new shape in CTIA.

Used an `enum` for the score types to help CTIA generate GraphQL objects (I didn't dig into why `f/any` or `f/str` didn't work).

