### PR TITLE
Fine tune the woke linter configuration

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,9 @@
+# generated doc #
+#################
+doc/
+
+# wontfix #
+###########
+src/ctim/examples/weaknesses.cljc
+src/ctim/schemas/coa.cljc
+src/ctim/schemas/vocabularies.cljc


### PR DESCRIPTION
The woke linter has been setup in the CI without proper configuration, thus it marks our builds as failed.
As a result we could unintentionally tend to ignore technical issues which could land in production.

CTIM is modeled to follow closely STIX ans as such we don't have so much leverage as we cannot drift too much from upstream, that being said, the linter should help us detect any new language issue arising and give us an opportunity to consider selecting alternative vocabularies whenever possible.

The current specification is already widely deployed so we cannot fix the existing vocabulary as this will induce a breaking change.