### PR TITLE
adds incident_time.created

### DIFF
--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -1,43 +1,58 @@
 {
-  "confidence" : "string",
-  "tlp" : "string",
-  "techniques" : [ "string" ],
-  "id" : "string",
-  "timestamp" : "2016-01-01T01:01:01.000Z",
-  "revision" : 10,
-  "categories" : [ "string" ],
-  "tactics" : [ "string" ],
-  "assignees" : [ "string" ],
-  "incident_time" : {
-    "opened" : "2016-01-01T01:01:01.000Z",
-    "discovered" : "2016-01-01T01:01:01.000Z",
-    "reported" : "2016-01-01T01:01:01.000Z",
-    "remediated" : "2016-01-01T01:01:01.000Z",
-    "closed" : "2016-01-01T01:01:01.000Z",
-    "rejected" : "2016-01-01T01:01:01.000Z"
+  "confidence": "string",
+  "tlp": "string",
+  "techniques": [
+    "string"
+  ],
+  "id": "string",
+  "timestamp": "2016-01-01T01:01:01.000Z",
+  "revision": 10,
+  "categories": [
+    "string"
+  ],
+  "tactics": [
+    "string"
+  ],
+  "assignees": [
+    "string"
+  ],
+  "incident_time": {
+    "opened": "2016-01-01T01:01:01.000Z",
+    "created": "2016-01-01T01:01:01.000Z",
+    "discovered": "2016-01-01T01:01:01.000Z",
+    "reported": "2016-01-01T01:01:01.000Z",
+    "remediated": "2016-01-01T01:01:01.000Z",
+    "closed": "2016-01-01T01:01:01.000Z",
+    "rejected": "2016-01-01T01:01:01.000Z"
   },
-  "discovery_method" : "string",
-  "status" : "string",
-  "short_description" : "string",
-  "promotion_method" : "string",
-  "schema_version" : "string",
-  "title" : "string",
-  "source" : "string",
-  "type" : "string",
-  "intended_effect" : "string",
-  "source_uri" : "string",
-  "language" : "string",
-  "external_references" : [ {
-    "source_name" : "string",
-    "description" : "string",
-    "url" : "string",
-    "hashes" : [ "string" ],
-    "external_id" : "string"
-  } ],
-  "severity" : "string",
-  "description" : "string",
-  "external_ids" : [ "string" ],
-  "scores" : {
-    "keyword" : 10.0
+  "discovery_method": "string",
+  "status": "string",
+  "short_description": "string",
+  "promotion_method": "string",
+  "schema_version": "string",
+  "title": "string",
+  "source": "string",
+  "type": "string",
+  "intended_effect": "string",
+  "source_uri": "string",
+  "language": "string",
+  "external_references": [
+    {
+      "source_name": "string",
+      "description": "string",
+      "url": "string",
+      "hashes": [
+        "string"
+      ],
+      "external_id": "string"
+    }
+  ],
+  "severity": "string",
+  "description": "string",
+  "external_ids": [
+    "string"
+  ],
+  "scores": {
+    "keyword": 10.0
   }
 }

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -33,6 +33,7 @@
    :status "Open"
    :incident_time {:discovered #inst "2016-02-11T00:40:48.212-00:00"
                    :opened #inst "2016-02-11T00:40:48.212-00:00"
+                   :created #inst "2016-02-11T00:40:48.212-00:00"
                    :remediated #inst "2016-02-11T00:40:48.212-00:00"
                    :reported #inst "2016-02-11T00:40:48.212-00:00"
                    :closed #inst "2016-02-11T00:40:48.212-00:00"

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -12,6 +12,8 @@
     (f/entry :opened c/Time
              :description "Time the incident was first opened."))
    (f/optional-entries
+    (f/entry :created c/Time
+             :description "Time the incident was created.")
     (f/entry :discovered c/Time
              :description "Time the incident was first discovered.")
     (f/entry :reported c/Time


### PR DESCRIPTION
We need to expose `created` field even though it won't be stored explicitly in CTIA.

> Related: https://github.com/advthreat/iroh/issues/7866

The discussion: https://github.com/advthreat/iroh/issues/7853#issuecomment-1540591124
