### PR TITLE
change select sighting context fields to optional

### DIFF
--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -7812,12 +7812,11 @@ Time of the observation. If the observation was made over a period of time, than
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrydeletetypeidentifierstring)|RegistryDeleteTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
-
+|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| ||
 
 <a id="propertyprocess_guid-integer"></a>
 ## Property process_guid ∷ Integer
@@ -7860,7 +7859,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_value-medstringstring"></a>
 ## Property registry_value ∷ MedStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *MedString* String with at most 2048 characters.
@@ -7922,13 +7921,13 @@ Time of the observation. If the observation was made over a period of time, than
 | -------- | ---- | ----------- | --------- |
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrysettypeidentifierstring)|RegistrySetTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
+|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| ||
 |[registry_data_length](#propertyregistry_data_length-integer)|Integer| ||
 
 
@@ -7965,7 +7964,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_data-longstringstring"></a>
 ## Property registry_data ∷ LongStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *LongString* String with at most 5000 characters.
@@ -8151,13 +8150,13 @@ Time of the observation. If the observation was made over a period of time, than
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[host](#propertyhost-shortstringstring)|ShortStringString| |&#10003;|
-|[method](#propertymethod-httpmethodstring)|HTTPMethodString| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
+|[method](#propertymethod-httpmethodstring)|HTTPMethodString| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
@@ -8182,8 +8181,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertymethod-httpmethodstring"></a>
 ## Property method ∷ HTTPMethodString
 
-* This entry is required
-
+* This entry is optional
 
   * Allowed Values:
     * CONNECT

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -6291,11 +6291,11 @@ Time of the observation. If the observation was made over a period of time, than
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrydeletetypeidentifierstring)|RegistryDeleteTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
+|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| ||
 
 
 <a id="propertyprocess_guid-integer"></a>
@@ -6339,7 +6339,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_value-medstringstring"></a>
 ## Property registry_value ∷ MedStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *MedString* String with at most 2048 characters.
@@ -6401,13 +6401,13 @@ Time of the observation. If the observation was made over a period of time, than
 | -------- | ---- | ----------- | --------- |
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrysettypeidentifierstring)|RegistrySetTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
+|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| ||
 |[registry_data_length](#propertyregistry_data_length-integer)|Integer| ||
 
 
@@ -6444,7 +6444,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_data-longstringstring"></a>
 ## Property registry_data ∷ LongStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *LongString* String with at most 5000 characters.
@@ -6630,13 +6630,13 @@ Time of the observation. If the observation was made over a period of time, than
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[host](#propertyhost-shortstringstring)|ShortStringString| |&#10003;|
-|[method](#propertymethod-httpmethodstring)|HTTPMethodString| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
+|[method](#propertymethod-httpmethodstring)|HTTPMethodString| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
@@ -6661,7 +6661,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertymethod-httpmethodstring"></a>
 ## Property method ∷ HTTPMethodString
 
-* This entry is required
+* This entry is optional
 
 
   * Allowed Values:

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -1715,11 +1715,11 @@ Time of the observation. If the observation was made over a period of time, than
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrydeletetypeidentifierstring)|RegistryDeleteTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
+|[registry_value](#propertyregistry_value-medstringstring)|MedStringString| ||
 
 
 <a id="propertyprocess_guid-integer"></a>
@@ -1763,7 +1763,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_value-medstringstring"></a>
 ## Property registry_value ∷ MedStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *MedString* String with at most 2048 characters.
@@ -1825,13 +1825,13 @@ Time of the observation. If the observation was made over a period of time, than
 | -------- | ---- | ----------- | --------- |
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
-|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| |&#10003;|
 |[registry_key](#propertyregistry_key-shortstringstring)|ShortStringString| |&#10003;|
 |[registry_value](#propertyregistry_value-medstringstring)|MedStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-registrysettypeidentifierstring)|RegistrySetTypeIdentifierString| |&#10003;|
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
+|[registry_data](#propertyregistry_data-longstringstring)|LongStringString| ||
 |[registry_data_length](#propertyregistry_data_length-integer)|Integer| ||
 
 
@@ -1868,7 +1868,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertyregistry_data-longstringstring"></a>
 ## Property registry_data ∷ LongStringString
 
-* This entry is required
+* This entry is optional
 
 
   * *LongString* String with at most 5000 characters.
@@ -2054,13 +2054,13 @@ Time of the observation. If the observation was made over a period of time, than
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[host](#propertyhost-shortstringstring)|ShortStringString| |&#10003;|
-|[method](#propertymethod-httpmethodstring)|HTTPMethodString| |&#10003;|
 |[process_id](#propertyprocess_id-integer)|Integer| |&#10003;|
 |[process_name](#propertyprocess_name-shortstringstring)|ShortStringString| |&#10003;|
 |[time](#propertytime-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[traffic](#propertytraffic-trafficobject)|*Traffic* Object| |&#10003;|
 |[type](#propertytype-httptypeidentifierstring)|HTTPTypeIdentifierString| |&#10003;|
 |[encrypted](#propertyencrypted-boolean)|Boolean| ||
+|[method](#propertymethod-httpmethodstring)|HTTPMethodString| ||
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[query](#propertyquery-longstringstring)|LongStringString| ||
@@ -2085,7 +2085,7 @@ Time of the observation. If the observation was made over a period of time, than
 <a id="propertymethod-httpmethodstring"></a>
 ## Property method ∷ HTTPMethodString
 
-* This entry is required
+* This entry is optional
 
 
   * Allowed Values:

--- a/src/ctim/schemas/sighting/context.cljc
+++ b/src/ctim/schemas/sighting/context.cljc
@@ -160,14 +160,14 @@
    (f/required-entries
     (f/entry :type HTTPTypeIdentifier)
     (f/entry :host c/ShortString)
-    (f/entry :method HTTPMethod)
     (f/entry :traffic Traffic))
    (f/optional-entries
     (f/entry :url_port f/any-int)
     (f/entry :process_guid f/any-int)
     (f/entry :process_username c/ShortString)
     (f/entry :query c/LongString)
-    (f/entry :encrypted f/any-bool))))
+    (f/entry :encrypted f/any-bool)
+    (f/entry :method HTTPMethod))))
 
 (def registry-event-entries
   (concat
@@ -192,10 +192,10 @@
    registry-event-entries
    (f/required-entries
     (f/entry :type RegistrySetTypeIdentifier)
-    (f/entry :registry_value c/MedString)
-    (f/entry :registry_data c/LongString))
+    (f/entry :registry_value c/MedString))
    (f/optional-entries
-    (f/entry :registry_data_length f/any-int))))
+    (f/entry :registry_data_length f/any-int)
+    (f/entry :registry_data c/LongString))))
 
 (def registry-delete-type-identifier "RegistryDeleteEvent")
 (def-eq RegistryDeleteTypeIdentifier registry-delete-type-identifier)
@@ -204,7 +204,8 @@
   (concat
    registry-event-entries
    (f/required-entries
-    (f/entry :type RegistryDeleteTypeIdentifier)
+    (f/entry :type RegistryDeleteTypeIdentifier))
+   (f/optional-entries
     (f/entry :registry_value c/MedString))))
 
 (def registry-rename-type-identifier "RegistryRenameEvent")


### PR DESCRIPTION
Per 8427 make the following changes to sighting context

Make [HTTPType > :method](https://github.com/threatgrid/ctim/blob/f6529ae7f56964c41fb69a0db06b3aa5465b815b/src/ctim/schemas/sighting/context.cljc#L163C33-L163C33) optional
Make RegistryDeleteType  > :registry_value optional
Make [RegistrySetType > :registry_data](https://github.com/threatgrid/ctim/blob/f6529ae7f56964c41fb69a0db06b3aa5465b815b/src/ctim/schemas/sighting/context.cljc#L196) optional