### PR TITLE
Contextual events fixes

### DIFF
--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -699,7 +699,6 @@
         "process_args" : "string",
         "parent_process_args" : "string",
         "process_disposition" : "string",
-        "creation_time" : "2016-01-01T01:01:01.000Z",
         "process_id" : 10,
         "process_guid" : 10,
         "parent_process_id" : 10,

--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -551,7 +551,7 @@
         "type" : "string",
         "process_name" : "string",
         "traffic" : {
-          "protocol" : "string",
+          "protocol" : 10,
           "destination_host_name" : "string",
           "source_subnet" : "string",
           "source_port" : 10,
@@ -625,7 +625,7 @@
         "process_account_type" : "string",
         "process_account" : "string",
         "traffic" : {
-          "protocol" : "string",
+          "protocol" : 10,
           "destination_host_name" : "string",
           "source_subnet" : "string",
           "source_port" : 10,

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -713,7 +713,6 @@
           "process_args" : "string",
           "parent_process_args" : "string",
           "process_disposition" : "string",
-          "creation_time" : "2016-01-01T01:01:01.000Z",
           "process_id" : 10,
           "process_guid" : 10,
           "parent_process_id" : 10,

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -565,7 +565,7 @@
           "type" : "string",
           "process_name" : "string",
           "traffic" : {
-            "protocol" : "string",
+            "protocol" : 10,
             "destination_host_name" : "string",
             "source_subnet" : "string",
             "source_port" : 10,
@@ -639,7 +639,7 @@
           "process_account_type" : "string",
           "process_account" : "string",
           "traffic" : {
-            "protocol" : "string",
+            "protocol" : 10,
             "destination_host_name" : "string",
             "source_subnet" : "string",
             "source_port" : 10,

--- a/doc/json/sighting.json
+++ b/doc/json/sighting.json
@@ -202,7 +202,6 @@
       "process_args" : "string",
       "parent_process_args" : "string",
       "process_disposition" : "string",
-      "creation_time" : "2016-01-01T01:01:01.000Z",
       "process_id" : 10,
       "process_guid" : 10,
       "parent_process_id" : 10,

--- a/doc/json/sighting.json
+++ b/doc/json/sighting.json
@@ -54,7 +54,7 @@
       "type" : "string",
       "process_name" : "string",
       "traffic" : {
-        "protocol" : "string",
+        "protocol" : 10,
         "destination_host_name" : "string",
         "source_subnet" : "string",
         "source_port" : 10,
@@ -128,7 +128,7 @@
       "process_account_type" : "string",
       "process_account" : "string",
       "traffic" : {
-        "protocol" : "string",
+        "protocol" : 10,
         "destination_host_name" : "string",
         "source_subnet" : "string",
         "source_port" : 10,

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -7921,7 +7921,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -7967,8 +7967,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 
@@ -8239,7 +8241,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -8285,8 +8287,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -8951,7 +8951,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[creation_time](#propertycreation_time-instdate)|Inst (Date)| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
@@ -8972,14 +8971,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[process_size](#propertyprocess_size-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 
-
-<a id="propertycreation_time-instdate"></a>
-## Property creation_time ∷ Inst (Date)
-
-* This entry is required
-
-
-  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyparent_creation_time-instdate"></a>
 ## Property parent_creation_time ∷ Inst (Date)

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -7802,11 +7802,11 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
-|[url_port](#propertyurl_port-integer)|Integer| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
+|[url_port](#propertyurl_port-integer)|Integer| ||
 
 
 <a id="propertyencrypted-boolean"></a>
@@ -7909,7 +7909,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 <a id="propertyurl_port-integer"></a>
 ## Property url_port ∷ Integer
 
-* This entry is required
+* This entry is optional
 
 
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -6412,11 +6412,11 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
-|[url_port](#propertyurl_port-integer)|Integer| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
+|[url_port](#propertyurl_port-integer)|Integer| ||
 
 
 <a id="propertyencrypted-boolean"></a>
@@ -6519,7 +6519,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 <a id="propertyurl_port-integer"></a>
 ## Property url_port ∷ Integer
 
-* This entry is required
+* This entry is optional
 
 
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -7561,7 +7561,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[creation_time](#propertycreation_time-instdate)|Inst (Date)| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
@@ -7582,14 +7581,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[process_size](#propertyprocess_size-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 
-
-<a id="propertycreation_time-instdate"></a>
-## Property creation_time ∷ Inst (Date)
-
-* This entry is required
-
-
-  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyparent_creation_time-instdate"></a>
 ## Property parent_creation_time ∷ Inst (Date)

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -6531,7 +6531,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -6577,8 +6577,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 
@@ -6849,7 +6851,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -6895,8 +6897,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -2141,7 +2141,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -2187,8 +2187,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 
@@ -2459,7 +2461,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[destination_ip](#propertydestination_ip-string)|String| |&#10003;|
 |[destination_port](#propertydestination_port-integer)|Integer| |&#10003;|
 |[direction](#propertydirection-trafficdirectionstring)|TrafficDirectionString| |&#10003;|
-|[protocol](#propertyprotocol-string)|String| |&#10003;|
+|[protocol](#propertyprotocol-integer)|Integer|The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)|&#10003;|
 |[source_ip](#propertysource_ip-string)|String| |&#10003;|
 |[source_port](#propertysource_port-integer)|Integer| |&#10003;|
 |[destination_host_name](#propertydestination_host_name-string)|String| ||
@@ -2505,8 +2507,10 @@ Time of the observation.  If the observation was made over a period of time, tha
     * incoming
     * outgoing
 
-<a id="propertyprotocol-string"></a>
-## Property protocol ∷ String
+<a id="propertyprotocol-integer"></a>
+## Property protocol ∷ Integer
+
+The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 
 * This entry is required
 

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -3171,7 +3171,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[creation_time](#propertycreation_time-instdate)|Inst (Date)| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
@@ -3192,14 +3191,6 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[process_size](#propertyprocess_size-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 
-
-<a id="propertycreation_time-instdate"></a>
-## Property creation_time ∷ Inst (Date)
-
-* This entry is required
-
-
-  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyparent_creation_time-instdate"></a>
 ## Property parent_creation_time ∷ Inst (Date)

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -2022,11 +2022,11 @@ Time of the observation.  If the observation was made over a period of time, tha
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
-|[url_port](#propertyurl_port-integer)|Integer| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
+|[url_port](#propertyurl_port-integer)|Integer| ||
 
 
 <a id="propertyencrypted-boolean"></a>
@@ -2129,7 +2129,7 @@ Time of the observation.  If the observation was made over a period of time, tha
 <a id="propertyurl_port-integer"></a>
 ## Property url_port ∷ Integer
 
-* This entry is required
+* This entry is optional
 
 
 

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -59,7 +59,6 @@
              [{:type "ProcessCreateEvent"
                :time {:start_time #inst "2022-01-24T18:52:11.000Z"
                       :end_time #inst "2022-01-24T18:52:11.000Z"}
-               :creation_time #inst "2022-01-24T18:52:11.000Z"
                :process_id 10724
                :process_guid 132465072105597400
                :process_args "-c"
@@ -252,7 +251,6 @@
              [{:type "ProcessCreateEvent"
                :time {:start_time #inst "2022-01-24T18:52:11.000Z"
                       :end_time #inst "2022-01-24T18:52:11.000Z"}
-               :creation_time #inst "2022-01-24T18:52:11.000Z"
                :process_id 10724
                :process_name "powershell.exe"
                :process_guid 132465072105597400

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -155,7 +155,7 @@
                :flow_time #inst "2022-01-24T18:52:11.000Z"
                :byte_count_out 0
                :byte_count_in 0
-               :traffic {:protocol "HTTP"
+               :traffic {:protocol 6
                          :source_ip "192.168.1.1"
                          :destination_ip "20.189.173.11"
                          :source_port 56407
@@ -175,7 +175,7 @@
                :host ""
                :url_port 1
                :method "GET"
-               :traffic {:protocol "HTTP"
+               :traffic {:protocol 6
                          :source_ip "192.168.1.1"
                          :destination_ip "20.189.173.11"
                          :source_port 56407

--- a/src/ctim/schemas/sighting/context.cljc
+++ b/src/ctim/schemas/sighting/context.cljc
@@ -107,7 +107,9 @@
 (def-map-type Traffic
   (concat
    (f/required-entries
-    (f/entry :protocol f/any-str)
+    (f/entry :protocol f/any-int
+             :description
+             "The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)")
     (f/entry :source_ip f/any-str)
     (f/entry :destination_ip f/any-str)
     (f/entry :source_port f/any-int)

--- a/src/ctim/schemas/sighting/context.cljc
+++ b/src/ctim/schemas/sighting/context.cljc
@@ -160,10 +160,10 @@
    (f/required-entries
     (f/entry :type HTTPTypeIdentifier)
     (f/entry :host c/ShortString)
-    (f/entry :url_port f/any-int)
     (f/entry :method HTTPMethod)
     (f/entry :traffic Traffic))
    (f/optional-entries
+    (f/entry :url_port f/any-int)
     (f/entry :process_guid f/any-int)
     (f/entry :process_username c/ShortString)
     (f/entry :query c/LongString)

--- a/src/ctim/schemas/sighting/context.cljc
+++ b/src/ctim/schemas/sighting/context.cljc
@@ -21,8 +21,7 @@
   (concat
    base-event-entries
    (f/required-entries
-    (f/entry :type ProcessCreateTypeIdentifier)
-    (f/entry :creation_time  c/Time))
+    (f/entry :type ProcessCreateTypeIdentifier))
    (f/optional-entries
     (f/entry :process_args c/MedString)
     (f/entry :process_hash c/MedString)


### PR DESCRIPTION
- Use `any-int` for Traffic.protocol which is the [IP protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
- Remove `:creation_time` from `ProcessCreateEvent`s
- Set `HTTPEvent.url_port` optional