### PR TITLE
Release ctim 1.3.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/ctim "1.3.5"
+(defproject threatgrid/ctim "1.3.6-SNAPSHOT"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/ctim "1.3.5-SNAPSHOT"
+(defproject threatgrid/ctim "1.3.5"
   :description "Cisco Threat Intelligence Model"
   :url "http://github.com/threatgrid/ctim"
   :license {:name "Eclipse Public License"

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -20,7 +20,7 @@
             [flanders.predicates :as fp]
             [clojure.string :as str]))
 
-(def ctim-schema-version "1.3.5")
+(def ctim-schema-version "1.3.6")
 
 (def-eq CTIMSchemaVersion ctim-schema-version)
 


### PR DESCRIPTION
- Restore Sighting contextual events (#407)
- add crowstrike_id and cybereason_id obs types (#408)