### PR TITLE
time metadata

### DIFF
--- a/doc/json/actor.json
+++ b/doc/json/actor.json
@@ -1,5 +1,6 @@
 {
   "confidence" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "aliases" : [ "string" ],
   "id" : "string",
@@ -26,6 +27,7 @@
   "source" : "string",
   "actor_types" : [ "string" ],
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "intended_effect" : "string",
   "source_uri" : "string",
   "language" : "string",

--- a/doc/json/asset.json
+++ b/doc/json/asset.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -12,6 +13,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "asset_type" : "string",
   "language" : "string",

--- a/doc/json/asset_mapping.json
+++ b/doc/json/asset_mapping.json
@@ -1,5 +1,6 @@
 {
   "confidence" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "asset_ref" : "string",
   "id" : "string",
@@ -18,6 +19,7 @@
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "asset_type" : "string",
   "language" : "string",

--- a/doc/json/asset_properties.json
+++ b/doc/json/asset_properties.json
@@ -3,6 +3,7 @@
     "name" : "string",
     "value" : "string"
   } ],
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "asset_ref" : "string",
   "id" : "string",
@@ -15,6 +16,7 @@
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/attack_pattern.json
+++ b/doc/json/attack_pattern.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "x_mitre_platforms" : [ "string" ],
   "x_mitre_data_sources" : [ "string" ],
@@ -16,6 +17,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/bundle.json
+++ b/doc/json/bundle.json
@@ -5,6 +5,7 @@
       "name" : "string",
       "value" : "string"
     } ],
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "asset_ref" : "string",
     "id" : "string",
@@ -17,6 +18,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -28,10 +30,12 @@
     } ],
     "external_ids" : [ "string" ]
   } ],
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "incidents" : [ {
     "confidence" : "string",
     "status_disposition" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "techniques" : [ "string" ],
     "id" : "string",
@@ -56,6 +60,10 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
+    "meta" : {
+      "keyword" : "string"
+    },
     "intended_effect" : "string",
     "source_uri" : "string",
     "language" : "string",
@@ -75,6 +83,7 @@
   } ],
   "vulnerability_refs" : [ "string" ],
   "tools" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "kill_chain_phases" : [ {
       "kill_chain_name" : "string",
@@ -91,6 +100,7 @@
     "source" : "string",
     "type" : "string",
     "tool_version" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -111,6 +121,7 @@
       "operator" : "string",
       "indicator_ids" : [ "string" ]
     },
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "negate" : true,
     "kill_chain_phases" : [ {
@@ -132,6 +143,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -161,6 +173,7 @@
   "coa_refs" : [ "string" ],
   "campaigns" : [ {
     "confidence" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "campaign_type" : "string",
     "activity" : [ {
@@ -181,6 +194,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "intended_effect" : [ "string" ],
     "source_uri" : "string",
     "language" : "string",
@@ -197,6 +211,7 @@
   "attack_pattern_refs" : [ "string" ],
   "judgement_refs" : [ "string" ],
   "feedbacks" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "entity_id" : "string",
     "id" : "string",
@@ -206,6 +221,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "reason" : "string",
     "source_uri" : "string",
     "language" : "string",
@@ -225,6 +241,7 @@
       "relationship" : "string",
       "COA_id" : "string"
     } ],
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "efficacy" : "string",
     "structured_coa_type" : "string",
@@ -278,6 +295,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -301,6 +319,7 @@
   "revision" : 10,
   "weakness_refs" : [ "string" ],
   "vulnerabilities" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "configurations" : {
       "CVE_data_version" : "string",
@@ -400,6 +419,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "published_date" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "cve" : {
@@ -423,6 +443,7 @@
   "data_table_refs" : [ "string" ],
   "target_record_refs" : [ "string" ],
   "identity_assertions" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "assertions" : [ {
       "name" : "string",
@@ -444,6 +465,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -459,6 +481,7 @@
   "short_description" : "string",
   "tool_refs" : [ "string" ],
   "target_records" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "id" : "string",
     "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -483,6 +506,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -520,6 +544,7 @@
         "type" : "string"
       }
     } ],
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "internal" : true,
     "id" : "string",
@@ -765,6 +790,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -799,6 +825,7 @@
   "actor_refs" : [ "string" ],
   "actors" : [ {
     "confidence" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "aliases" : [ "string" ],
     "id" : "string",
@@ -825,6 +852,7 @@
     "source" : "string",
     "actor_types" : [ "string" ],
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "intended_effect" : "string",
     "source_uri" : "string",
     "language" : "string",
@@ -845,6 +873,7 @@
   "source" : "string",
   "judgements" : [ {
     "confidence" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "priority" : 10,
     "id" : "string",
@@ -863,6 +892,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "reason" : "string",
     "source_uri" : "string",
     "language" : "string",
@@ -879,6 +909,7 @@
   } ],
   "type" : "string",
   "relationships" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "target_ref" : "string",
     "relationship_type" : "string",
@@ -891,6 +922,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -903,6 +935,7 @@
     "description" : "string",
     "external_ids" : [ "string" ]
   } ],
+  "modified" : "2016-01-01T01:01:01.000Z",
   "identity_assertion_refs" : [ "string" ],
   "weaknesses" : [ {
     "detection_methods" : [ {
@@ -912,6 +945,7 @@
       "effectiveness_notes" : "string"
     } ],
     "background_details" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "architectures" : [ {
       "prevalence" : "string",
@@ -950,6 +984,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "common_consequences" : [ {
       "scopes" : [ "string" ],
       "impacts" : [ "string" ],
@@ -1003,6 +1038,7 @@
     }
   } ],
   "assets" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "id" : "string",
     "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -1016,6 +1052,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "asset_type" : "string",
     "language" : "string",
@@ -1032,6 +1069,7 @@
   "asset_properties_refs" : [ "string" ],
   "source_uri" : "string",
   "notes" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "related_entities" : [ {
       "entity_type" : "string",
@@ -1046,6 +1084,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -1059,6 +1098,7 @@
   } ],
   "incident_refs" : [ "string" ],
   "attack_patterns" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "x_mitre_platforms" : [ "string" ],
     "x_mitre_data_sources" : [ "string" ],
@@ -1076,6 +1116,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -1089,6 +1130,7 @@
     "external_ids" : [ "string" ]
   } ],
   "data_tables" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "row_count" : 10,
     "columns" : [ {
@@ -1110,6 +1152,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "rows" : [ [ {
       "anything" : "anything"
@@ -1135,6 +1178,7 @@
   } ],
   "asset_mapping_refs" : [ "string" ],
   "malwares" : [ {
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "kill_chain_phases" : [ {
       "kill_chain_name" : "string",
@@ -1151,6 +1195,7 @@
     "title" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "language" : "string",
     "external_references" : [ {
@@ -1168,6 +1213,7 @@
   "asset_refs" : [ "string" ],
   "asset_mappings" : [ {
     "confidence" : "string",
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "asset_ref" : "string",
     "id" : "string",
@@ -1186,6 +1232,7 @@
     "schema_version" : "string",
     "source" : "string",
     "type" : "string",
+    "modified" : "2016-01-01T01:01:01.000Z",
     "source_uri" : "string",
     "asset_type" : "string",
     "language" : "string",

--- a/doc/json/campaign.json
+++ b/doc/json/campaign.json
@@ -1,5 +1,6 @@
 {
   "confidence" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "campaign_type" : "string",
   "activity" : [ {
@@ -20,6 +21,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "intended_effect" : [ "string" ],
   "source_uri" : "string",
   "language" : "string",

--- a/doc/json/casebook.json
+++ b/doc/json/casebook.json
@@ -3,6 +3,7 @@
     "value" : "string",
     "type" : "string"
   } ],
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -19,6 +20,7 @@
         "name" : "string",
         "value" : "string"
       } ],
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "asset_ref" : "string",
       "id" : "string",
@@ -31,6 +33,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -42,10 +45,12 @@
       } ],
       "external_ids" : [ "string" ]
     } ],
+    "created" : "2016-01-01T01:01:01.000Z",
     "tlp" : "string",
     "incidents" : [ {
       "confidence" : "string",
       "status_disposition" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "techniques" : [ "string" ],
       "id" : "string",
@@ -70,6 +75,10 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
+      "meta" : {
+        "keyword" : "string"
+      },
       "intended_effect" : "string",
       "source_uri" : "string",
       "language" : "string",
@@ -89,6 +98,7 @@
     } ],
     "vulnerability_refs" : [ "string" ],
     "tools" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "kill_chain_phases" : [ {
         "kill_chain_name" : "string",
@@ -105,6 +115,7 @@
       "source" : "string",
       "type" : "string",
       "tool_version" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -125,6 +136,7 @@
         "operator" : "string",
         "indicator_ids" : [ "string" ]
       },
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "negate" : true,
       "kill_chain_phases" : [ {
@@ -146,6 +158,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -175,6 +188,7 @@
     "coa_refs" : [ "string" ],
     "campaigns" : [ {
       "confidence" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "campaign_type" : "string",
       "activity" : [ {
@@ -195,6 +209,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "intended_effect" : [ "string" ],
       "source_uri" : "string",
       "language" : "string",
@@ -211,6 +226,7 @@
     "attack_pattern_refs" : [ "string" ],
     "judgement_refs" : [ "string" ],
     "feedbacks" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "entity_id" : "string",
       "id" : "string",
@@ -220,6 +236,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "reason" : "string",
       "source_uri" : "string",
       "language" : "string",
@@ -239,6 +256,7 @@
         "relationship" : "string",
         "COA_id" : "string"
       } ],
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "efficacy" : "string",
       "structured_coa_type" : "string",
@@ -292,6 +310,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -315,6 +334,7 @@
     "revision" : 10,
     "weakness_refs" : [ "string" ],
     "vulnerabilities" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "configurations" : {
         "CVE_data_version" : "string",
@@ -414,6 +434,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "published_date" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "cve" : {
@@ -437,6 +458,7 @@
     "data_table_refs" : [ "string" ],
     "target_record_refs" : [ "string" ],
     "identity_assertions" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "assertions" : [ {
         "name" : "string",
@@ -458,6 +480,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -473,6 +496,7 @@
     "short_description" : "string",
     "tool_refs" : [ "string" ],
     "target_records" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "id" : "string",
       "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -497,6 +521,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -534,6 +559,7 @@
           "type" : "string"
         }
       } ],
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "internal" : true,
       "id" : "string",
@@ -779,6 +805,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -813,6 +840,7 @@
     "actor_refs" : [ "string" ],
     "actors" : [ {
       "confidence" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "aliases" : [ "string" ],
       "id" : "string",
@@ -839,6 +867,7 @@
       "source" : "string",
       "actor_types" : [ "string" ],
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "intended_effect" : "string",
       "source_uri" : "string",
       "language" : "string",
@@ -859,6 +888,7 @@
     "source" : "string",
     "judgements" : [ {
       "confidence" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "priority" : 10,
       "id" : "string",
@@ -877,6 +907,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "reason" : "string",
       "source_uri" : "string",
       "language" : "string",
@@ -893,6 +924,7 @@
     } ],
     "type" : "string",
     "relationships" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "target_ref" : "string",
       "relationship_type" : "string",
@@ -905,6 +937,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -917,6 +950,7 @@
       "description" : "string",
       "external_ids" : [ "string" ]
     } ],
+    "modified" : "2016-01-01T01:01:01.000Z",
     "identity_assertion_refs" : [ "string" ],
     "weaknesses" : [ {
       "detection_methods" : [ {
@@ -926,6 +960,7 @@
         "effectiveness_notes" : "string"
       } ],
       "background_details" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "architectures" : [ {
         "prevalence" : "string",
@@ -964,6 +999,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "common_consequences" : [ {
         "scopes" : [ "string" ],
         "impacts" : [ "string" ],
@@ -1017,6 +1053,7 @@
       }
     } ],
     "assets" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "id" : "string",
       "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -1030,6 +1067,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "asset_type" : "string",
       "language" : "string",
@@ -1046,6 +1084,7 @@
     "asset_properties_refs" : [ "string" ],
     "source_uri" : "string",
     "notes" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "related_entities" : [ {
         "entity_type" : "string",
@@ -1060,6 +1099,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -1073,6 +1113,7 @@
     } ],
     "incident_refs" : [ "string" ],
     "attack_patterns" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "x_mitre_platforms" : [ "string" ],
       "x_mitre_data_sources" : [ "string" ],
@@ -1090,6 +1131,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -1103,6 +1145,7 @@
       "external_ids" : [ "string" ]
     } ],
     "data_tables" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "row_count" : 10,
       "columns" : [ {
@@ -1124,6 +1167,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "rows" : [ [ {
         "anything" : "anything"
@@ -1149,6 +1193,7 @@
     } ],
     "asset_mapping_refs" : [ "string" ],
     "malwares" : [ {
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "kill_chain_phases" : [ {
         "kill_chain_name" : "string",
@@ -1165,6 +1210,7 @@
       "title" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "language" : "string",
       "external_references" : [ {
@@ -1182,6 +1228,7 @@
     "asset_refs" : [ "string" ],
     "asset_mappings" : [ {
       "confidence" : "string",
+      "created" : "2016-01-01T01:01:01.000Z",
       "tlp" : "string",
       "asset_ref" : "string",
       "id" : "string",
@@ -1200,6 +1247,7 @@
       "schema_version" : "string",
       "source" : "string",
       "type" : "string",
+      "modified" : "2016-01-01T01:01:01.000Z",
       "source_uri" : "string",
       "asset_type" : "string",
       "language" : "string",
@@ -1217,6 +1265,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/coa.json
+++ b/doc/json/coa.json
@@ -5,6 +5,7 @@
     "relationship" : "string",
     "COA_id" : "string"
   } ],
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "efficacy" : "string",
   "structured_coa_type" : "string",
@@ -58,6 +59,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/feedback.json
+++ b/doc/json/feedback.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "entity_id" : "string",
   "id" : "string",
@@ -8,6 +9,7 @@
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "reason" : "string",
   "source_uri" : "string",
   "language" : "string",

--- a/doc/json/incident.json
+++ b/doc/json/incident.json
@@ -1,6 +1,7 @@
 {
   "confidence" : "string",
   "status_disposition" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "techniques" : [ "string" ],
   "id" : "string",
@@ -25,6 +26,10 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
+  "meta" : {
+    "keyword" : "string"
+  },
   "intended_effect" : "string",
   "source_uri" : "string",
   "language" : "string",

--- a/doc/json/indicator.json
+++ b/doc/json/indicator.json
@@ -6,6 +6,7 @@
     "operator" : "string",
     "indicator_ids" : [ "string" ]
   },
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "negate" : true,
   "kill_chain_phases" : [ {
@@ -27,6 +28,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/judgement.json
+++ b/doc/json/judgement.json
@@ -1,5 +1,6 @@
 {
   "confidence" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "priority" : 10,
   "id" : "string",
@@ -18,6 +19,7 @@
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "reason" : "string",
   "source_uri" : "string",
   "language" : "string",

--- a/doc/json/malware.json
+++ b/doc/json/malware.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "kill_chain_phases" : [ {
     "kill_chain_name" : "string",
@@ -15,6 +16,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/note.json
+++ b/doc/json/note.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "related_entities" : [ {
     "entity_type" : "string",
@@ -13,6 +14,7 @@
   "schema_version" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/relationship.json
+++ b/doc/json/relationship.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "target_ref" : "string",
   "relationship_type" : "string",
@@ -11,6 +12,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/sighting.json
+++ b/doc/json/sighting.json
@@ -22,6 +22,7 @@
       "type" : "string"
     }
   } ],
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "internal" : true,
   "id" : "string",
@@ -267,6 +268,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/target_record.json
+++ b/doc/json/target_record.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "id" : "string",
   "timestamp" : "2016-01-01T01:01:01.000Z",
@@ -23,6 +24,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/tool.json
+++ b/doc/json/tool.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "kill_chain_phases" : [ {
     "kill_chain_name" : "string",
@@ -15,6 +16,7 @@
   "source" : "string",
   "type" : "string",
   "tool_version" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "language" : "string",
   "external_references" : [ {

--- a/doc/json/vulnerability.json
+++ b/doc/json/vulnerability.json
@@ -1,4 +1,5 @@
 {
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "configurations" : {
     "CVE_data_version" : "string",
@@ -98,6 +99,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "published_date" : "2016-01-01T01:01:01.000Z",
   "source_uri" : "string",
   "cve" : {

--- a/doc/json/weakness.json
+++ b/doc/json/weakness.json
@@ -6,6 +6,7 @@
     "effectiveness_notes" : "string"
   } ],
   "background_details" : "string",
+  "created" : "2016-01-01T01:01:01.000Z",
   "tlp" : "string",
   "architectures" : [ {
     "prevalence" : "string",
@@ -44,6 +45,7 @@
   "title" : "string",
   "source" : "string",
   "type" : "string",
+  "modified" : "2016-01-01T01:01:01.000Z",
   "common_consequences" : [ {
     "scopes" : [ "string" ],
     "impacts" : [ "string" ],

--- a/doc/structures/actor.md
+++ b/doc/structures/actor.md
@@ -16,11 +16,13 @@
 |[actor_types](#propertyactor_types-threatactortypestringlist)|ThreatActorTypeString List| ||
 |[aliases](#propertyaliases-shortstringstringlist)|ShortStringString List|A list of other names that this Threat Actor is believed to use.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|This field can help analysts decide how much trust they can put in the information provided by the threat intelligence sources.  For example, an Actor entity can have high confidence if the organization's security researchers have been tracking it for a long time and have gathered a significant amount of intelligence about it through various sources, such as analysis of malware, network traffic, and human intelligence. In contrast, low confidence may indicate the organization has only seen limited or circumstantial evidence.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[identity](#propertyidentity-identityobject)|*Identity* Object|Can contain information such as the name of the attacker, the group or organization they belong to, or any other identifier that can help in the attribution process.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Represents the desired outcome or impact the threat actor is trying to achieve through their malicious activities.    Helps security analysts to understand the attacker's goals beyond the immediate impact of the attack. By understanding the intended effect, analysts can draw connections between seemingly unrelated attacks and build a more complete understanding of an attacker's long-term goals and motivations.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[motivation](#propertymotivation-motivationstring)|MotivationString|The reason or purpose behind the malicious activity attributed to this Actor. By understanding a threat actor's motivation, analysts can better predict the attacker's behavior and anticipate future malicious actions.||
 |[planning_and_operational_support](#propertyplanning_and_operational_support-longstringstring)|LongStringString|Provides information about the resources and capabilities of the attacker that could be used to assist in planning and operations related to the threat.   It can be used to describe Infrastructure, Tools, Techniques, and Capabilities used by the threat actor.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -86,6 +88,16 @@ For example, an Actor entity can have high confidence if the organization's secu
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -196,6 +208,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertymotivation-motivationstring"></a>
 ## Property motivation ∷ MotivationString

--- a/doc/structures/asset.md
+++ b/doc/structures/asset.md
@@ -11,10 +11,12 @@
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assettypeidentifierstring)|AssetTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Specifies the time range during which the asset is considered valid or accurate. For example, if an asset entity represents a device, the `valid_time` field could be used to indicate the period during which the device's configuration information is deemed accurate.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -38,6 +40,16 @@ Type of the Asset: Device, Person, Application, etc.
     * device
     * network
     * person
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -100,6 +112,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/asset_mapping.md
+++ b/doc/structures/asset_mapping.md
@@ -16,9 +16,11 @@
 |[stability](#propertystability-stabilitystring)|StabilityString|Do we manage when it changes, or is it always a time bound assignment?|&#10003;|
 |[type](#propertytype-assetmappingtypeidentifierstring)|AssetMappingTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|For each asset, we allow for the assertion of time bound properties.This gives us both a record of the current state of the asset,as well as history.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
@@ -67,6 +69,16 @@ Level of confidence held in the characterization of this AssetMapping e.g.: is i
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -119,6 +131,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object

--- a/doc/structures/asset_properties.md
+++ b/doc/structures/asset_properties.md
@@ -11,9 +11,11 @@
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assetpropertiestypeidentifierstring)|AssetPropertiesTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which the AssetProperties is considered valid.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[properties](#propertyproperties-assetpropertyobjectlist)|*AssetProperty* Object List| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -31,6 +33,16 @@ URI that points to the associated Asset.
 
 
   * A URI leading to an entity.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -83,6 +95,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyproperties-assetpropertyobjectlist"></a>
 ## Property properties ∷ *AssetProperty* Object List

--- a/doc/structures/attack_pattern.md
+++ b/doc/structures/attack_pattern.md
@@ -12,10 +12,12 @@
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-attackpatterntypeidentifierstring)|AttackPatternTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-attackpatternabstractionsstring)|AttackPatternAbstractionsString|The CAPEC abstraction level for patterns describing techniques to attack a system.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|A list of external references which refer to non-STIX information. This property MAY be used to provide one or more Attack Pattern identifiers, such as a CAPEC ID. When specifying a CAPEC ID, the source_name property of the external reference MUST be set to capec and the external_id property MUST be formatted as CAPEC-[id].||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|A kill chain is a series of steps that an attacker must go through to successfully achieve their objective. The concept was originally developed by the military, but has been adapted to the cybersecurity field to describe the steps an attacker goes through to compromise a target system and achieve their goal.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -43,6 +45,16 @@ The CAPEC abstraction level for patterns describing techniques to attack a syste
     * meta
     * standard
   * Reference: [Common Attack Pattern Enumeration and Classification](https://capec.mitre.org)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -112,6 +124,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -24,6 +24,7 @@
 |[campaigns](#propertycampaigns-campaignobject)|#{*Campaign* Object}|a list of `Campaign`s.||
 |[coa_refs](#propertycoa_refs-string)|#{String}| ||
 |[coas](#propertycoas-coaobject)|#{*COA* Object}|a list of `COA`s.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[data_table_refs](#propertydata_table_refs-string)|#{String}| ||
 |[data_tables](#propertydata_tables-datatableobject)|#{*DataTable* Object}|a list of `DataTable`s.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
@@ -42,6 +43,7 @@
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[malware_refs](#propertymalware_refs-string)|#{String}| ||
 |[malwares](#propertymalwares-malwareobject)|#{*Malware* Object}|a list of `Malware`s.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[note_refs](#propertynote_refs-string)|#{String}| ||
 |[notes](#propertynotes-noteobject)|#{*Note* Object}|a list of `Note`s.||
 |[relationship_refs](#propertyrelationship_refs-string)|#{String}| ||
@@ -220,6 +222,16 @@ a list of `COA`s.
 <a id="map8-ref"></a>
 * *COA* Object Value
   * Details: [*COA* Object](#map8)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydata_table_refs-string"></a>
 ## Property data_table_refs ∷ #{String}
@@ -436,6 +448,16 @@ a list of `Malware`s.
 <a id="map13-ref"></a>
 * *Malware* Object Value
   * Details: [*Malware* Object](#map13)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynote_refs-string"></a>
 ## Property note_refs ∷ #{String}
@@ -800,11 +822,13 @@ A URL reference to an external resource.
 |[actor_types](#propertyactor_types-threatactortypestringlist)|ThreatActorTypeString List| ||
 |[aliases](#propertyaliases-shortstringstringlist)|ShortStringString List|A list of other names that this Threat Actor is believed to use.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|This field can help analysts decide how much trust they can put in the information provided by the threat intelligence sources.  For example, an Actor entity can have high confidence if the organization's security researchers have been tracking it for a long time and have gathered a significant amount of intelligence about it through various sources, such as analysis of malware, network traffic, and human intelligence. In contrast, low confidence may indicate the organization has only seen limited or circumstantial evidence.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[identity](#propertyidentity-identityobject)|*Identity* Object|Can contain information such as the name of the attacker, the group or organization they belong to, or any other identifier that can help in the attribution process.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Represents the desired outcome or impact the threat actor is trying to achieve through their malicious activities.    Helps security analysts to understand the attacker's goals beyond the immediate impact of the attack. By understanding the intended effect, analysts can draw connections between seemingly unrelated attacks and build a more complete understanding of an attacker's long-term goals and motivations.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[motivation](#propertymotivation-motivationstring)|MotivationString|The reason or purpose behind the malicious activity attributed to this Actor. By understanding a threat actor's motivation, analysts can better predict the attacker's behavior and anticipate future malicious actions.||
 |[planning_and_operational_support](#propertyplanning_and_operational_support-longstringstring)|LongStringString|Provides information about the resources and capabilities of the attacker that could be used to assist in planning and operations related to the threat.   It can be used to describe Infrastructure, Tools, Techniques, and Capabilities used by the threat actor.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -870,6 +894,16 @@ For example, an Actor entity can have high confidence if the organization's secu
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -980,6 +1014,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertymotivation-motivationstring"></a>
 ## Property motivation ∷ MotivationString
@@ -1344,10 +1388,12 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assettypeidentifierstring)|AssetTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Specifies the time range during which the asset is considered valid or accurate. For example, if an asset entity represents a device, the `valid_time` field could be used to indicate the period during which the device's configuration information is deemed accurate.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -1371,6 +1417,16 @@ Type of the Asset: Device, Person, Application, etc.
     * device
     * network
     * person
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -1433,6 +1489,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -1656,9 +1722,11 @@ A URL reference to an external resource.
 |[stability](#propertystability-stabilitystring)|StabilityString|Do we manage when it changes, or is it always a time bound assignment?|&#10003;|
 |[type](#propertytype-assetmappingtypeidentifierstring)|AssetMappingTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|For each asset, we allow for the assertion of time bound properties.This gives us both a record of the current state of the asset,as well as history.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
@@ -1707,6 +1775,16 @@ Level of confidence held in the characterization of this AssetMapping e.g.: is i
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -1759,6 +1837,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object
@@ -2072,9 +2160,11 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assetpropertiestypeidentifierstring)|AssetPropertiesTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which the AssetProperties is considered valid.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[properties](#propertyproperties-assetpropertyobjectlist)|*AssetProperty* Object List| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -2092,6 +2182,16 @@ URI that points to the associated Asset.
 
 
   * A URI leading to an entity.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -2144,6 +2244,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyproperties-assetpropertyobjectlist"></a>
 ## Property properties ∷ *AssetProperty* Object List
@@ -2379,10 +2489,12 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-attackpatterntypeidentifierstring)|AttackPatternTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-attackpatternabstractionsstring)|AttackPatternAbstractionsString|The CAPEC abstraction level for patterns describing techniques to attack a system.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|A list of external references which refer to non-STIX information. This property MAY be used to provide one or more Attack Pattern identifiers, such as a CAPEC ID. When specifying a CAPEC ID, the source_name property of the external reference MUST be set to capec and the external_id property MUST be formatted as CAPEC-[id].||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|A kill chain is a series of steps that an attacker must go through to successfully achieve their objective. The concept was originally developed by the military, but has been adapted to the cybersecurity field to describe the steps an attacker goes through to compromise a target system and achieve their goal.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -2410,6 +2522,16 @@ The CAPEC abstraction level for patterns describing techniques to attack a syste
     * meta
     * standard
   * Reference: [Common Attack Pattern Enumeration and Classification](https://capec.mitre.org)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -2479,6 +2601,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -2794,10 +2926,12 @@ A URL reference to an external resource.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Timestamp for the definition of a specific version of a campaign.|&#10003;|
 |[activity](#propertyactivity-activityobjectlist)|*Activity* Object List|Used to capture specific activities or tactics associated with the campaign. The 'activity' field is an array of objects, and each element represents a specific activity and time associated with the campaign. Examples of activities may include malicious software delivery, command and control communication, network reconnaissance, data exfiltration, etc. By capturing these activities analysts can identify the specific tactics used by the threat actor(s) behind the campaign.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|Level of confidence held in the characterization of this Campaign.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstringlist)|IntendedEffectString List|Characterizes the intended effect of this cyber threat campaign.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[names](#propertynames-shortstringstringlist)|ShortStringString List|Used to capture alternate names or aliases associated with the campaign. A cyberattack campaign may have multiple names or aliases depending on the group or actor(s) behind the attack, e.g., 'Wannacry' is also known as 'WannaCrypt', 'WCry', 'Wanna Decryptor', etc.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -2849,6 +2983,16 @@ Level of confidence held in the characterization of this Campaign.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -2946,6 +3090,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynames-shortstringstringlist"></a>
 ## Property names ∷ ShortStringString List
@@ -3227,12 +3381,14 @@ A URL reference to an external resource.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
 |[coa_type](#propertycoa_type-coatypestring)|COATypeString|The type of this COA||
 |[cost](#propertycost-highmedlowstring)|HighMedLowString|Characterizes the estimated cost for applying this course of action.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[efficacy](#propertyefficacy-highmedlowstring)|HighMedLowString|Effectiveness of this course of action in achieving its targeted objective.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-shortstringstring)|ShortStringString|Characterizes the estimated impact of applying this course of action.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[objective](#propertyobjective-shortstringstringlist)|ShortStringString List|Characterizes the objective to provide guidance on how to mitigate a security incident that has been identified.||
 |[open_c2_coa](#propertyopen_c2_coa-openc2coaobject)|*OpenC2COA* Object| ||
 |[related_COAs](#propertyrelated_coas-relatedcoaobjectlist)|*RelatedCOA* Object List|Identifies or characterizes relationships to one or more related courses of action.||
@@ -3294,6 +3450,16 @@ Characterizes the estimated cost for applying this course of action.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -3383,6 +3549,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobjective-shortstringstringlist"></a>
 ## Property objective ∷ ShortStringString List
@@ -4189,15 +4365,27 @@ A URL reference to an external resource.
 |[reason](#propertyreason-string)|String| |&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-feedbacktypeidentifierstring)|FeedbackTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyentity_id-string"></a>
 ## Property entity_id ∷ String
@@ -4269,6 +4457,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyreason-string"></a>
 ## Property reason ∷ String
@@ -4435,12 +4633,15 @@ A URL reference to an external resource.
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
 |[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|A set of owners assigned to this incident.||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|A set of categories for this incident.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|Identifies how the incident was discovered.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[meta](#propertymeta-metadataobject)|*MetaData* Object|metadata associated to the incident.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|Describes method for promoting an Incident, whether manually or automatically. An Incident may be created manually by a SOAR analyst or SOC operator, or through an automated correlation or aggregation rule or engine that matches a specific set of events or alerts, and promotes them to Incident(s).||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|Used to indicate the severity or impact score of the threat represented by the incident.||
@@ -4521,6 +4722,16 @@ It is important to note that the `confidence` field is subjective and can be int
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -4659,6 +4870,28 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymeta-metadataobject"></a>
+## Property meta ∷ *MetaData* Object
+
+metadata associated to the incident.
+
+* This entry is optional
+
+
+<a id="map56-ref"></a>
+* *MetaData* Object Value
+  * Details: [*MetaData* Object](#map56)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertypromotion_method-promotionmethodstring"></a>
 ## Property promotion_method ∷ PromotionMethodString
 
@@ -4699,9 +4932,9 @@ Used to indicate the severity or impact score of the threat represented by the i
 * This entry is optional
 
 
-<a id="map56-ref"></a>
+<a id="map57-ref"></a>
 * *IncidentScores* Object Value
-  * Details: [*IncidentScores* Object](#map56)
+  * Details: [*IncidentScores* Object](#map57)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -4866,7 +5099,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "incident"
 
-<a id="map56"></a>
+<a id="map57"></a>
 # *IncidentScores* Object
 
 | Property | Type | Description | Required? |
@@ -4896,6 +5129,29 @@ For example, systems can have the following score types:
     * :ttp
 
   * A non-negative score number.
+
+<a id="map56"></a>
+# *MetaData* Object
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[Keyword](#propertykeyword-either)|String|custom field relevant to attach meta data to.||
+
+
+<a id="propertykeyword-either"></a>
+## Property Keyword ∷ Either
+
+custom field relevant to attach meta data to.
+
+* This entry is optional
+
+
+  * Only one of the following schemas will match
+
+
+
+
+
 
 <a id="map55"></a>
 # *IncidentTime* Object
@@ -5059,6 +5315,7 @@ _specification_ value.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which this Indicator is considered valid.|&#10003;|
 |[composite_indicator_expression](#propertycomposite_indicator_expression-compositeindicatorexpressionobject)|*CompositeIndicatorExpression* Object| ||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|level of confidence held in the accuracy of this Indicator.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -5066,6 +5323,7 @@ _specification_ value.
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|Relevant kill chain phases indicated by this Indicator.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[likely_impact](#propertylikely_impact-longstringstring)|LongStringString|Likely potential impact within the relevant context if this Indicator were to occur.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[negate](#propertynegate-boolean)|Boolean|Specifies the absence of the pattern.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[severity](#propertyseverity-severitystring)|SeverityString| ||
@@ -5087,9 +5345,9 @@ _specification_ value.
 * This entry is optional
 
 
-<a id="map59-ref"></a>
+<a id="map60-ref"></a>
 * *CompositeIndicatorExpression* Object Value
-  * Details: [*CompositeIndicatorExpression* Object](#map59)
+  * Details: [*CompositeIndicatorExpression* Object](#map60)
 
 <a id="propertyconfidence-highmedlowstring"></a>
 ## Property confidence ∷ HighMedLowString
@@ -5107,6 +5365,16 @@ level of confidence held in the accuracy of this Indicator.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -5144,9 +5412,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map57-ref"></a>
+<a id="map58-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map57)
+  * Details: [*ExternalReference* Object](#map58)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -5195,9 +5463,9 @@ Relevant kill chain phases indicated by this Indicator.
 * Dev Notes: simplified
 
 
-<a id="map60-ref"></a>
+<a id="map61-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map60)
+  * Details: [*KillChainPhase* Object](#map61)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortStringString
@@ -5220,6 +5488,16 @@ Likely potential impact within the relevant context if this Indicator were to oc
 
 
   * *LongString* String with at most 5000 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynegate-boolean"></a>
 ## Property negate ∷ Boolean
@@ -5312,25 +5590,25 @@ URI of the source of the intelligence that led to the creation of the entity.
 
   * Only one of the following schemas will match
 
-<a id="map61-ref"></a>
-* *JudgementSpecification* Object Value
-  * Details: [*JudgementSpecification* Object](#map61)
-
 <a id="map62-ref"></a>
-* *ThreatBrainSpecification* Object Value
-  * Details: [*ThreatBrainSpecification* Object](#map62)
+* *JudgementSpecification* Object Value
+  * Details: [*JudgementSpecification* Object](#map62)
 
 <a id="map63-ref"></a>
-* *SnortSpecification* Object Value
-  * Details: [*SnortSpecification* Object](#map63)
+* *ThreatBrainSpecification* Object Value
+  * Details: [*ThreatBrainSpecification* Object](#map63)
 
 <a id="map64-ref"></a>
-* *SIOCSpecification* Object Value
-  * Details: [*SIOCSpecification* Object](#map64)
+* *SnortSpecification* Object Value
+  * Details: [*SnortSpecification* Object](#map64)
 
 <a id="map65-ref"></a>
+* *SIOCSpecification* Object Value
+  * Details: [*SIOCSpecification* Object](#map65)
+
+<a id="map66-ref"></a>
 * *OpenIOCSpecification* Object Value
-  * Details: [*OpenIOCSpecification* Object](#map65)
+  * Details: [*OpenIOCSpecification* Object](#map66)
 
 <a id="propertytags-shortstringstringlist"></a>
 ## Property tags ∷ ShortStringString List
@@ -5413,11 +5691,11 @@ The time range during which this Indicator is considered valid.
 * This entry is required
 
 
-<a id="map58-ref"></a>
+<a id="map59-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map58)
+  * Details: [*ValidTime* Object](#map59)
 
-<a id="map65"></a>
+<a id="map66"></a>
 # *OpenIOCSpecification* Object
 
 *OpenIOCSpecification* An indicator which contains an XML blob of an openIOC indicator.
@@ -5443,7 +5721,7 @@ The time range during which this Indicator is considered valid.
 
   * Must equal: "OpenIOC"
 
-<a id="map64"></a>
+<a id="map65"></a>
 # *SIOCSpecification* Object
 
 *SIOCSpecification* An indicator which runs in snort...
@@ -5469,7 +5747,7 @@ The time range during which this Indicator is considered valid.
 
   * Must equal: "SIOC"
 
-<a id="map63"></a>
+<a id="map64"></a>
 # *SnortSpecification* Object
 
 *SnortSpecification* An indicator which runs in snort...
@@ -5495,7 +5773,7 @@ The time range during which this Indicator is considered valid.
 
   * Must equal: "Snort"
 
-<a id="map62"></a>
+<a id="map63"></a>
 # *ThreatBrainSpecification* Object
 
 *ThreatBrainSpecification* An indicator which runs in threatbrain...
@@ -5530,7 +5808,7 @@ The time range during which this Indicator is considered valid.
 
 
 
-<a id="map61"></a>
+<a id="map62"></a>
 # *JudgementSpecification* Object
 
 *JudgementSpecification* An indicator based on a list of judgements.  If any of the Observables in it's judgements are encountered, than it may be matches against.  If there are any required judgements, they all must be matched in order for the indicator to be considered a match.
@@ -5558,9 +5836,9 @@ The time range during which this Indicator is considered valid.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map66-ref"></a>
+<a id="map67-ref"></a>
 * *RelatedJudgement* Object Value
-  * Details: [*RelatedJudgement* Object](#map66)
+  * Details: [*RelatedJudgement* Object](#map67)
 
 <a id="propertytype-judgementspecificationtypestring"></a>
 ## Property type ∷ JudgementSpecificationTypeString
@@ -5570,7 +5848,7 @@ The time range during which this Indicator is considered valid.
 
   * Must equal: "Judgement"
 
-<a id="map66"></a>
+<a id="map67"></a>
 # *RelatedJudgement* Object
 
 | Property | Type | Description | Required? |
@@ -5618,7 +5896,7 @@ The time range during which this Indicator is considered valid.
 
 
 
-<a id="map60"></a>
+<a id="map61"></a>
 # *KillChainPhase* Object
 
 *KillChainPhase* The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -5661,7 +5939,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map59"></a>
+<a id="map60"></a>
 # *CompositeIndicatorExpression* Object
 
 | Property | Type | Description | Required? |
@@ -5691,7 +5969,7 @@ The name of the phase in the kill chain.
     * not
     * or
 
-<a id="map58"></a>
+<a id="map59"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -5723,7 +6001,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map57"></a>
+<a id="map58"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -5813,9 +6091,11 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-judgementtypeidentifierstring)|JudgementTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[reason](#propertyreason-shortstringstring)|ShortStringString| ||
 |[reason_uri](#propertyreason_uri-string)|String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -5838,6 +6118,16 @@ A URL reference to an external resource.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydisposition-dispositionnumberinteger"></a>
 ## Property disposition ∷ DispositionNumberInteger
@@ -5895,9 +6185,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map67-ref"></a>
+<a id="map68-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map67)
+  * Details: [*ExternalReference* Object](#map68)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -5921,15 +6211,25 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object
 
 * This entry is required
 
 
-<a id="map68-ref"></a>
+<a id="map69-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map68)
+  * Details: [*Observable* Object](#map69)
 
 <a id="propertypriority-integer"></a>
 ## Property priority ∷ Integer
@@ -6053,11 +6353,11 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is required
 
 
-<a id="map69-ref"></a>
+<a id="map70-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map69)
+  * Details: [*ValidTime* Object](#map70)
 
-<a id="map69"></a>
+<a id="map70"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -6089,7 +6389,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map68"></a>
+<a id="map69"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -6167,7 +6467,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
 
 
-<a id="map67"></a>
+<a id="map68"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6244,10 +6544,12 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-malwareabstractionsstring)|MalwareAbstractionsString|Malware abstraction level.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -6270,6 +6572,16 @@ Malware abstraction level.
     * family
     * variant
     * version
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -6307,9 +6619,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map70-ref"></a>
+<a id="map71-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map70)
+  * Details: [*ExternalReference* Object](#map71)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -6330,9 +6642,9 @@ The list of Kill Chain Phases for which this Malware can be used.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map71-ref"></a>
+<a id="map72-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map71)
+  * Details: [*KillChainPhase* Object](#map72)
 
 <a id="propertylabels-malwarelabelstringlist"></a>
 ## Property labels ∷ MalwareLabelString List
@@ -6375,6 +6687,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -6484,7 +6806,7 @@ ATT&CK Software.aliases.
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map71"></a>
+<a id="map72"></a>
 # *KillChainPhase* Object
 
 *KillChainPhase* The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -6527,7 +6849,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map70"></a>
+<a id="map71"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6604,9 +6926,11 @@ For example, an analyst may add a Note to a Campaign object created by another o
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-notetypeidentifierstring)|NoteTypeIdentifierString| |&#10003;|
 |[author](#propertyauthor-string)|String| ||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -6628,6 +6952,16 @@ For example, an analyst may add a Note to a Campaign object created by another o
 
 
   * *Markdown* Markdown string with at most 5000 characters.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -6655,9 +6989,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map72-ref"></a>
+<a id="map73-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map72)
+  * Details: [*ExternalReference* Object](#map73)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -6681,6 +7015,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertynote_class-keyword"></a>
 ## Property note_class ∷ Keyword
 
@@ -6695,9 +7039,9 @@ For example, if an incident involves an attack on a system in a country where a 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map73-ref"></a>
+<a id="map74-ref"></a>
 * *NoteRelatedEntity* Object Value
-  * Details: [*NoteRelatedEntity* Object](#map73)
+  * Details: [*NoteRelatedEntity* Object](#map74)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -6776,7 +7120,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "note"
 
-<a id="map73"></a>
+<a id="map74"></a>
 # *NoteRelatedEntity* Object
 
 | Property | Type | Description | Required? |
@@ -6800,7 +7144,7 @@ For example, an entity containing information about a critical vulnerability in 
 
 
 
-<a id="map72"></a>
+<a id="map73"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -6875,10 +7219,12 @@ A URL reference to an external resource.
 |[source_ref](#propertysource_ref-string)|String| |&#10003;|
 |[target_ref](#propertytarget_ref-string)|String| |&#10003;|
 |[type](#propertytype-relationshiptypeidentifierstring)|RelationshipTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -6887,6 +7233,16 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -6924,9 +7280,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map74-ref"></a>
+<a id="map75-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map74)
+  * Details: [*ExternalReference* Object](#map75)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -6949,6 +7305,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrelationship_type-relationshiptypestring"></a>
 ## Property relationship_type ∷ RelationshipTypeString
@@ -7090,7 +7456,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "relationship"
 
-<a id="map74"></a>
+<a id="map75"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -7166,12 +7532,14 @@ A URL reference to an external resource.
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-sightingtypeidentifierstring)|SightingTypeIdentifierString| |&#10003;|
 |[context](#propertycontext-contextobject)|*Context* Object|Context including the event type that best fits the type of the sighting.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[data](#propertydata-sightingdatatableobject)|*SightingDataTable* Object|An embedded data table for the Sighting.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[internal](#propertyinternal-boolean)|Boolean|If `true`, indicates that the sighting was reported from internal sources, such as an organization's own internal security tools or SOC.  Internal sightings are often considered more reliable and actionable than external sightings, which are reported from external sources and may have a lower level of trustworthiness. Internal sightings can provide more context and can help identify potential threats that are unique to a particular environment or organization.  Internal sightings can also help organizations prioritize their security response efforts by identifying threats that are specific to their environment and may not yet be widely known.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List|The object(s) of interest.||
 |[relations](#propertyrelations-observedrelationobjectlist)|*ObservedRelation* Object List|Provide any context we can about where the observable came from.||
 |[resolution](#propertyresolution-resolutionstring)|ResolutionString|Represents the disposition or actions taken on the associated threat intelligence.||
@@ -7212,9 +7580,9 @@ Context including the event type that best fits the type of the sighting.
 * This entry is optional
 
 
-<a id="map82-ref"></a>
+<a id="map83-ref"></a>
 * *Context* Object Value
-  * Details: [*Context* Object](#map82)
+  * Details: [*Context* Object](#map83)
 
 <a id="propertycount-integer"></a>
 ## Property count ∷ Integer
@@ -7228,6 +7596,16 @@ It can also be used to prioritize security alerts and indicate the urgency of a 
 
   * Zero, or a positive integer.
 
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertydata-sightingdatatableobject"></a>
 ## Property data ∷ *SightingDataTable* Object
 
@@ -7236,9 +7614,9 @@ An embedded data table for the Sighting.
 * This entry is optional
 
 
-<a id="map77-ref"></a>
+<a id="map78-ref"></a>
 * *SightingDataTable* Object Value
-  * Details: [*SightingDataTable* Object](#map77)
+  * Details: [*SightingDataTable* Object](#map78)
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -7276,9 +7654,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map75-ref"></a>
+<a id="map76-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map75)
+  * Details: [*ExternalReference* Object](#map76)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -7313,6 +7691,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyobservables-observableobjectlist"></a>
 ## Property observables ∷ *Observable* Object List
 
@@ -7322,9 +7710,9 @@ The object(s) of interest.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map80-ref"></a>
+<a id="map81-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map80)
+  * Details: [*Observable* Object](#map81)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -7332,9 +7720,9 @@ The object(s) of interest.
 * This entry is required
 
 
-<a id="map76-ref"></a>
+<a id="map77-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map76)
+  * Details: [*ObservedTime* Object](#map77)
 
 <a id="propertyrelations-observedrelationobjectlist"></a>
 ## Property relations ∷ *ObservedRelation* Object List
@@ -7345,9 +7733,9 @@ Provide any context we can about where the observable came from.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map81-ref"></a>
+<a id="map82-ref"></a>
 * *ObservedRelation* Object Value
-  * Details: [*ObservedRelation* Object](#map81)
+  * Details: [*ObservedRelation* Object](#map82)
 
 <a id="propertyresolution-resolutionstring"></a>
 ## Property resolution ∷ ResolutionString
@@ -7447,9 +7835,9 @@ The OpenC2 Actuator name that best fits the device that is creating this sightin
 * This entry is optional
 
 
-<a id="map78-ref"></a>
+<a id="map79-ref"></a>
 * *SensorCoordinates* Object Value
-  * Details: [*SensorCoordinates* Object](#map78)
+  * Details: [*SensorCoordinates* Object](#map79)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -7507,9 +7895,9 @@ Can be used to assess the scope of potential threats, helping analysts understan
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map79-ref"></a>
+<a id="map80-ref"></a>
 * *IdentitySpecification* Object Value
-  * Details: [*IdentitySpecification* Object](#map79)
+  * Details: [*IdentitySpecification* Object](#map80)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -7558,7 +7946,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "sighting"
 
-<a id="map82"></a>
+<a id="map83"></a>
 # *Context* Object
 
 | Property | Type | Description | Required? |
@@ -7586,9 +7974,9 @@ a list of `FileCreateType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map85-ref"></a>
+<a id="map86-ref"></a>
 * *FileCreateType* Object Value
-  * Details: [*FileCreateType* Object](#map85)
+  * Details: [*FileCreateType* Object](#map86)
 
 <a id="propertyfile_delete_events-filedeletetypeobjectlist"></a>
 ## Property file_delete_events ∷ *FileDeleteType* Object List
@@ -7599,9 +7987,9 @@ a list of `FileDeleteType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map86-ref"></a>
+<a id="map87-ref"></a>
 * *FileDeleteType* Object Value
-  * Details: [*FileDeleteType* Object](#map86)
+  * Details: [*FileDeleteType* Object](#map87)
 
 <a id="propertyfile_modify_events-filemodifytypeobjectlist"></a>
 ## Property file_modify_events ∷ *FileModifyType* Object List
@@ -7612,9 +8000,9 @@ a list of `FileModifyType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map87-ref"></a>
+<a id="map88-ref"></a>
 * *FileModifyType* Object Value
-  * Details: [*FileModifyType* Object](#map87)
+  * Details: [*FileModifyType* Object](#map88)
 
 <a id="propertyfile_move_events-filemovetypeobjectlist"></a>
 ## Property file_move_events ∷ *FileMoveType* Object List
@@ -7625,9 +8013,9 @@ a list of `FileMoveType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map88-ref"></a>
+<a id="map89-ref"></a>
 * *FileMoveType* Object Value
-  * Details: [*FileMoveType* Object](#map88)
+  * Details: [*FileMoveType* Object](#map89)
 
 <a id="propertyhttp_events-httptypeobjectlist"></a>
 ## Property http_events ∷ *HTTPType* Object List
@@ -7638,9 +8026,9 @@ a list of `HTTPType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map90-ref"></a>
+<a id="map91-ref"></a>
 * *HTTPType* Object Value
-  * Details: [*HTTPType* Object](#map90)
+  * Details: [*HTTPType* Object](#map91)
 
 <a id="propertylibrary_load_events-libraryloadtypeobjectlist"></a>
 ## Property library_load_events ∷ *LibraryLoadType* Object List
@@ -7651,9 +8039,9 @@ a list of `LibraryLoadType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map84-ref"></a>
+<a id="map85-ref"></a>
 * *LibraryLoadType* Object Value
-  * Details: [*LibraryLoadType* Object](#map84)
+  * Details: [*LibraryLoadType* Object](#map85)
 
 <a id="propertynetflow_events-netflowtypeobjectlist"></a>
 ## Property netflow_events ∷ *NetflowType* Object List
@@ -7664,9 +8052,9 @@ a list of `NetflowType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map89-ref"></a>
+<a id="map90-ref"></a>
 * *NetflowType* Object Value
-  * Details: [*NetflowType* Object](#map89)
+  * Details: [*NetflowType* Object](#map90)
 
 <a id="propertyprocess_create_events-processcreatetypeobjectlist"></a>
 ## Property process_create_events ∷ *ProcessCreateType* Object List
@@ -7677,9 +8065,9 @@ a list of `ProcessCreate`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map83-ref"></a>
+<a id="map84-ref"></a>
 * *ProcessCreateType* Object Value
-  * Details: [*ProcessCreateType* Object](#map83)
+  * Details: [*ProcessCreateType* Object](#map84)
 
 <a id="propertyregistry_create_events-registrycreatetypeobjectlist"></a>
 ## Property registry_create_events ∷ *RegistryCreateType* Object List
@@ -7690,9 +8078,9 @@ a list of `RegistryCreateType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map91-ref"></a>
+<a id="map92-ref"></a>
 * *RegistryCreateType* Object Value
-  * Details: [*RegistryCreateType* Object](#map91)
+  * Details: [*RegistryCreateType* Object](#map92)
 
 <a id="propertyregistry_delete_events-registrydeletetypeobjectlist"></a>
 ## Property registry_delete_events ∷ *RegistryDeleteType* Object List
@@ -7703,9 +8091,9 @@ a list of `RegistryDeleteType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map93-ref"></a>
+<a id="map94-ref"></a>
 * *RegistryDeleteType* Object Value
-  * Details: [*RegistryDeleteType* Object](#map93)
+  * Details: [*RegistryDeleteType* Object](#map94)
 
 <a id="propertyregistry_rename_events-registryrenametypeobjectlist"></a>
 ## Property registry_rename_events ∷ *RegistryRenameType* Object List
@@ -7716,9 +8104,9 @@ a list of `RegistryRenameType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map94-ref"></a>
+<a id="map95-ref"></a>
 * *RegistryRenameType* Object Value
-  * Details: [*RegistryRenameType* Object](#map94)
+  * Details: [*RegistryRenameType* Object](#map95)
 
 <a id="propertyregistry_set_events-registrysettypeobjectlist"></a>
 ## Property registry_set_events ∷ *RegistrySetType* Object List
@@ -7729,11 +8117,11 @@ a list of `RegistrySetType`
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map92-ref"></a>
+<a id="map93-ref"></a>
 * *RegistrySetType* Object Value
-  * Details: [*RegistrySetType* Object](#map92)
+  * Details: [*RegistrySetType* Object](#map93)
 
-<a id="map94"></a>
+<a id="map95"></a>
 # *RegistryRenameType* Object
 
 | Property | Type | Description | Required? |
@@ -7800,9 +8188,9 @@ a list of `RegistrySetType`
 * This entry is required
 
 
-<a id="map95-ref"></a>
+<a id="map96-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map95)
+  * Details: [*ObservedTime* Object](#map96)
 
 <a id="propertytype-registryrenametypeidentifierstring"></a>
 ## Property type ∷ RegistryRenameTypeIdentifierString
@@ -7812,7 +8200,7 @@ a list of `RegistrySetType`
 
   * Must equal: "RegistryRenameEvent"
 
-<a id="map95"></a>
+<a id="map96"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -7844,7 +8232,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map93"></a>
+<a id="map94"></a>
 # *RegistryDeleteType* Object
 
 | Property | Type | Description | Required? |
@@ -7857,6 +8245,7 @@ Time of the observation. If the observation was made over a period of time, than
 |[process_guid](#propertyprocess_guid-integer)|Integer| ||
 |[process_username](#propertyprocess_username-shortstringstring)|ShortStringString| ||
 |[registry_value](#propertyregistry_value-medstringstring)|MedStringString| ||
+
 
 <a id="propertyprocess_guid-integer"></a>
 ## Property process_guid ∷ Integer
@@ -7910,9 +8299,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map96-ref"></a>
+<a id="map97-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map96)
+  * Details: [*ObservedTime* Object](#map97)
 
 <a id="propertytype-registrydeletetypeidentifierstring"></a>
 ## Property type ∷ RegistryDeleteTypeIdentifierString
@@ -7922,7 +8311,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "RegistryDeleteEvent"
 
-<a id="map96"></a>
+<a id="map97"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -7954,7 +8343,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map92"></a>
+<a id="map93"></a>
 # *RegistrySetType* Object
 
 | Property | Type | Description | Required? |
@@ -8038,9 +8427,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map97-ref"></a>
+<a id="map98-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map97)
+  * Details: [*ObservedTime* Object](#map98)
 
 <a id="propertytype-registrysettypeidentifierstring"></a>
 ## Property type ∷ RegistrySetTypeIdentifierString
@@ -8050,7 +8439,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "RegistrySetEvent"
 
-<a id="map97"></a>
+<a id="map98"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8082,7 +8471,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map91"></a>
+<a id="map92"></a>
 # *RegistryCreateType* Object
 
 | Property | Type | Description | Required? |
@@ -8140,9 +8529,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map98-ref"></a>
+<a id="map99-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map98)
+  * Details: [*ObservedTime* Object](#map99)
 
 <a id="propertytype-registrycreatetypeidentifierstring"></a>
 ## Property type ∷ RegistryCreateTypeIdentifierString
@@ -8152,7 +8541,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "RegistryCreateEvent"
 
-<a id="map98"></a>
+<a id="map99"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8184,7 +8573,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map90"></a>
+<a id="map91"></a>
 # *HTTPType* Object
 
 | Property | Type | Description | Required? |
@@ -8222,6 +8611,7 @@ Time of the observation. If the observation was made over a period of time, than
 ## Property method ∷ HTTPMethodString
 
 * This entry is optional
+
 
   * Allowed Values:
     * CONNECT
@@ -8277,9 +8667,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map99-ref"></a>
+<a id="map100-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map99)
+  * Details: [*ObservedTime* Object](#map100)
 
 <a id="propertytraffic-trafficobject"></a>
 ## Property traffic ∷ *Traffic* Object
@@ -8287,9 +8677,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map100-ref"></a>
+<a id="map101-ref"></a>
 * *Traffic* Object Value
-  * Details: [*Traffic* Object](#map100)
+  * Details: [*Traffic* Object](#map101)
 
 <a id="propertytype-httptypeidentifierstring"></a>
 ## Property type ∷ HTTPTypeIdentifierString
@@ -8306,7 +8696,7 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 
-<a id="map100"></a>
+<a id="map101"></a>
 # *Traffic* Object
 
 | Property | Type | Description | Required? |
@@ -8390,7 +8780,7 @@ The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-
 
 
 
-<a id="map99"></a>
+<a id="map100"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8422,7 +8812,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map89"></a>
+<a id="map90"></a>
 # *NetflowType* Object
 
 | Property | Type | Description | Required? |
@@ -8604,9 +8994,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map101-ref"></a>
+<a id="map102-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map101)
+  * Details: [*ObservedTime* Object](#map102)
 
 <a id="propertytraffic-trafficobject"></a>
 ## Property traffic ∷ *Traffic* Object
@@ -8614,9 +9004,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map102-ref"></a>
+<a id="map103-ref"></a>
 * *Traffic* Object Value
-  * Details: [*Traffic* Object](#map102)
+  * Details: [*Traffic* Object](#map103)
 
 <a id="propertytype-netflowtypeidentifierstring"></a>
 ## Property type ∷ NetflowTypeIdentifierString
@@ -8626,7 +9016,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "NetflowEvent"
 
-<a id="map102"></a>
+<a id="map103"></a>
 # *Traffic* Object
 
 | Property | Type | Description | Required? |
@@ -8710,7 +9100,7 @@ The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-
 
 
 
-<a id="map101"></a>
+<a id="map102"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8742,7 +9132,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map88"></a>
+<a id="map89"></a>
 # *FileMoveType* Object
 
 | Property | Type | Description | Required? |
@@ -8827,9 +9217,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map103-ref"></a>
+<a id="map104-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map103)
+  * Details: [*ObservedTime* Object](#map104)
 
 <a id="propertytype-filemovetypeidentifierstring"></a>
 ## Property type ∷ FileMoveTypeIdentifierString
@@ -8839,7 +9229,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "FileMoveEvent"
 
-<a id="map103"></a>
+<a id="map104"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8871,7 +9261,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map87"></a>
+<a id="map88"></a>
 # *FileModifyType* Object
 
 | Property | Type | Description | Required? |
@@ -8946,9 +9336,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map104-ref"></a>
+<a id="map105-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map104)
+  * Details: [*ObservedTime* Object](#map105)
 
 <a id="propertytype-filemodifytypeidentifierstring"></a>
 ## Property type ∷ FileModifyTypeIdentifierString
@@ -8958,7 +9348,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "FileModifyEvent"
 
-<a id="map104"></a>
+<a id="map105"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -8990,7 +9380,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map86"></a>
+<a id="map87"></a>
 # *FileDeleteType* Object
 
 | Property | Type | Description | Required? |
@@ -9065,9 +9455,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map105-ref"></a>
+<a id="map106-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map105)
+  * Details: [*ObservedTime* Object](#map106)
 
 <a id="propertytype-filedeletetypeidentifierstring"></a>
 ## Property type ∷ FileDeleteTypeIdentifierString
@@ -9077,7 +9467,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "FileDeleteEvent"
 
-<a id="map105"></a>
+<a id="map106"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -9109,7 +9499,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map85"></a>
+<a id="map86"></a>
 # *FileCreateType* Object
 
 | Property | Type | Description | Required? |
@@ -9184,9 +9574,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map106-ref"></a>
+<a id="map107-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map106)
+  * Details: [*ObservedTime* Object](#map107)
 
 <a id="propertytype-filecreatetypeidentifierstring"></a>
 ## Property type ∷ FileCreateTypeIdentifierString
@@ -9196,7 +9586,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "FileCreateEvent"
 
-<a id="map106"></a>
+<a id="map107"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -9228,7 +9618,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map84"></a>
+<a id="map85"></a>
 # *LibraryLoadType* Object
 
 | Property | Type | Description | Required? |
@@ -9295,9 +9685,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map107-ref"></a>
+<a id="map108-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map107)
+  * Details: [*ObservedTime* Object](#map108)
 
 <a id="propertytype-libraryloadtypeidentifierstring"></a>
 ## Property type ∷ LibraryLoadTypeIdentifierString
@@ -9307,7 +9697,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "LibraryLoadEvent"
 
-<a id="map107"></a>
+<a id="map108"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -9339,7 +9729,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map83"></a>
+<a id="map84"></a>
 # *ProcessCreateType* Object
 
 | Property | Type | Description | Required? |
@@ -9501,9 +9891,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map108-ref"></a>
+<a id="map109-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map108)
+  * Details: [*ObservedTime* Object](#map109)
 
 <a id="propertytype-processcreatetypeidentifierstring"></a>
 ## Property type ∷ ProcessCreateTypeIdentifierString
@@ -9513,7 +9903,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * Must equal: "ProcessCreateEvent"
 
-<a id="map108"></a>
+<a id="map109"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -9545,7 +9935,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map81"></a>
+<a id="map82"></a>
 # *ObservedRelation* Object
 
 *ObservedRelation* A relation inside a Sighting.
@@ -9581,9 +9971,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map111-ref"></a>
+<a id="map112-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map111)
+  * Details: [*Observable* Object](#map112)
 
 <a id="propertyrelation-observablerelationtypestring"></a>
 ## Property relation ∷ ObservableRelationTypeString
@@ -9737,9 +10127,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is optional
 
 
-<a id="map109-ref"></a>
+<a id="map110-ref"></a>
 * Object Value
-  * Details: [Object](#map109)
+  * Details: [Object](#map110)
 
 <a id="propertysource-observableobject"></a>
 ## Property source ∷ *Observable* Object
@@ -9747,9 +10137,87 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry is required
 
 
-<a id="map110-ref"></a>
+<a id="map111-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map110)
+  * Details: [*Observable* Object](#map111)
+
+<a id="map112"></a>
+# *Observable* Object
+
+*Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifierString| |&#10003;|
+|[value](#propertyvalue-string)|String| |&#10003;|
+
+
+<a id="propertytype-observabletypeidentifierstring"></a>
+## Property type ∷ ObservableTypeIdentifierString
+
+* This entry is required
+
+
+  * *ObservableTypeIdentifier* Observable type names
+  * Allowed Values:
+    * amp_computer_guid
+    * certificate_common_name
+    * certificate_issuer
+    * certificate_serial
+    * cisco_cm_id
+    * cisco_mid
+    * cisco_uc_id
+    * cortex_agent_id
+    * crowdstrike_id
+    * cybereason_id
+    * darktrace_id
+    * device
+    * domain
+    * email
+    * email_messageid
+    * email_subject
+    * file_name
+    * file_path
+    * hostname
+    * imei
+    * imsi
+    * ip
+    * ipv6
+    * mac_address
+    * md5
+    * ms_machine_id
+    * mutex
+    * ngfw_id
+    * ngfw_name
+    * odns_identity
+    * odns_identity_label
+    * orbital_node_id
+    * pki_serial
+    * process_args
+    * process_hash
+    * process_name
+    * process_path
+    * process_username
+    * processor_id
+    * registry_key
+    * registry_name
+    * registry_path
+    * s1_agent_id
+    * serial_number
+    * sha1
+    * sha256
+    * swc_device_id
+    * trend_micro_id
+    * url
+    * user
+    * user_agent
+
+<a id="propertyvalue-string"></a>
+## Property value ∷ String
+
+* This entry is required
+
+
 
 <a id="map111"></a>
 # *Observable* Object
@@ -9830,6 +10298,21 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 <a id="map110"></a>
+# Object
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[Keyword](#propertykeyword-anything)|Anything| |&#10003;|
+
+
+<a id="propertykeyword-anything"></a>
+## Property Keyword ∷ Anything
+
+* This entry is required
+
+
+
+<a id="map81"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -9907,22 +10390,134 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 
-<a id="map109"></a>
-# Object
+<a id="map80"></a>
+# *IdentitySpecification* Object
+
+*IdentitySpecification* Describes the target of the sighting and contains identifying observables for the target.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
-|[Keyword](#propertykeyword-anything)|Anything| |&#10003;|
+|[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
+|[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
+|[type](#propertytype-sensorstring)|SensorString| |&#10003;|
+|[os](#propertyos-string)|String| ||
 
 
-<a id="propertykeyword-anything"></a>
-## Property Keyword ∷ Anything
+<a id="propertyobservables-observableobjectlist"></a>
+## Property observables ∷ *Observable* Object List
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map113-ref"></a>
+* *Observable* Object Value
+  * Details: [*Observable* Object](#map113)
+
+<a id="propertyobserved_time-observedtimeobject"></a>
+## Property observed_time ∷ *ObservedTime* Object
 
 * This entry is required
 
 
+<a id="map114-ref"></a>
+* *ObservedTime* Object Value
+  * Details: [*ObservedTime* Object](#map114)
 
-<a id="map80"></a>
+<a id="propertyos-string"></a>
+## Property os ∷ String
+
+* This entry is optional
+
+
+
+<a id="propertytype-sensorstring"></a>
+## Property type ∷ SensorString
+
+* This entry is required
+
+
+  * *Sensor* The sensor/actuator name that best fits a device.
+  * Allowed Values:
+    * endpoint
+    * endpoint.digital-telephone-handset
+    * endpoint.laptop
+    * endpoint.pos-terminal
+    * endpoint.printer
+    * endpoint.sensor
+    * endpoint.server
+    * endpoint.smart-meter
+    * endpoint.smart-phone
+    * endpoint.tablet
+    * endpoint.workstation
+    * network
+    * network.bridge
+    * network.firewall
+    * network.gateway
+    * network.guard
+    * network.hips
+    * network.hub
+    * network.ids
+    * network.ips
+    * network.modem
+    * network.nic
+    * network.proxy
+    * network.router
+    * network.security_manager
+    * network.sense_making
+    * network.sensor
+    * network.switch
+    * network.vpn
+    * network.wap
+    * process
+    * process.aaa-server
+    * process.anti-virus-scanner
+    * process.connection-scanner
+    * process.directory-service
+    * process.dns-server
+    * process.email-service
+    * process.file-scanner
+    * process.location-service
+    * process.network-scanner
+    * process.remediation-service
+    * process.reputation-service
+    * process.sandbox
+    * process.virtualization-service
+    * process.vulnerability-scanner
+
+<a id="map114"></a>
+# *ObservedTime* Object
+
+*ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[start_time](#propertystart_time-instdate)|Inst (Date)|Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.|&#10003;|
+|[end_time](#propertyend_time-instdate)|Inst (Date)|If the observation was made over a period of time, than this field indicates the end of that period.||
+
+* Reference: [ValidTimeType](http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/)
+
+<a id="propertyend_time-instdate"></a>
+## Property end_time ∷ Inst (Date)
+
+If the observation was made over a period of time, than this field indicates the end of that period.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="propertystart_time-instdate"></a>
+## Property start_time ∷ Inst (Date)
+
+Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.
+
+* This entry is required
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="map113"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -10001,14 +10596,13 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 <a id="map79"></a>
-# *IdentitySpecification* Object
+# *SensorCoordinates* Object
 
-*IdentitySpecification* Describes the target of the sighting and contains identifying observables for the target.
+*SensorCoordinates* Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.
 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
-|[observed_time](#propertyobserved_time-observedtimeobject)|*ObservedTime* Object| |&#10003;|
 |[type](#propertytype-sensorstring)|SensorString| |&#10003;|
 |[os](#propertyos-string)|String| ||
 
@@ -10020,19 +10614,9 @@ Time of the observation. If the observation was made over a period of time, than
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map112-ref"></a>
+<a id="map115-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map112)
-
-<a id="propertyobserved_time-observedtimeobject"></a>
-## Property observed_time ∷ *ObservedTime* Object
-
-* This entry is required
-
-
-<a id="map113-ref"></a>
-* *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map113)
+  * Details: [*Observable* Object](#map115)
 
 <a id="propertyos-string"></a>
 ## Property os ∷ String
@@ -10095,39 +10679,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process.virtualization-service
     * process.vulnerability-scanner
 
-<a id="map113"></a>
-# *ObservedTime* Object
-
-*ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[start_time](#propertystart_time-instdate)|Inst (Date)|Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.|&#10003;|
-|[end_time](#propertyend_time-instdate)|Inst (Date)|If the observation was made over a period of time, than this field indicates the end of that period.||
-
-* Reference: [ValidTimeType](http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/)
-
-<a id="propertyend_time-instdate"></a>
-## Property end_time ∷ Inst (Date)
-
-If the observation was made over a period of time, than this field indicates the end of that period.
-
-* This entry is optional
-
-
-  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-
-<a id="propertystart_time-instdate"></a>
-## Property start_time ∷ Inst (Date)
-
-Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.
-
-* This entry is required
-
-
-  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
-
-<a id="map112"></a>
+<a id="map115"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -10206,168 +10758,6 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 <a id="map78"></a>
-# *SensorCoordinates* Object
-
-*SensorCoordinates* Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| |&#10003;|
-|[type](#propertytype-sensorstring)|SensorString| |&#10003;|
-|[os](#propertyos-string)|String| ||
-
-
-<a id="propertyobservables-observableobjectlist"></a>
-## Property observables ∷ *Observable* Object List
-
-* This entry is required
-* This entry's type is sequential (allows zero or more values)
-
-
-<a id="map114-ref"></a>
-* *Observable* Object Value
-  * Details: [*Observable* Object](#map114)
-
-<a id="propertyos-string"></a>
-## Property os ∷ String
-
-* This entry is optional
-
-
-
-<a id="propertytype-sensorstring"></a>
-## Property type ∷ SensorString
-
-* This entry is required
-
-
-  * *Sensor* The sensor/actuator name that best fits a device.
-  * Allowed Values:
-    * endpoint
-    * endpoint.digital-telephone-handset
-    * endpoint.laptop
-    * endpoint.pos-terminal
-    * endpoint.printer
-    * endpoint.sensor
-    * endpoint.server
-    * endpoint.smart-meter
-    * endpoint.smart-phone
-    * endpoint.tablet
-    * endpoint.workstation
-    * network
-    * network.bridge
-    * network.firewall
-    * network.gateway
-    * network.guard
-    * network.hips
-    * network.hub
-    * network.ids
-    * network.ips
-    * network.modem
-    * network.nic
-    * network.proxy
-    * network.router
-    * network.security_manager
-    * network.sense_making
-    * network.sensor
-    * network.switch
-    * network.vpn
-    * network.wap
-    * process
-    * process.aaa-server
-    * process.anti-virus-scanner
-    * process.connection-scanner
-    * process.directory-service
-    * process.dns-server
-    * process.email-service
-    * process.file-scanner
-    * process.location-service
-    * process.network-scanner
-    * process.remediation-service
-    * process.reputation-service
-    * process.sandbox
-    * process.virtualization-service
-    * process.vulnerability-scanner
-
-<a id="map114"></a>
-# *Observable* Object
-
-*Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[type](#propertytype-observabletypeidentifierstring)|ObservableTypeIdentifierString| |&#10003;|
-|[value](#propertyvalue-string)|String| |&#10003;|
-
-
-<a id="propertytype-observabletypeidentifierstring"></a>
-## Property type ∷ ObservableTypeIdentifierString
-
-* This entry is required
-
-
-  * *ObservableTypeIdentifier* Observable type names
-  * Allowed Values:
-    * amp_computer_guid
-    * certificate_common_name
-    * certificate_issuer
-    * certificate_serial
-    * cisco_cm_id
-    * cisco_mid
-    * cisco_uc_id
-    * cortex_agent_id
-    * crowdstrike_id
-    * cybereason_id
-    * darktrace_id
-    * device
-    * domain
-    * email
-    * email_messageid
-    * email_subject
-    * file_name
-    * file_path
-    * hostname
-    * imei
-    * imsi
-    * ip
-    * ipv6
-    * mac_address
-    * md5
-    * ms_machine_id
-    * mutex
-    * ngfw_id
-    * ngfw_name
-    * odns_identity
-    * odns_identity_label
-    * orbital_node_id
-    * pki_serial
-    * process_args
-    * process_hash
-    * process_name
-    * process_path
-    * process_username
-    * processor_id
-    * registry_key
-    * registry_name
-    * registry_path
-    * s1_agent_id
-    * serial_number
-    * sha1
-    * sha256
-    * swc_device_id
-    * trend_micro_id
-    * url
-    * user
-    * user_agent
-
-<a id="propertyvalue-string"></a>
-## Property value ∷ String
-
-* This entry is required
-
-
-
-<a id="map77"></a>
 # *SightingDataTable* Object
 
 *SightingDataTable* An embedded data table for sightings data.
@@ -10388,9 +10778,9 @@ an ordered list of column definitions
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map115-ref"></a>
+<a id="map116-ref"></a>
 * *ColumnDefinition* Object Value
-  * Details: [*ColumnDefinition* Object](#map115)
+  * Details: [*ColumnDefinition* Object](#map116)
 
 <a id="propertyrow_count-integer"></a>
 ## Property row_count ∷ Integer
@@ -10411,7 +10801,7 @@ an ordered list of rows
 
 
 
-<a id="map115"></a>
+<a id="map116"></a>
 # *ColumnDefinition* Object
 
 | Property | Type | Description | Required? |
@@ -10468,7 +10858,7 @@ If `true`, the row entries for this column cannot contain `nulls`. Defaults to `
     * string
     * url
 
-<a id="map76"></a>
+<a id="map77"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -10500,7 +10890,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map75"></a>
+<a id="map76"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -10575,9 +10965,11 @@ A URL reference to an external resource.
 |[identity](#propertyidentity-identitycoordinatesobject)|*IdentityCoordinates* Object|Attributes for which the assertion is being made.|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-identityassertiontypeidentifierstring)|IdentityAssertionTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -10595,9 +10987,19 @@ Any known context about the identity attributes.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map118-ref"></a>
+<a id="map119-ref"></a>
 * *Assertion* Object Value
-  * Details: [*Assertion* Object](#map118)
+  * Details: [*Assertion* Object](#map119)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -10625,9 +11027,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map116-ref"></a>
+<a id="map117-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map116)
+  * Details: [*ExternalReference* Object](#map117)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -10647,9 +11049,9 @@ Attributes for which the assertion is being made.
 * This entry is required
 
 
-<a id="map117-ref"></a>
+<a id="map118-ref"></a>
 * *IdentityCoordinates* Object Value
-  * Details: [*IdentityCoordinates* Object](#map117)
+  * Details: [*IdentityCoordinates* Object](#map118)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortStringString
@@ -10662,6 +11064,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -10746,11 +11158,11 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map119-ref"></a>
+<a id="map120-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map119)
+  * Details: [*ValidTime* Object](#map120)
 
-<a id="map119"></a>
+<a id="map120"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -10782,7 +11194,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map118"></a>
+<a id="map119"></a>
 # *Assertion* Object
 
 | Property | Type | Description | Required? |
@@ -10858,7 +11270,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
 
 
-<a id="map117"></a>
+<a id="map118"></a>
 # *IdentityCoordinates* Object
 
 | Property | Type | Description | Required? |
@@ -10873,11 +11285,11 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map120-ref"></a>
+<a id="map121-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map120)
+  * Details: [*Observable* Object](#map121)
 
-<a id="map120"></a>
+<a id="map121"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -10955,7 +11367,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
 
 
-<a id="map116"></a>
+<a id="map117"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -11030,10 +11442,12 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[targets](#propertytargets-targetobjectlist)|*Target* Object List| |&#10003;|
 |[type](#propertytype-targetrecordtypeidentifierstring)|TargetRecordTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -11042,6 +11456,16 @@ A URL reference to an external resource.
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
 * Reference: [TargetRecord](https://github.com/threatgrid/response/blob/master/features/assets/assets.org#targetrecord)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -11079,9 +11503,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map121-ref"></a>
+<a id="map122-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map121)
+  * Details: [*ExternalReference* Object](#map122)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -11104,6 +11528,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -11162,9 +11596,9 @@ URI of the source of the intelligence that led to the creation of the entity.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map122-ref"></a>
+<a id="map123-ref"></a>
 * *Target* Object Value
-  * Details: [*Target* Object](#map122)
+  * Details: [*Target* Object](#map123)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -11213,7 +11647,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "target-record"
 
-<a id="map122"></a>
+<a id="map123"></a>
 # *Target* Object
 
 *Target* Schema for TargetRecord Targets
@@ -11245,9 +11679,9 @@ Is it internal to our network?
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map123-ref"></a>
+<a id="map124-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map123)
+  * Details: [*Observable* Object](#map124)
 
 <a id="propertyobserved_time-observedtimeobject"></a>
 ## Property observed_time ∷ *ObservedTime* Object
@@ -11255,9 +11689,9 @@ Is it internal to our network?
 * This entry is required
 
 
-<a id="map124-ref"></a>
+<a id="map125-ref"></a>
 * *ObservedTime* Object Value
-  * Details: [*ObservedTime* Object](#map124)
+  * Details: [*ObservedTime* Object](#map125)
 
 <a id="propertyos-string"></a>
 ## Property os ∷ String
@@ -11339,7 +11773,7 @@ The OpenC2 Actuator name that best fits the device that is creating this TargetR
     * process.virtualization-service
     * process.vulnerability-scanner
 
-<a id="map124"></a>
+<a id="map125"></a>
 # *ObservedTime* Object
 
 *ObservedTime* Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified).
@@ -11371,7 +11805,7 @@ Time of the observation. If the observation was made over a period of time, than
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map123"></a>
+<a id="map124"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -11449,7 +11883,7 @@ Time of the observation. If the observation was made over a period of time, than
 
 
 
-<a id="map121"></a>
+<a id="map122"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -11525,10 +11959,12 @@ A URL reference to an external resource.
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.|&#10003;|
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-tooltypeidentifierstring)|ToolTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of kill chain phases for which this Tool can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -11538,6 +11974,16 @@ A URL reference to an external resource.
 |[x_mitre_aliases](#propertyx_mitre_aliases-shortstringstringlist)|ShortStringString List|ATT&CK Software.aliases.||
 
 * Reference: [Tool](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.z4voa9ndw8v)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -11575,9 +12021,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map125-ref"></a>
+<a id="map126-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map125)
+  * Details: [*ExternalReference* Object](#map126)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -11598,9 +12044,9 @@ The list of kill chain phases for which this Tool can be used.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map126-ref"></a>
+<a id="map127-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map126)
+  * Details: [*KillChainPhase* Object](#map127)
 
 <a id="propertylabels-toollabelstringlist"></a>
 ## Property labels ∷ ToolLabelString List
@@ -11633,6 +12079,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -11752,7 +12208,7 @@ ATT&CK Software.aliases.
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map126"></a>
+<a id="map127"></a>
 # *KillChainPhase* Object
 
 *KillChainPhase* The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -11795,7 +12251,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map125"></a>
+<a id="map126"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -11918,9 +12374,9 @@ The disposition_name field is optional, but is intended to be shown to a user.  
 * This entry is required
 
 
-<a id="map127-ref"></a>
+<a id="map128-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map127)
+  * Details: [*Observable* Object](#map128)
 
 <a id="propertytype-verdicttypeidentifierstring"></a>
 ## Property type ∷ VerdictTypeIdentifierString
@@ -11936,11 +12392,11 @@ The disposition_name field is optional, but is intended to be shown to a user.  
 * This entry is required
 
 
-<a id="map128-ref"></a>
+<a id="map129-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map128)
+  * Details: [*ValidTime* Object](#map129)
 
-<a id="map128"></a>
+<a id="map129"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -11972,7 +12428,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map127"></a>
+<a id="map128"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -12063,10 +12519,12 @@ If not present, the valid time position of the indicator does not have an upper 
 |[rows](#propertyrows-anythinglistlist)|Anything List|An ordered list of rows|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-datatabletypeidentifierstring)|DataTableTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[row_count](#propertyrow_count-integer)|Integer|The number of rows in the data table.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -12087,9 +12545,19 @@ An ordered list of column definitions.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map130-ref"></a>
+<a id="map131-ref"></a>
 * *ColumnDefinition* Object Value
-  * Details: [*ColumnDefinition* Object](#map130)
+  * Details: [*ColumnDefinition* Object](#map131)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -12127,9 +12595,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map129-ref"></a>
+<a id="map130-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map129)
+  * Details: [*ExternalReference* Object](#map130)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -12152,6 +12620,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -12275,11 +12753,11 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map131-ref"></a>
+<a id="map132-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map131)
+  * Details: [*ValidTime* Object](#map132)
 
-<a id="map131"></a>
+<a id="map132"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -12311,7 +12789,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map130"></a>
+<a id="map131"></a>
 # *ColumnDefinition* Object
 
 | Property | Type | Description | Required? |
@@ -12368,7 +12846,7 @@ If `true`, the row entries for this column cannot contain `nulls`. Defaults to `
     * string
     * url
 
-<a id="map129"></a>
+<a id="map130"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -12447,6 +12925,7 @@ A URL reference to an external resource.
 |[architectures](#propertyarchitectures-architectureobjectlist)|*Architecture* Object List|Applicable architectures.||
 |[background_details](#propertybackground_details-markdownstring)|MarkdownString|Information that is relevant but not related to the nature of the weakness itself.||
 |[common_consequences](#propertycommon_consequences-consequenceobjectlist)|*Consequence* Object List|Refers to the typical or expected negative effects that can result from exploiting the weakness. This could include anything from unauthorized access to data, denial of service, system crashes or other things.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[detection_methods](#propertydetection_methods-detectionmethodobjectlist)|*DetectionMethod* Object List|Identifies methods that may be employed to detect this weakness, including their strengths and limitations.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -12455,6 +12934,7 @@ A URL reference to an external resource.
 |[languages](#propertylanguages-languageobjectlist)|*Language* Object List|Applicable Languages.||
 |[likelihood](#propertylikelihood-highmedlowstring)|HighMedLowString|Likelihood of exploit.||
 |[modes_of_introduction](#propertymodes_of_introduction-modeofintroductionobjectlist)|*ModeOfIntroduction* Object List|Information about how and when a given weakness may be introduced.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[notes](#propertynotes-noteobjectlist)|*Note* Object List|Provides any additional comments about the weakness.||
 |[operating_systems](#propertyoperating_systems-operatingsystemobjectlist)|*OperatingSystem* Object List|Applicable operating systems.||
 |[paradigms](#propertyparadigms-paradigmobjectlist)|*Paradigm* Object List|Applicable paradigms.||
@@ -12524,9 +13004,9 @@ Indicates one or more other names used to describe this weakness.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map138-ref"></a>
+<a id="map139-ref"></a>
 * *AlternateTerm* Object Value
-  * Details: [*AlternateTerm* Object](#map138)
+  * Details: [*AlternateTerm* Object](#map139)
 
 <a id="propertyarchitectures-architectureobjectlist"></a>
 ## Property architectures ∷ *Architecture* Object List
@@ -12537,9 +13017,9 @@ Applicable architectures.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map135-ref"></a>
+<a id="map136-ref"></a>
 * *Architecture* Object Value
-  * Details: [*Architecture* Object](#map135)
+  * Details: [*Architecture* Object](#map136)
 
 <a id="propertybackground_details-markdownstring"></a>
 ## Property background_details ∷ MarkdownString
@@ -12560,9 +13040,19 @@ Refers to the typical or expected negative effects that can result from exploiti
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map140-ref"></a>
+<a id="map141-ref"></a>
 * *Consequence* Object Value
-  * Details: [*Consequence* Object](#map140)
+  * Details: [*Consequence* Object](#map141)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -12583,9 +13073,9 @@ Identifies methods that may be employed to detect this weakness, including their
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map141-ref"></a>
+<a id="map142-ref"></a>
 * *DetectionMethod* Object Value
-  * Details: [*DetectionMethod* Object](#map141)
+  * Details: [*DetectionMethod* Object](#map142)
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -12613,9 +13103,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map132-ref"></a>
+<a id="map133-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map132)
+  * Details: [*ExternalReference* Object](#map133)
 
 <a id="propertyfunctional_areas-functionalareastringlist"></a>
 ## Property functional_areas ∷ FunctionalAreaString List
@@ -12679,9 +13169,9 @@ Applicable Languages.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map133-ref"></a>
+<a id="map134-ref"></a>
 * *Language* Object Value
-  * Details: [*Language* Object](#map133)
+  * Details: [*Language* Object](#map134)
 
 <a id="propertylikelihood-highmedlowstring"></a>
 ## Property likelihood ∷ HighMedLowString
@@ -12709,9 +13199,19 @@ Information about how and when a given weakness may be introduced.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map139-ref"></a>
+<a id="map140-ref"></a>
 * *ModeOfIntroduction* Object Value
-  * Details: [*ModeOfIntroduction* Object](#map139)
+  * Details: [*ModeOfIntroduction* Object](#map140)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynotes-noteobjectlist"></a>
 ## Property notes ∷ *Note* Object List
@@ -12722,9 +13222,9 @@ Provides any additional comments about the weakness.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map143-ref"></a>
+<a id="map144-ref"></a>
 * *Note* Object Value
-  * Details: [*Note* Object](#map143)
+  * Details: [*Note* Object](#map144)
 
 <a id="propertyoperating_systems-operatingsystemobjectlist"></a>
 ## Property operating_systems ∷ *OperatingSystem* Object List
@@ -12735,9 +13235,9 @@ Applicable operating systems.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map134-ref"></a>
+<a id="map135-ref"></a>
 * *OperatingSystem* Object Value
-  * Details: [*OperatingSystem* Object](#map134)
+  * Details: [*OperatingSystem* Object](#map135)
 
 <a id="propertyparadigms-paradigmobjectlist"></a>
 ## Property paradigms ∷ *Paradigm* Object List
@@ -12748,9 +13248,9 @@ Applicable paradigms.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map136-ref"></a>
+<a id="map137-ref"></a>
 * *Paradigm* Object Value
-  * Details: [*Paradigm* Object](#map136)
+  * Details: [*Paradigm* Object](#map137)
 
 <a id="propertypotential_mitigations-mitigationobjectlist"></a>
 ## Property potential_mitigations ∷ *Mitigation* Object List
@@ -12761,9 +13261,9 @@ Describes potential mitigations associated with a weakness.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map142-ref"></a>
+<a id="map143-ref"></a>
 * *Mitigation* Object Value
-  * Details: [*Mitigation* Object](#map142)
+  * Details: [*Mitigation* Object](#map143)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -12845,9 +13345,9 @@ Applicable technologies.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map137-ref"></a>
+<a id="map138-ref"></a>
 * *Technology* Object Value
-  * Details: [*Technology* Object](#map137)
+  * Details: [*Technology* Object](#map138)
 
 <a id="propertytimestamp-instdate"></a>
 ## Property timestamp ∷ Inst (Date)
@@ -12899,7 +13399,7 @@ The fixed value weakness
   * *WeaknessTypeIdentifier* The fixed value "weakness"
   * Must equal: "weakness"
 
-<a id="map143"></a>
+<a id="map144"></a>
 # *Note* Object
 
 | Property | Type | Description | Required? |
@@ -12932,7 +13432,7 @@ The fixed value weakness
     * Theoretical
   * Reference: [NoteTypeEnumeration] (https://cwe.mitre.org/documents/schema/#NoteTypeEnumeration)
 
-<a id="map142"></a>
+<a id="map143"></a>
 # *Mitigation* Object
 
 | Property | Type | Description | Required? |
@@ -13034,7 +13534,7 @@ A general strategy for protecting a system to which this mitigation contributes.
     * Separation of Privilege
   * Reference: [MitigationStrategyEnumeration](https://cwe.mitre.org/documents/schema/#MitigationStrategyEnumeration)
 
-<a id="map141"></a>
+<a id="map142"></a>
 # *DetectionMethod* Object
 
 | Property | Type | Description | Required? |
@@ -13113,7 +13613,7 @@ Identifies the particular detection method being described.
     * White Box
   * Reference: [DetectionMethodEnumeration](https://cwe.mitre.org/documents/schema/#DetectionMethodEnumeration)
 
-<a id="map140"></a>
+<a id="map141"></a>
 # *Consequence* Object
 
 | Property | Type | Description | Required? |
@@ -13205,7 +13705,7 @@ Identifies the security property that is violated.
     * Non-Repudiation
   * Reference: [ScopeEnumeration](https://cwe.mitre.org/documents/schema/#ScopeEnumeration)
 
-<a id="map139"></a>
+<a id="map140"></a>
 # *ModeOfIntroduction* Object
 
 | Property | Type | Description | Required? |
@@ -13251,7 +13751,7 @@ Identifies the point in the software life cycle at which the weakness may be int
     * Testing
   * Reference: [PhaseEnumeration](https://cwe.mitre.org/documents/schema/#PhaseEnumeration)
 
-<a id="map138"></a>
+<a id="map139"></a>
 # *AlternateTerm* Object
 
 | Property | Type | Description | Required? |
@@ -13280,7 +13780,7 @@ The actual alternate term.
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map137"></a>
+<a id="map138"></a>
 # *Technology* Object
 
 | Property | Type | Description | Required? |
@@ -13315,7 +13815,7 @@ Defines the different regularities that guide the applicability of platforms.
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map136"></a>
+<a id="map137"></a>
 # *Paradigm* Object
 
 | Property | Type | Description | Required? |
@@ -13350,7 +13850,7 @@ Defines the different regularities that guide the applicability of platforms.
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map135"></a>
+<a id="map136"></a>
 # *Architecture* Object
 
 | Property | Type | Description | Required? |
@@ -13400,7 +13900,7 @@ Defines the different regularities that guide the applicability of platforms.
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map134"></a>
+<a id="map135"></a>
 # *OperatingSystem* Object
 
 | Property | Type | Description | Required? |
@@ -13469,7 +13969,7 @@ Defines the different regularities that guide the applicability of platforms.
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map133"></a>
+<a id="map134"></a>
 # *Language* Object
 
 | Property | Type | Description | Required? |
@@ -13520,7 +14020,7 @@ Defines the different regularities that guide the applicability of platforms.
     * Undetermined
   * Reference: [PrevalenceEnumeration](https://cwe.mitre.org/documents/schema/#PrevalenceEnumeration)
 
-<a id="map132"></a>
+<a id="map133"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -13594,12 +14094,14 @@ A URL reference to an external resource.
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-vulnerabilitytypeidentifierstring)|VulnerabilityTypeIdentifierString|The fixed value vulnerability|&#10003;|
 |[configurations](#propertyconfigurations-configurationsobject)|*Configurations* Object|Represents a list of affected versions or configurations of a software component that is impacted by a vulnerability.  By tracking the affected software components and versions, defenders can identify which systems are potentially exposed to an attack, and apply appropriate mitigations.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[cve](#propertycve-cveobject)|*CVE* Object| ||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-vulnerabilityimpactobject)|*VulnerabilityImpact* Object|Describes the potential impact of a vulnerability that is being tracked in the system. Provides information on the extent of damage that a vulnerability can cause and how serious the consequences could be if it is exploited.   May contain granular information about the vulnerability severity using the CVSS system, versions 2 and 3.  CVSSv2 and CVSSv3 have different methods of calculating base scores, but both are designed to provide an indication of the level of risk that a vulnerability poses. The base score ranges from 0 to 10, with 10 being the most severe. Additionally, both CVSSv2 and CVSSv3 define severity levels, such as low, medium, high, and critical, based on the base score.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[last_modified_date](#propertylast_modified_date-instdate)|Inst (Date)|Represents the date when the vulnerability metadata was last updated in the internal database. It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[published_date](#propertypublished_date-instdate)|Inst (Date)|Represents the date when a vulnerability was publicly disclosed or made available to the general public.   Important for tracking the age of a vulnerability, as well as for determining when a particular vulnerability was first introduced into a system. The published date can be used to identify the time window during which a system may have been vulnerable to a particular exploit.  For example, if an organization discovers that a vulnerability was published before their system's installation date, but they did not apply the necessary security updates in a timely manner, it can be concluded that their system was vulnerable for the period between the installation date and the date when the necessary security updates were applied.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -13620,9 +14122,19 @@ By tracking the affected software components and versions, defenders can identif
 * This entry is optional
 
 
-<a id="map147-ref"></a>
+<a id="map148-ref"></a>
 * *Configurations* Object Value
-  * Details: [*Configurations* Object](#map147)
+  * Details: [*Configurations* Object](#map148)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertycve-cveobject"></a>
 ## Property cve ∷ *CVE* Object
@@ -13630,9 +14142,9 @@ By tracking the affected software components and versions, defenders can identif
 * This entry is optional
 
 
-<a id="map145-ref"></a>
+<a id="map146-ref"></a>
 * *CVE* Object Value
-  * Details: [*CVE* Object](#map145)
+  * Details: [*CVE* Object](#map146)
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -13672,9 +14184,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map144-ref"></a>
+<a id="map145-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map144)
+  * Details: [*ExternalReference* Object](#map145)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -13698,9 +14210,9 @@ CVSSv2 and CVSSv3 have different methods of calculating base scores, but both ar
 * This entry is optional
 
 
-<a id="map146-ref"></a>
+<a id="map147-ref"></a>
 * *VulnerabilityImpact* Object Value
-  * Details: [*VulnerabilityImpact* Object](#map146)
+  * Details: [*VulnerabilityImpact* Object](#map147)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortStringString
@@ -13719,6 +14231,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 Represents the date when the vulnerability metadata was last updated in the internal database.
 It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
 
 * This entry is optional
 
@@ -13839,7 +14361,7 @@ The fixed value vulnerability
   * *VulnerabilityTypeIdentifier* The fixed value "vulnerability"
   * Must equal: "vulnerability"
 
-<a id="map147"></a>
+<a id="map148"></a>
 # *Configurations* Object
 
 | Property | Type | Description | Required? |
@@ -13867,11 +14389,11 @@ Each `node` in the CTIM standard configuration includes information such as the 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map148-ref"></a>
+<a id="map149-ref"></a>
 * *CPENode* Object Value
-  * Details: [*CPENode* Object](#map148)
+  * Details: [*CPENode* Object](#map149)
 
-<a id="map148"></a>
+<a id="map149"></a>
 # *CPENode* Object
 
 | Property | Type | Description | Required? |
@@ -13889,61 +14411,20 @@ Each `node` in the CTIM standard configuration includes information such as the 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map150-ref"></a>
-* *CPELeafNode* Object Value
-  * Details: [*CPELeafNode* Object](#map150)
-
-<a id="propertycpe_match-cpematchobjectlist"></a>
-## Property cpe_match ∷ *CPEMatch* Object List
-
-* This entry is optional
-* This entry's type is sequential (allows zero or more values)
-
-
-<a id="map149-ref"></a>
-* *CPEMatch* Object Value
-  * Details: [*CPEMatch* Object](#map149)
-
-<a id="propertynegate-boolean"></a>
-## Property negate ∷ Boolean
-
-Negates operator when true.
-
-* This entry is optional
-
-
-
-<a id="propertyoperator-cpe-node-operator-stringstring"></a>
-## Property operator ∷ cpe-node-operator-stringString
-
-* This entry is required
-
-
-  * *cpe-node-operator-string* The operator string influences how seqs of cpe matches are related to one another.
-  * Allowed Values:
-    * AND
-    * OR
-
-<a id="map150"></a>
-# *CPELeafNode* Object
-
-| Property | Type | Description | Required? |
-| -------- | ---- | ----------- | --------- |
-|[cpe_match](#propertycpe_match-cpematchobjectlist)|*CPEMatch* Object List| |&#10003;|
-|[operator](#propertyoperator-cpe-node-operator-stringstring)|cpe-node-operator-stringString| |&#10003;|
-|[negate](#propertynegate-boolean)|Boolean|Negates operator when true.||
-
-
-<a id="propertycpe_match-cpematchobjectlist"></a>
-## Property cpe_match ∷ *CPEMatch* Object List
-
-* This entry is required
-* This entry's type is sequential (allows zero or more values)
-
-
 <a id="map151-ref"></a>
+* *CPELeafNode* Object Value
+  * Details: [*CPELeafNode* Object](#map151)
+
+<a id="propertycpe_match-cpematchobjectlist"></a>
+## Property cpe_match ∷ *CPEMatch* Object List
+
+* This entry is optional
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map150-ref"></a>
 * *CPEMatch* Object Value
-  * Details: [*CPEMatch* Object](#map151)
+  * Details: [*CPEMatch* Object](#map150)
 
 <a id="propertynegate-boolean"></a>
 ## Property negate ∷ Boolean
@@ -13966,6 +14447,47 @@ Negates operator when true.
     * OR
 
 <a id="map151"></a>
+# *CPELeafNode* Object
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[cpe_match](#propertycpe_match-cpematchobjectlist)|*CPEMatch* Object List| |&#10003;|
+|[operator](#propertyoperator-cpe-node-operator-stringstring)|cpe-node-operator-stringString| |&#10003;|
+|[negate](#propertynegate-boolean)|Boolean|Negates operator when true.||
+
+
+<a id="propertycpe_match-cpematchobjectlist"></a>
+## Property cpe_match ∷ *CPEMatch* Object List
+
+* This entry is required
+* This entry's type is sequential (allows zero or more values)
+
+
+<a id="map152-ref"></a>
+* *CPEMatch* Object Value
+  * Details: [*CPEMatch* Object](#map152)
+
+<a id="propertynegate-boolean"></a>
+## Property negate ∷ Boolean
+
+Negates operator when true.
+
+* This entry is optional
+
+
+
+<a id="propertyoperator-cpe-node-operator-stringstring"></a>
+## Property operator ∷ cpe-node-operator-stringString
+
+* This entry is required
+
+
+  * *cpe-node-operator-string* The operator string influences how seqs of cpe matches are related to one another.
+  * Allowed Values:
+    * AND
+    * OR
+
+<a id="map152"></a>
 # *CPEMatch* Object
 
 | Property | Type | Description | Required? |
@@ -14033,7 +14555,7 @@ A string representing the lower bound(inclusive) of version in the CPE.
 
 
 
-<a id="map149"></a>
+<a id="map150"></a>
 # *CPEMatch* Object
 
 | Property | Type | Description | Required? |
@@ -14101,7 +14623,7 @@ A string representing the lower bound(inclusive) of version in the CPE.
 
 
 
-<a id="map146"></a>
+<a id="map147"></a>
 # *VulnerabilityImpact* Object
 
 | Property | Type | Description | Required? |
@@ -14116,9 +14638,9 @@ A string representing the lower bound(inclusive) of version in the CPE.
 * This entry is optional
 
 
-<a id="map152-ref"></a>
+<a id="map153-ref"></a>
 * *CVSSv2* Object Value
-  * Details: [*CVSSv2* Object](#map152)
+  * Details: [*CVSSv2* Object](#map153)
 
 <a id="propertycvss_v3-cvssv3object"></a>
 ## Property cvss_v3 ∷ *CVSSv3* Object
@@ -14126,11 +14648,11 @@ A string representing the lower bound(inclusive) of version in the CPE.
 * This entry is optional
 
 
-<a id="map153-ref"></a>
+<a id="map154-ref"></a>
 * *CVSSv3* Object Value
-  * Details: [*CVSSv3* Object](#map153)
+  * Details: [*CVSSv3* Object](#map154)
 
-<a id="map153"></a>
+<a id="map154"></a>
 # *CVSSv3* Object
 
 | Property | Type | Description | Required? |
@@ -14604,7 +15126,7 @@ captures the requirement for a user, other than the attacker, to participate in 
 
   * a text representation of a set of CVSSv3 metrics. It is commonly used to record or transfer CVSSv3 metric information in a concise form
 
-<a id="map152"></a>
+<a id="map153"></a>
 # *CVSSv2* Object
 
 | Property | Type | Description | Required? |
@@ -14938,7 +15460,7 @@ The base score is a key metric in CVSS, which uses a scoring system to determine
 
   * a text representation of a set of CVSSv2 metrics. It is commonly used to record or transfer CVSSv2 metric information in a concise form
 
-<a id="map145"></a>
+<a id="map146"></a>
 # *CVE* Object
 
 | Property | Type | Description | Required? |
@@ -14952,11 +15474,11 @@ The base score is a key metric in CVSS, which uses a scoring system to determine
 * This entry is required
 
 
-<a id="map154-ref"></a>
+<a id="map155-ref"></a>
 * *CVEDataMeta* Object Value
-  * Details: [*CVEDataMeta* Object](#map154)
+  * Details: [*CVEDataMeta* Object](#map155)
 
-<a id="map154"></a>
+<a id="map155"></a>
 # *CVEDataMeta* Object
 
 | Property | Type | Description | Required? |
@@ -14981,7 +15503,7 @@ The base score is a key metric in CVSS, which uses a scoring system to determine
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map144"></a>
+<a id="map145"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.

--- a/doc/structures/campaign.md
+++ b/doc/structures/campaign.md
@@ -15,10 +15,12 @@
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Timestamp for the definition of a specific version of a campaign.|&#10003;|
 |[activity](#propertyactivity-activityobjectlist)|*Activity* Object List|Used to capture specific activities or tactics associated with the campaign. The 'activity' field is an array of objects, and each element represents a specific activity and time associated with the campaign. Examples of activities may include malicious software delivery, command and control communication, network reconnaissance, data exfiltration, etc. By capturing these activities analysts can identify the specific tactics used by the threat actor(s) behind the campaign.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|Level of confidence held in the characterization of this Campaign.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstringlist)|IntendedEffectString List|Characterizes the intended effect of this cyber threat campaign.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[names](#propertynames-shortstringstringlist)|ShortStringString List|Used to capture alternate names or aliases associated with the campaign. A cyberattack campaign may have multiple names or aliases depending on the group or actor(s) behind the attack, e.g., 'Wannacry' is also known as 'WannaCrypt', 'WCry', 'Wanna Decryptor', etc.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -70,6 +72,16 @@ Level of confidence held in the characterization of this Campaign.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -167,6 +179,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynames-shortstringstringlist"></a>
 ## Property names ∷ ShortStringString List

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -9,10 +9,12 @@
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-casebooktypeidentifierstring)|CasebookTypeIdentifierString| |&#10003;|
 |[bundle](#propertybundle-bundleobject)|*Bundle* Object| ||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -34,6 +36,16 @@
 <a id="map3-ref"></a>
 * *Bundle* Object Value
   * Details: [*Bundle* Object](#map3)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -96,6 +108,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservables-observableobjectlist"></a>
 ## Property observables ∷ *Observable* Object List
@@ -382,6 +404,7 @@ A URL reference to an external resource.
 |[campaigns](#propertycampaigns-campaignobject)|#{*Campaign* Object}|a list of `Campaign`s.||
 |[coa_refs](#propertycoa_refs-string)|#{String}| ||
 |[coas](#propertycoas-coaobject)|#{*COA* Object}|a list of `COA`s.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[data_table_refs](#propertydata_table_refs-string)|#{String}| ||
 |[data_tables](#propertydata_tables-datatableobject)|#{*DataTable* Object}|a list of `DataTable`s.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
@@ -400,6 +423,7 @@ A URL reference to an external resource.
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[malware_refs](#propertymalware_refs-string)|#{String}| ||
 |[malwares](#propertymalwares-malwareobject)|#{*Malware* Object}|a list of `Malware`s.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[note_refs](#propertynote_refs-string)|#{String}| ||
 |[notes](#propertynotes-noteobject)|#{*Note* Object}|a list of `Note`s.||
 |[relationship_refs](#propertyrelationship_refs-string)|#{String}| ||
@@ -578,6 +602,16 @@ a list of `COA`s.
 <a id="map12-ref"></a>
 * *COA* Object Value
   * Details: [*COA* Object](#map12)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydata_table_refs-string"></a>
 ## Property data_table_refs ∷ #{String}
@@ -794,6 +828,16 @@ a list of `Malware`s.
 <a id="map17-ref"></a>
 * *Malware* Object Value
   * Details: [*Malware* Object](#map17)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynote_refs-string"></a>
 ## Property note_refs ∷ #{String}
@@ -1122,12 +1166,14 @@ If not present, the valid time position of the indicator does not have an upper 
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-vulnerabilitytypeidentifierstring)|VulnerabilityTypeIdentifierString|The fixed value vulnerability|&#10003;|
 |[configurations](#propertyconfigurations-configurationsobject)|*Configurations* Object|Represents a list of affected versions or configurations of a software component that is impacted by a vulnerability.  By tracking the affected software components and versions, defenders can identify which systems are potentially exposed to an attack, and apply appropriate mitigations.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[cve](#propertycve-cveobject)|*CVE* Object| ||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-vulnerabilityimpactobject)|*VulnerabilityImpact* Object|Describes the potential impact of a vulnerability that is being tracked in the system. Provides information on the extent of damage that a vulnerability can cause and how serious the consequences could be if it is exploited.   May contain granular information about the vulnerability severity using the CVSS system, versions 2 and 3.  CVSSv2 and CVSSv3 have different methods of calculating base scores, but both are designed to provide an indication of the level of risk that a vulnerability poses. The base score ranges from 0 to 10, with 10 being the most severe. Additionally, both CVSSv2 and CVSSv3 define severity levels, such as low, medium, high, and critical, based on the base score.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[last_modified_date](#propertylast_modified_date-instdate)|Inst (Date)|Represents the date when the vulnerability metadata was last updated in the internal database. It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[published_date](#propertypublished_date-instdate)|Inst (Date)|Represents the date when a vulnerability was publicly disclosed or made available to the general public.   Important for tracking the age of a vulnerability, as well as for determining when a particular vulnerability was first introduced into a system. The published date can be used to identify the time window during which a system may have been vulnerable to a particular exploit.  For example, if an organization discovers that a vulnerability was published before their system's installation date, but they did not apply the necessary security updates in a timely manner, it can be concluded that their system was vulnerable for the period between the installation date and the date when the necessary security updates were applied.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -1151,6 +1197,16 @@ By tracking the affected software components and versions, defenders can identif
 <a id="map32-ref"></a>
 * *Configurations* Object Value
   * Details: [*Configurations* Object](#map32)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertycve-cveobject"></a>
 ## Property cve ∷ *CVE* Object
@@ -1247,6 +1303,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 Represents the date when the vulnerability metadata was last updated in the internal database.
 It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
 
 * This entry is optional
 
@@ -2588,6 +2654,7 @@ A URL reference to an external resource.
 |[architectures](#propertyarchitectures-architectureobjectlist)|*Architecture* Object List|Applicable architectures.||
 |[background_details](#propertybackground_details-markdownstring)|MarkdownString|Information that is relevant but not related to the nature of the weakness itself.||
 |[common_consequences](#propertycommon_consequences-consequenceobjectlist)|*Consequence* Object List|Refers to the typical or expected negative effects that can result from exploiting the weakness. This could include anything from unauthorized access to data, denial of service, system crashes or other things.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[detection_methods](#propertydetection_methods-detectionmethodobjectlist)|*DetectionMethod* Object List|Identifies methods that may be employed to detect this weakness, including their strengths and limitations.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -2596,6 +2663,7 @@ A URL reference to an external resource.
 |[languages](#propertylanguages-languageobjectlist)|*Language* Object List|Applicable Languages.||
 |[likelihood](#propertylikelihood-highmedlowstring)|HighMedLowString|Likelihood of exploit.||
 |[modes_of_introduction](#propertymodes_of_introduction-modeofintroductionobjectlist)|*ModeOfIntroduction* Object List|Information about how and when a given weakness may be introduced.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[notes](#propertynotes-noteobjectlist)|*Note* Object List|Provides any additional comments about the weakness.||
 |[operating_systems](#propertyoperating_systems-operatingsystemobjectlist)|*OperatingSystem* Object List|Applicable operating systems.||
 |[paradigms](#propertyparadigms-paradigmobjectlist)|*Paradigm* Object List|Applicable paradigms.||
@@ -2704,6 +2772,16 @@ Refers to the typical or expected negative effects that can result from exploiti
 <a id="map48-ref"></a>
 * *Consequence* Object Value
   * Details: [*Consequence* Object](#map48)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -2853,6 +2931,16 @@ Information about how and when a given weakness may be introduced.
 <a id="map47-ref"></a>
 * *ModeOfIntroduction* Object Value
   * Details: [*ModeOfIntroduction* Object](#map47)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynotes-noteobjectlist"></a>
 ## Property notes ∷ *Note* Object List
@@ -3736,10 +3824,12 @@ A URL reference to an external resource.
 |[rows](#propertyrows-anythinglistlist)|Anything List|An ordered list of rows|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-datatabletypeidentifierstring)|DataTableTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[row_count](#propertyrow_count-integer)|Integer|The number of rows in the data table.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -3763,6 +3853,16 @@ An ordered list of column definitions.
 <a id="map53-ref"></a>
 * *ColumnDefinition* Object Value
   * Details: [*ColumnDefinition* Object](#map53)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -3825,6 +3925,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -4310,10 +4420,12 @@ If not present, the valid time position of the indicator does not have an upper 
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.|&#10003;|
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-tooltypeidentifierstring)|ToolTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of kill chain phases for which this Tool can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -4323,6 +4435,16 @@ If not present, the valid time position of the indicator does not have an upper 
 |[x_mitre_aliases](#propertyx_mitre_aliases-shortstringstringlist)|ShortStringString List|ATT&CK Software.aliases.||
 
 * Reference: [Tool](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.z4voa9ndw8v)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -4418,6 +4540,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -4655,10 +4787,12 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[targets](#propertytargets-targetobjectlist)|*Target* Object List| |&#10003;|
 |[type](#propertytype-targetrecordtypeidentifierstring)|TargetRecordTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -4667,6 +4801,16 @@ A URL reference to an external resource.
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
 * Reference: [TargetRecord](https://github.com/threatgrid/response/blob/master/features/assets/assets.org#targetrecord)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -4729,6 +4873,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -5149,9 +5303,11 @@ A URL reference to an external resource.
 |[identity](#propertyidentity-identitycoordinatesobject)|*IdentityCoordinates* Object|Attributes for which the assertion is being made.|&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-identityassertiontypeidentifierstring)|IdentityAssertionTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -5172,6 +5328,16 @@ Any known context about the identity attributes.
 <a id="map65-ref"></a>
 * *Assertion* Object Value
   * Details: [*Assertion* Object](#map65)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -5236,6 +5402,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -5605,12 +5781,14 @@ A URL reference to an external resource.
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-sightingtypeidentifierstring)|SightingTypeIdentifierString| |&#10003;|
 |[context](#propertycontext-contextobject)|*Context* Object|Context including the event type that best fits the type of the sighting.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[data](#propertydata-sightingdatatableobject)|*SightingDataTable* Object|An embedded data table for the Sighting.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[internal](#propertyinternal-boolean)|Boolean|If `true`, indicates that the sighting was reported from internal sources, such as an organization's own internal security tools or SOC.  Internal sightings are often considered more reliable and actionable than external sightings, which are reported from external sources and may have a lower level of trustworthiness. Internal sightings can provide more context and can help identify potential threats that are unique to a particular environment or organization.  Internal sightings can also help organizations prioritize their security response efforts by identifying threats that are specific to their environment and may not yet be widely known.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List|The object(s) of interest.||
 |[relations](#propertyrelations-observedrelationobjectlist)|*ObservedRelation* Object List|Provide any context we can about where the observable came from.||
 |[resolution](#propertyresolution-resolutionstring)|ResolutionString|Represents the disposition or actions taken on the associated threat intelligence.||
@@ -5666,6 +5844,16 @@ It can also be used to prioritize security alerts and indicate the urgency of a 
 
 
   * Zero, or a positive integer.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydata-sightingdatatableobject"></a>
 ## Property data ∷ *SightingDataTable* Object
@@ -5751,6 +5939,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservables-observableobjectlist"></a>
 ## Property observables ∷ *Observable* Object List
@@ -9016,10 +9214,12 @@ A URL reference to an external resource.
 |[source_ref](#propertysource_ref-string)|String| |&#10003;|
 |[target_ref](#propertytarget_ref-string)|String| |&#10003;|
 |[type](#propertytype-relationshiptypeidentifierstring)|RelationshipTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -9028,6 +9228,16 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -9090,6 +9300,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrelationship_type-relationshiptypestring"></a>
 ## Property relationship_type ∷ RelationshipTypeString
@@ -9308,9 +9528,11 @@ For example, an analyst may add a Note to a Campaign object created by another o
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-notetypeidentifierstring)|NoteTypeIdentifierString| |&#10003;|
 |[author](#propertyauthor-string)|String| ||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -9332,6 +9554,16 @@ For example, an analyst may add a Note to a Campaign object created by another o
 
 
   * *Markdown* Markdown string with at most 5000 characters.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -9384,6 +9616,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynote_class-keyword"></a>
 ## Property note_class ∷ Keyword
@@ -9581,10 +9823,12 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-malwareabstractionsstring)|MalwareAbstractionsString|Malware abstraction level.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -9607,6 +9851,16 @@ Malware abstraction level.
     * family
     * variant
     * version
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -9712,6 +9966,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -9954,9 +10218,11 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-judgementtypeidentifierstring)|JudgementTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[reason](#propertyreason-shortstringstring)|ShortStringString| ||
 |[reason_uri](#propertyreason_uri-string)|String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -9979,6 +10245,16 @@ A URL reference to an external resource.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydisposition-dispositionnumberinteger"></a>
 ## Property disposition ∷ DispositionNumberInteger
@@ -10061,6 +10337,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object
@@ -10397,6 +10683,7 @@ _specification_ value.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which this Indicator is considered valid.|&#10003;|
 |[composite_indicator_expression](#propertycomposite_indicator_expression-compositeindicatorexpressionobject)|*CompositeIndicatorExpression* Object| ||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|level of confidence held in the accuracy of this Indicator.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -10404,6 +10691,7 @@ _specification_ value.
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|Relevant kill chain phases indicated by this Indicator.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[likely_impact](#propertylikely_impact-longstringstring)|LongStringString|Likely potential impact within the relevant context if this Indicator were to occur.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[negate](#propertynegate-boolean)|Boolean|Specifies the absence of the pattern.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[severity](#propertyseverity-severitystring)|SeverityString| ||
@@ -10445,6 +10733,16 @@ level of confidence held in the accuracy of this Indicator.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -10558,6 +10856,16 @@ Likely potential impact within the relevant context if this Indicator were to oc
 
 
   * *LongString* String with at most 5000 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynegate-boolean"></a>
 ## Property negate ∷ Boolean
@@ -11142,12 +11450,15 @@ A URL reference to an external resource.
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
 |[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|A set of owners assigned to this incident.||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|A set of categories for this incident.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|Identifies how the incident was discovered.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[meta](#propertymeta-metadataobject)|*MetaData* Object|metadata associated to the incident.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|Describes method for promoting an Incident, whether manually or automatically. An Incident may be created manually by a SOAR analyst or SOC operator, or through an automated correlation or aggregation rule or engine that matches a specific set of events or alerts, and promotes them to Incident(s).||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|Used to indicate the severity or impact score of the threat represented by the incident.||
@@ -11228,6 +11539,16 @@ It is important to note that the `confidence` field is subjective and can be int
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -11366,6 +11687,28 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymeta-metadataobject"></a>
+## Property meta ∷ *MetaData* Object
+
+metadata associated to the incident.
+
+* This entry is optional
+
+
+<a id="map129-ref"></a>
+* *MetaData* Object Value
+  * Details: [*MetaData* Object](#map129)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertypromotion_method-promotionmethodstring"></a>
 ## Property promotion_method ∷ PromotionMethodString
 
@@ -11406,9 +11749,9 @@ Used to indicate the severity or impact score of the threat represented by the i
 * This entry is optional
 
 
-<a id="map129-ref"></a>
+<a id="map130-ref"></a>
 * *IncidentScores* Object Value
-  * Details: [*IncidentScores* Object](#map129)
+  * Details: [*IncidentScores* Object](#map130)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -11573,7 +11916,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "incident"
 
-<a id="map129"></a>
+<a id="map130"></a>
 # *IncidentScores* Object
 
 | Property | Type | Description | Required? |
@@ -11603,6 +11946,29 @@ For example, systems can have the following score types:
     * :ttp
 
   * A non-negative score number.
+
+<a id="map129"></a>
+# *MetaData* Object
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[Keyword](#propertykeyword-either)|String|custom field relevant to attach meta data to.||
+
+
+<a id="propertykeyword-either"></a>
+## Property Keyword ∷ Either
+
+custom field relevant to attach meta data to.
+
+* This entry is optional
+
+
+  * Only one of the following schemas will match
+
+
+
+
+
 
 <a id="map128"></a>
 # *IncidentTime* Object
@@ -11753,15 +12119,27 @@ A URL reference to an external resource.
 |[reason](#propertyreason-string)|String| |&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-feedbacktypeidentifierstring)|FeedbackTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyentity_id-string"></a>
 ## Property entity_id ∷ String
@@ -11797,9 +12175,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map130-ref"></a>
+<a id="map131-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map130)
+  * Details: [*ExternalReference* Object](#map131)
 
 <a id="propertyfeedback-integer"></a>
 ## Property feedback ∷ Integer
@@ -11833,6 +12211,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyreason-string"></a>
 ## Property reason ∷ String
@@ -11918,7 +12306,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "feedback"
 
-<a id="map130"></a>
+<a id="map131"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -11993,12 +12381,14 @@ A URL reference to an external resource.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
 |[coa_type](#propertycoa_type-coatypestring)|COATypeString|The type of this COA||
 |[cost](#propertycost-highmedlowstring)|HighMedLowString|Characterizes the estimated cost for applying this course of action.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[efficacy](#propertyefficacy-highmedlowstring)|HighMedLowString|Effectiveness of this course of action in achieving its targeted objective.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-shortstringstring)|ShortStringString|Characterizes the estimated impact of applying this course of action.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[objective](#propertyobjective-shortstringstringlist)|ShortStringString List|Characterizes the objective to provide guidance on how to mitigate a security incident that has been identified.||
 |[open_c2_coa](#propertyopen_c2_coa-openc2coaobject)|*OpenC2COA* Object| ||
 |[related_COAs](#propertyrelated_coas-relatedcoaobjectlist)|*RelatedCOA* Object List|Identifies or characterizes relationships to one or more related courses of action.||
@@ -12061,6 +12451,16 @@ Characterizes the estimated cost for applying this course of action.
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
 
@@ -12114,9 +12514,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map131-ref"></a>
+<a id="map132-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map131)
+  * Details: [*ExternalReference* Object](#map132)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -12150,6 +12550,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyobjective-shortstringstringlist"></a>
 ## Property objective ∷ ShortStringString List
 
@@ -12168,9 +12578,9 @@ Characterizes the objective to provide guidance on how to mitigate a security in
 * This entry is optional
 
 
-<a id="map134-ref"></a>
+<a id="map135-ref"></a>
 * *OpenC2COA* Object Value
-  * Details: [*OpenC2COA* Object](#map134)
+  * Details: [*OpenC2COA* Object](#map135)
 
 <a id="propertyrelated_coas-relatedcoaobjectlist"></a>
 ## Property related_COAs ∷ *RelatedCOA* Object List
@@ -12181,9 +12591,9 @@ Identifies or characterizes relationships to one or more related courses of acti
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map133-ref"></a>
+<a id="map134-ref"></a>
 * *RelatedCOA* Object Value
-  * Details: [*RelatedCOA* Object](#map133)
+  * Details: [*RelatedCOA* Object](#map134)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -12315,11 +12725,11 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is required
 
 
-<a id="map132-ref"></a>
+<a id="map133-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map132)
+  * Details: [*ValidTime* Object](#map133)
 
-<a id="map134"></a>
+<a id="map135"></a>
 # *OpenC2COA* Object
 
 | Property | Type | Description | Required? |
@@ -12338,9 +12748,9 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is required
 
 
-<a id="map135-ref"></a>
+<a id="map136-ref"></a>
 * *ActionType* Object Value
-  * Details: [*ActionType* Object](#map135)
+  * Details: [*ActionType* Object](#map136)
 
 <a id="propertyactuator-actuatortypeobject"></a>
 ## Property actuator ∷ *ActuatorType* Object
@@ -12348,9 +12758,9 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map137-ref"></a>
+<a id="map138-ref"></a>
 * *ActuatorType* Object Value
-  * Details: [*ActuatorType* Object](#map137)
+  * Details: [*ActuatorType* Object](#map138)
 
 <a id="propertyid-shortstringstring"></a>
 ## Property id ∷ ShortStringString
@@ -12366,9 +12776,9 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map138-ref"></a>
+<a id="map139-ref"></a>
 * *ModifierType* Object Value
-  * Details: [*ModifierType* Object](#map138)
+  * Details: [*ModifierType* Object](#map139)
 
 <a id="propertytarget-targettypeobject"></a>
 ## Property target ∷ *TargetType* Object
@@ -12376,9 +12786,9 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map136-ref"></a>
+<a id="map137-ref"></a>
 * *TargetType* Object Value
-  * Details: [*TargetType* Object](#map136)
+  * Details: [*TargetType* Object](#map137)
 
 <a id="propertytype-structuredcoatypestring"></a>
 ## Property type ∷ StructuredCOATypeString
@@ -12388,7 +12798,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * Must equal: "structured_coa"
 
-<a id="map138"></a>
+<a id="map139"></a>
 # *ModifierType* Object
 
 | Property | Type | Description | Required? |
@@ -12414,9 +12824,9 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map140-ref"></a>
+<a id="map141-ref"></a>
 * *AdditionalProperties* Object Value
-  * Details: [*AdditionalProperties* Object](#map140)
+  * Details: [*AdditionalProperties* Object](#map141)
 
 <a id="propertydelay-instdate"></a>
 ## Property delay ∷ Inst (Date)
@@ -12543,11 +12953,11 @@ For example, an entity containing information about a critical vulnerability in 
 * This entry is optional
 
 
-<a id="map139-ref"></a>
+<a id="map140-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map139)
+  * Details: [*ValidTime* Object](#map140)
 
-<a id="map140"></a>
+<a id="map141"></a>
 # *AdditionalProperties* Object
 
 | Property | Type | Description | Required? |
@@ -12563,7 +12973,7 @@ For example, an entity containing information about a critical vulnerability in 
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map139"></a>
+<a id="map140"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -12595,7 +13005,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map137"></a>
+<a id="map138"></a>
 # *ActuatorType* Object
 
 | Property | Type | Description | Required? |
@@ -12669,7 +13079,7 @@ List of additional properties describing the actuator.
     * process.virtualization-service
     * process.vulnerability-scanner
 
-<a id="map136"></a>
+<a id="map137"></a>
 # *TargetType* Object
 
 | Property | Type | Description | Required? |
@@ -12747,7 +13157,7 @@ Observable types that can be acted upon.
     * user
     * user_agent
 
-<a id="map135"></a>
+<a id="map136"></a>
 # *ActionType* Object
 
 | Property | Type | Description | Required? |
@@ -12799,7 +13209,7 @@ Observable types that can be acted upon.
     * update
   * Reference: [OpenC2/STIX COA XML schema](https://github.com/OpenC2-org/subgroup-stix/blob/master/schema/openc2_stix_coa.xsd)
 
-<a id="map133"></a>
+<a id="map134"></a>
 # *RelatedCOA* Object
 
 | Property | Type | Description | Required? |
@@ -12847,7 +13257,7 @@ Observable types that can be acted upon.
 
 
 
-<a id="map132"></a>
+<a id="map133"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -12879,7 +13289,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map131"></a>
+<a id="map132"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -12958,10 +13368,12 @@ A URL reference to an external resource.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Timestamp for the definition of a specific version of a campaign.|&#10003;|
 |[activity](#propertyactivity-activityobjectlist)|*Activity* Object List|Used to capture specific activities or tactics associated with the campaign. The 'activity' field is an array of objects, and each element represents a specific activity and time associated with the campaign. Examples of activities may include malicious software delivery, command and control communication, network reconnaissance, data exfiltration, etc. By capturing these activities analysts can identify the specific tactics used by the threat actor(s) behind the campaign.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|Level of confidence held in the characterization of this Campaign.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstringlist)|IntendedEffectString List|Characterizes the intended effect of this cyber threat campaign.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[names](#propertynames-shortstringstringlist)|ShortStringString List|Used to capture alternate names or aliases associated with the campaign. A cyberattack campaign may have multiple names or aliases depending on the group or actor(s) behind the attack, e.g., 'Wannacry' is also known as 'WannaCrypt', 'WCry', 'Wanna Decryptor', etc.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -12982,9 +13394,9 @@ The 'activity' field is an array of objects, and each element represents a speci
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map143-ref"></a>
+<a id="map144-ref"></a>
 * *Activity* Object Value
-  * Details: [*Activity* Object](#map143)
+  * Details: [*Activity* Object](#map144)
 
 <a id="propertycampaign_type-shortstringstring"></a>
 ## Property campaign_type ∷ ShortStringString
@@ -13013,6 +13425,16 @@ Level of confidence held in the characterization of this Campaign.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -13050,9 +13472,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map141-ref"></a>
+<a id="map142-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map141)
+  * Details: [*ExternalReference* Object](#map142)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -13110,6 +13532,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynames-shortstringstringlist"></a>
 ## Property names ∷ ShortStringString List
@@ -13248,11 +13680,11 @@ Timestamp for the definition of a specific version of a campaign.
 * This entry is required
 
 
-<a id="map142-ref"></a>
+<a id="map143-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map142)
+  * Details: [*ValidTime* Object](#map143)
 
-<a id="map143"></a>
+<a id="map144"></a>
 # *Activity* Object
 
 *Activity* Captures the specific activities or tactics associated with the entity. Examples of activities may include malicious software delivery, command and control communication, network reconnaissance, data exfiltration, etc.
@@ -13284,7 +13716,7 @@ A description of the activity.
 
   * *Markdown* Markdown string with at most 5000 characters.
 
-<a id="map142"></a>
+<a id="map143"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -13316,7 +13748,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map141"></a>
+<a id="map142"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -13392,10 +13824,12 @@ A URL reference to an external resource.
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-attackpatterntypeidentifierstring)|AttackPatternTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-attackpatternabstractionsstring)|AttackPatternAbstractionsString|The CAPEC abstraction level for patterns describing techniques to attack a system.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|A list of external references which refer to non-STIX information. This property MAY be used to provide one or more Attack Pattern identifiers, such as a CAPEC ID. When specifying a CAPEC ID, the source_name property of the external reference MUST be set to capec and the external_id property MUST be formatted as CAPEC-[id].||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|A kill chain is a series of steps that an attacker must go through to successfully achieve their objective. The concept was originally developed by the military, but has been adapted to the cybersecurity field to describe the steps an attacker goes through to compromise a target system and achieve their goal.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -13423,6 +13857,16 @@ The CAPEC abstraction level for patterns describing techniques to attack a syste
     * meta
     * standard
   * Reference: [Common Attack Pattern Enumeration and Classification](https://capec.mitre.org)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -13454,9 +13898,9 @@ A list of external references which refer to non-STIX information. This property
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map145-ref"></a>
+<a id="map146-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map145)
+  * Details: [*ExternalReference* Object](#map146)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -13477,9 +13921,9 @@ A kill chain is a series of steps that an attacker must go through to successful
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map146-ref"></a>
+<a id="map147-ref"></a>
 * *KillChainPhase* Object Value
-  * Details: [*KillChainPhase* Object](#map146)
+  * Details: [*KillChainPhase* Object](#map147)
 
 <a id="propertylanguage-shortstringstring"></a>
 ## Property language ∷ ShortStringString
@@ -13492,6 +13936,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -13623,7 +14077,7 @@ ATT&CK Technique.Platforms.
 
   * *ShortString* String with at most 1024 characters.
 
-<a id="map146"></a>
+<a id="map147"></a>
 # *KillChainPhase* Object
 
 *KillChainPhase* The kill-chain-phase represents a phase in a kill chain, which describes the various phases an attacker may undertake in order to achieve their objectives.
@@ -13666,7 +14120,7 @@ The name of the phase in the kill chain.
     * weaponization
   * Reference: [Open Vocabulary](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.u4s6d165nk3c)
 
-<a id="map145"></a>
+<a id="map146"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -13728,7 +14182,7 @@ A URL reference to an external resource.
 
   * A URI
 
-<a id="map144"></a>
+<a id="map145"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -13803,9 +14257,11 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assetpropertiestypeidentifierstring)|AssetPropertiesTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which the AssetProperties is considered valid.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[properties](#propertyproperties-assetpropertyobjectlist)|*AssetProperty* Object List| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -13823,6 +14279,16 @@ URI that points to the associated Asset.
 
 
   * A URI leading to an entity.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -13850,9 +14316,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map147-ref"></a>
+<a id="map148-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map147)
+  * Details: [*ExternalReference* Object](#map148)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -13876,6 +14342,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyproperties-assetpropertyobjectlist"></a>
 ## Property properties ∷ *AssetProperty* Object List
 
@@ -13883,9 +14359,9 @@ For example, if an incident involves an attack on a system in a country where a 
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map149-ref"></a>
+<a id="map150-ref"></a>
 * *AssetProperty* Object Value
-  * Details: [*AssetProperty* Object](#map149)
+  * Details: [*AssetProperty* Object](#map150)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -13972,11 +14448,11 @@ The time range during which the AssetProperties is considered valid.
 * This entry is required
 
 
-<a id="map148-ref"></a>
+<a id="map149-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map148)
+  * Details: [*ValidTime* Object](#map149)
 
-<a id="map149"></a>
+<a id="map150"></a>
 # *AssetProperty* Object
 
 | Property | Type | Description | Required? |
@@ -14002,7 +14478,7 @@ The properties are an open vocabulary.
 
 
 
-<a id="map148"></a>
+<a id="map149"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -14034,7 +14510,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map147"></a>
+<a id="map148"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -14114,9 +14590,11 @@ A URL reference to an external resource.
 |[stability](#propertystability-stabilitystring)|StabilityString|Do we manage when it changes, or is it always a time bound assignment?|&#10003;|
 |[type](#propertytype-assetmappingtypeidentifierstring)|AssetMappingTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|For each asset, we allow for the assertion of time bound properties.This gives us both a record of the current state of the asset,as well as history.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
@@ -14166,6 +14644,16 @@ Level of confidence held in the characterization of this AssetMapping e.g.: is i
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
 
@@ -14192,9 +14680,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map150-ref"></a>
+<a id="map151-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map150)
+  * Details: [*ExternalReference* Object](#map151)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -14218,6 +14706,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object
 
@@ -14226,9 +14724,9 @@ An AssetMapping is a record that a specific Observable maps to an Asset for an i
 * This entry is required
 
 
-<a id="map152-ref"></a>
+<a id="map153-ref"></a>
 * *Observable* Object Value
-  * Details: [*Observable* Object](#map152)
+  * Details: [*Observable* Object](#map153)
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -14341,11 +14839,11 @@ For each asset, we allow for the assertion of time bound properties.This gives u
 * This entry is required
 
 
-<a id="map151-ref"></a>
+<a id="map152-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map151)
+  * Details: [*ValidTime* Object](#map152)
 
-<a id="map152"></a>
+<a id="map153"></a>
 # *Observable* Object
 
 *Observable* A simple, atomic value which has a consistent identity, and is stable enough to be attributed an intent or nature.  This is the classic 'indicator' which might appear in a data feed of bad IPs, or bad Domains.  These do not exist as objects within the CTIA storage model, so you never create an observable.
@@ -14423,7 +14921,7 @@ For each asset, we allow for the assertion of time bound properties.This gives u
 
 
 
-<a id="map151"></a>
+<a id="map152"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -14455,7 +14953,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map150"></a>
+<a id="map151"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -14530,10 +15028,12 @@ A URL reference to an external resource.
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-assettypeidentifierstring)|AssetTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|Specifies the time range during which the asset is considered valid or accurate. For example, if an asset entity represents a device, the `valid_time` field could be used to indicate the period during which the device's configuration information is deemed accurate.|&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -14557,6 +15057,16 @@ Type of the Asset: Device, Person, Application, etc.
     * device
     * network
     * person
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -14594,9 +15104,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map153-ref"></a>
+<a id="map154-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map153)
+  * Details: [*ExternalReference* Object](#map154)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -14619,6 +15129,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer
@@ -14726,11 +15246,11 @@ For example, if an asset entity represents a device, the `valid_time` field coul
 * This entry is required
 
 
-<a id="map154-ref"></a>
+<a id="map155-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map154)
+  * Details: [*ValidTime* Object](#map155)
 
-<a id="map154"></a>
+<a id="map155"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -14762,7 +15282,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map153"></a>
+<a id="map154"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.
@@ -14842,11 +15362,13 @@ A URL reference to an external resource.
 |[actor_types](#propertyactor_types-threatactortypestringlist)|ThreatActorTypeString List| ||
 |[aliases](#propertyaliases-shortstringstringlist)|ShortStringString List|A list of other names that this Threat Actor is believed to use.||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|This field can help analysts decide how much trust they can put in the information provided by the threat intelligence sources.  For example, an Actor entity can have high confidence if the organization's security researchers have been tracking it for a long time and have gathered a significant amount of intelligence about it through various sources, such as analysis of malware, network traffic, and human intelligence. In contrast, low confidence may indicate the organization has only seen limited or circumstantial evidence.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[identity](#propertyidentity-identityobject)|*Identity* Object|Can contain information such as the name of the attacker, the group or organization they belong to, or any other identifier that can help in the attribution process.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Represents the desired outcome or impact the threat actor is trying to achieve through their malicious activities.    Helps security analysts to understand the attacker's goals beyond the immediate impact of the attack. By understanding the intended effect, analysts can draw connections between seemingly unrelated attacks and build a more complete understanding of an attacker's long-term goals and motivations.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[motivation](#propertymotivation-motivationstring)|MotivationString|The reason or purpose behind the malicious activity attributed to this Actor. By understanding a threat actor's motivation, analysts can better predict the attacker's behavior and anticipate future malicious actions.||
 |[planning_and_operational_support](#propertyplanning_and_operational_support-longstringstring)|LongStringString|Provides information about the resources and capabilities of the attacker that could be used to assist in planning and operations related to the threat.   It can be used to describe Infrastructure, Tools, Techniques, and Capabilities used by the threat actor.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -14913,6 +15435,16 @@ For example, an Actor entity can have high confidence if the organization's secu
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
 
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
 
@@ -14949,9 +15481,9 @@ Similar to `external_ids` field with major differences:
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map155-ref"></a>
+<a id="map156-ref"></a>
 * *ExternalReference* Object Value
-  * Details: [*ExternalReference* Object](#map155)
+  * Details: [*ExternalReference* Object](#map156)
 
 <a id="propertyid-string"></a>
 ## Property id ∷ String
@@ -14971,9 +15503,9 @@ Can contain information such as the name of the attacker, the group or organizat
 * This entry is optional
 
 
-<a id="map157-ref"></a>
+<a id="map158-ref"></a>
 * *Identity* Object Value
-  * Details: [*Identity* Object](#map157)
+  * Details: [*Identity* Object](#map158)
 
 <a id="propertyintended_effect-intendedeffectstring"></a>
 ## Property intended_effect ∷ IntendedEffectString
@@ -15022,6 +15554,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertymotivation-motivationstring"></a>
 ## Property motivation ∷ MotivationString
@@ -15185,11 +15727,11 @@ Indicates the time span for which the information about the Actor is relevant, a
 * This entry is required
 
 
-<a id="map156-ref"></a>
+<a id="map157-ref"></a>
 * *ValidTime* Object Value
-  * Details: [*ValidTime* Object](#map156)
+  * Details: [*ValidTime* Object](#map157)
 
-<a id="map157"></a>
+<a id="map158"></a>
 # *Identity* Object
 
 *Identity* Describes a person or an organization.
@@ -15218,11 +15760,11 @@ Identifies other entity Identities related to this Identity.
 * This entry's type is sequential (allows zero or more values)
 
 
-<a id="map158-ref"></a>
+<a id="map159-ref"></a>
 * *RelatedIdentity* Object Value
-  * Details: [*RelatedIdentity* Object](#map158)
+  * Details: [*RelatedIdentity* Object](#map159)
 
-<a id="map158"></a>
+<a id="map159"></a>
 # *RelatedIdentity* Object
 
 *RelatedIdentity* Describes a related Identity
@@ -15279,7 +15821,7 @@ Specifies the source of the information about the relationship between the two c
 
 
 
-<a id="map156"></a>
+<a id="map157"></a>
 # *ValidTime* Object
 
 *ValidTime* Period of time when a cyber observation is valid.
@@ -15311,7 +15853,7 @@ If not present, the valid time position of the indicator does not have an upper 
 
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
-<a id="map155"></a>
+<a id="map156"></a>
 # *ExternalReference* Object
 
 *ExternalReference* External references are used to describe pointers to information represented outside of CTIM. For example, a Malware object could use an external reference to indicate an ID for that malware in an external database or a report could use references to represent source material.

--- a/doc/structures/coa.md
+++ b/doc/structures/coa.md
@@ -11,12 +11,14 @@
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
 |[coa_type](#propertycoa_type-coatypestring)|COATypeString|The type of this COA||
 |[cost](#propertycost-highmedlowstring)|HighMedLowString|Characterizes the estimated cost for applying this course of action.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[efficacy](#propertyefficacy-highmedlowstring)|HighMedLowString|Effectiveness of this course of action in achieving its targeted objective.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-shortstringstring)|ShortStringString|Characterizes the estimated impact of applying this course of action.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[objective](#propertyobjective-shortstringstringlist)|ShortStringString List|Characterizes the objective to provide guidance on how to mitigate a security incident that has been identified.||
 |[open_c2_coa](#propertyopen_c2_coa-openc2coaobject)|*OpenC2COA* Object| ||
 |[related_COAs](#propertyrelated_coas-relatedcoaobjectlist)|*RelatedCOA* Object List|Identifies or characterizes relationships to one or more related courses of action.||
@@ -78,6 +80,16 @@ Characterizes the estimated cost for applying this course of action.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -167,6 +179,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobjective-shortstringstringlist"></a>
 ## Property objective ∷ ShortStringString List

--- a/doc/structures/feedback.md
+++ b/doc/structures/feedback.md
@@ -12,15 +12,27 @@
 |[reason](#propertyreason-string)|String| |&#10003;|
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-feedbacktypeidentifierstring)|FeedbackTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
 |[timestamp](#propertytimestamp-instdate)|Inst (Date)|The time this object was created at, or last modified.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyentity_id-string"></a>
 ## Property entity_id ∷ String
@@ -92,6 +104,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyreason-string"></a>
 ## Property reason ∷ String

--- a/doc/structures/incident.md
+++ b/doc/structures/incident.md
@@ -17,12 +17,15 @@
 |[type](#propertytype-incidenttypeidentifierstring)|IncidentTypeIdentifierString| |&#10003;|
 |[assignees](#propertyassignees-shortstringstringlist)|ShortStringString List|A set of owners assigned to this incident.||
 |[categories](#propertycategories-incidentcategorystringlist)|IncidentCategoryString List|A set of categories for this incident.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[discovery_method](#propertydiscovery_method-discoverymethodstring)|DiscoveryMethodString|Identifies how the incident was discovered.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[intended_effect](#propertyintended_effect-intendedeffectstring)|IntendedEffectString|Specifies the suspected intended effect of this incident||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[meta](#propertymeta-metadataobject)|*MetaData* Object|metadata associated to the incident.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[promotion_method](#propertypromotion_method-promotionmethodstring)|PromotionMethodString|Describes method for promoting an Incident, whether manually or automatically. An Incident may be created manually by a SOAR analyst or SOC operator, or through an automated correlation or aggregation rule or engine that matches a specific set of events or alerts, and promotes them to Incident(s).||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[scores](#propertyscores-incidentscoresobject)|*IncidentScores* Object|Used to indicate the severity or impact score of the threat represented by the incident.||
@@ -103,6 +106,16 @@ It is important to note that the `confidence` field is subjective and can be int
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -241,6 +254,28 @@ For example, if an incident involves an attack on a system in a country where a 
 
   * *ShortString* String with at most 1024 characters.
 
+<a id="propertymeta-metadataobject"></a>
+## Property meta ∷ *MetaData* Object
+
+metadata associated to the incident.
+
+* This entry is optional
+
+
+<a id="map3-ref"></a>
+* *MetaData* Object Value
+  * Details: [*MetaData* Object](#map3)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
 <a id="propertypromotion_method-promotionmethodstring"></a>
 ## Property promotion_method ∷ PromotionMethodString
 
@@ -281,9 +316,9 @@ Used to indicate the severity or impact score of the threat represented by the i
 * This entry is optional
 
 
-<a id="map3-ref"></a>
+<a id="map4-ref"></a>
 * *IncidentScores* Object Value
-  * Details: [*IncidentScores* Object](#map3)
+  * Details: [*IncidentScores* Object](#map4)
 
 <a id="propertyseverity-severitystring"></a>
 ## Property severity ∷ SeverityString
@@ -584,6 +619,29 @@ Time the incident was first reported.
   * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="map3"></a>
+# *MetaData* Object
+
+| Property | Type | Description | Required? |
+| -------- | ---- | ----------- | --------- |
+|[Keyword](#propertykeyword-either)|String|custom field relevant to attach meta data to.||
+
+
+<a id="propertykeyword-either"></a>
+## Property Keyword ∷ Either
+
+custom field relevant to attach meta data to.
+
+* This entry is optional
+
+
+  * Only one of the following schemas will match
+
+
+
+
+
+
+<a id="map4"></a>
 # *IncidentScores* Object
 
 | Property | Type | Description | Required? |

--- a/doc/structures/indicator.md
+++ b/doc/structures/indicator.md
@@ -25,6 +25,7 @@ _specification_ value.
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object|The time range during which this Indicator is considered valid.|&#10003;|
 |[composite_indicator_expression](#propertycomposite_indicator_expression-compositeindicatorexpressionobject)|*CompositeIndicatorExpression* Object| ||
 |[confidence](#propertyconfidence-highmedlowstring)|HighMedLowString|level of confidence held in the accuracy of this Indicator.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -32,6 +33,7 @@ _specification_ value.
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|Relevant kill chain phases indicated by this Indicator.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[likely_impact](#propertylikely_impact-longstringstring)|LongStringString|Likely potential impact within the relevant context if this Indicator were to occur.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[negate](#propertynegate-boolean)|Boolean|Specifies the absence of the pattern.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[severity](#propertyseverity-severitystring)|SeverityString| ||
@@ -73,6 +75,16 @@ level of confidence held in the accuracy of this Indicator.
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -186,6 +198,16 @@ Likely potential impact within the relevant context if this Indicator were to oc
 
 
   * *LongString* String with at most 5000 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynegate-boolean"></a>
 ## Property negate ∷ Boolean

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -26,9 +26,11 @@
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[type](#propertytype-judgementtypeidentifierstring)|JudgementTypeIdentifierString| |&#10003;|
 |[valid_time](#propertyvalid_time-validtimeobject)|*ValidTime* Object| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[reason](#propertyreason-shortstringstring)|ShortStringString| ||
 |[reason_uri](#propertyreason_uri-string)|String| ||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
@@ -51,6 +53,16 @@
     * None
     * Unknown
   * Reference: [HighMedLowVocab](http://stixproject.github.io/data-model/1.2/stixVocabs/HighMediumLowVocab-1.0/)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydisposition-dispositionnumberinteger"></a>
 ## Property disposition ∷ DispositionNumberInteger
@@ -133,6 +145,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservable-observableobject"></a>
 ## Property observable ∷ *Observable* Object

--- a/doc/structures/malware.md
+++ b/doc/structures/malware.md
@@ -13,10 +13,12 @@
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-malwaretypeidentifierstring)|MalwareTypeIdentifierString| |&#10003;|
 |[abstraction_level](#propertyabstraction_level-malwareabstractionsstring)|MalwareAbstractionsString|Malware abstraction level.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of Kill Chain Phases for which this Malware can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -39,6 +41,16 @@ Malware abstraction level.
     * family
     * variant
     * version
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -144,6 +156,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/note.md
+++ b/doc/structures/note.md
@@ -13,9 +13,11 @@ For example, an analyst may add a Note to a Campaign object created by another o
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-notetypeidentifierstring)|NoteTypeIdentifierString| |&#10003;|
 |[author](#propertyauthor-string)|String| ||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -37,6 +39,16 @@ For example, an analyst may add a Note to a Campaign object created by another o
 
 
   * *Markdown* Markdown string with at most 5000 characters.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyexternal_ids-stringlist"></a>
 ## Property external_ids ∷ String List
@@ -89,6 +101,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynote_class-keyword"></a>
 ## Property note_class ∷ Keyword

--- a/doc/structures/relationship.md
+++ b/doc/structures/relationship.md
@@ -11,10 +11,12 @@
 |[source_ref](#propertysource_ref-string)|String| |&#10003;|
 |[target_ref](#propertytarget_ref-string)|String| |&#10003;|
 |[type](#propertytype-relationshiptypeidentifierstring)|RelationshipTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
@@ -23,6 +25,16 @@
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.||
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -85,6 +97,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrelationship_type-relationshiptypestring"></a>
 ## Property relationship_type ∷ RelationshipTypeString

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -12,12 +12,14 @@
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-sightingtypeidentifierstring)|SightingTypeIdentifierString| |&#10003;|
 |[context](#propertycontext-contextobject)|*Context* Object|Context including the event type that best fits the type of the sighting.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[data](#propertydata-sightingdatatableobject)|*SightingDataTable* Object|An embedded data table for the Sighting.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[internal](#propertyinternal-boolean)|Boolean|If `true`, indicates that the sighting was reported from internal sources, such as an organization's own internal security tools or SOC.  Internal sightings are often considered more reliable and actionable than external sightings, which are reported from external sources and may have a lower level of trustworthiness. Internal sightings can provide more context and can help identify potential threats that are unique to a particular environment or organization.  Internal sightings can also help organizations prioritize their security response efforts by identifying threats that are specific to their environment and may not yet be widely known.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[observables](#propertyobservables-observableobjectlist)|*Observable* Object List|The object(s) of interest.||
 |[relations](#propertyrelations-observedrelationobjectlist)|*ObservedRelation* Object List|Provide any context we can about where the observable came from.||
 |[resolution](#propertyresolution-resolutionstring)|ResolutionString|Represents the disposition or actions taken on the associated threat intelligence.||
@@ -73,6 +75,16 @@ It can also be used to prioritize security alerts and indicate the urgency of a 
 
 
   * Zero, or a positive integer.
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydata-sightingdatatableobject"></a>
 ## Property data ∷ *SightingDataTable* Object
@@ -158,6 +170,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyobservables-observableobjectlist"></a>
 ## Property observables ∷ *Observable* Object List

--- a/doc/structures/target_record.md
+++ b/doc/structures/target_record.md
@@ -11,10 +11,12 @@
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.|&#10003;|
 |[targets](#propertytargets-targetobjectlist)|*Target* Object List| |&#10003;|
 |[type](#propertytype-targetrecordtypeidentifierstring)|TargetRecordTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[description](#propertydescription-markdownstring)|MarkdownString|A description of object, which may be detailed.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -23,6 +25,16 @@
 |[tlp](#propertytlp-tlpstring)|TLPString|TLP stands for [Traffic Light Protocol](https://www.us-cert.gov/tlp), which indicates precisely how a resource is intended to be shared, replicated, copied, etc.  It is used to indicate the sensitivity of the information contained within the message. This allows recipients to determine the appropriate handling and dissemination of the information based on their clearance level and need-to-know.  For example, an entity containing information about a critical vulnerability in a widely-used software might be marked as `red`, indicating that it should only be shared with a small group of highly trusted individuals who need to know in order to take appropriate action. On the other hand, a message containing more general information about security threats might be marked as `amber` or `green`, indicating that it can be shared more broadly within an organization.||
 
 * Reference: [TargetRecord](https://github.com/threatgrid/response/blob/master/features/assets/assets.org#targetrecord)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -85,6 +97,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/tool.md
+++ b/doc/structures/tool.md
@@ -12,10 +12,12 @@
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.|&#10003;|
 |[title](#propertytitle-shortstringstring)|ShortStringString|A short title for this object, used as primary display and reference value.|&#10003;|
 |[type](#propertytype-tooltypeidentifierstring)|ToolTypeIdentifierString| |&#10003;|
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[kill_chain_phases](#propertykill_chain_phases-killchainphaseobjectlist)|*KillChainPhase* Object List|The list of kill chain phases for which this Tool can be used.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[source](#propertysource-medstringstring)|MedStringString|Represents the source of the intelligence that led to the creation of the entity.||
 |[source_uri](#propertysource_uri-string)|String|URI of the source of the intelligence that led to the creation of the entity.||
@@ -25,6 +27,16 @@
 |[x_mitre_aliases](#propertyx_mitre_aliases-shortstringstringlist)|ShortStringString List|ATT&CK Software.aliases.||
 
 * Reference: [Tool](https://docs.google.com/document/d/1IvkLxg_tCnICsatu2lyxKmWmh1gY2h8HUNssKIE-UIA/pub#h.z4voa9ndw8v)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -120,6 +132,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 
   * *ShortString* String with at most 1024 characters.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertyrevision-integer"></a>
 ## Property revision ∷ Integer

--- a/doc/structures/vulnerability.md
+++ b/doc/structures/vulnerability.md
@@ -10,12 +10,14 @@
 |[schema_version](#propertyschema_version-string)|String|CTIM schema version for this entity.|&#10003;|
 |[type](#propertytype-vulnerabilitytypeidentifierstring)|VulnerabilityTypeIdentifierString|The fixed value vulnerability|&#10003;|
 |[configurations](#propertyconfigurations-configurationsobject)|*Configurations* Object|Represents a list of affected versions or configurations of a software component that is impacted by a vulnerability.  By tracking the affected software components and versions, defenders can identify which systems are potentially exposed to an attack, and apply appropriate mitigations.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[cve](#propertycve-cveobject)|*CVE* Object| ||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
 |[impact](#propertyimpact-vulnerabilityimpactobject)|*VulnerabilityImpact* Object|Describes the potential impact of a vulnerability that is being tracked in the system. Provides information on the extent of damage that a vulnerability can cause and how serious the consequences could be if it is exploited.   May contain granular information about the vulnerability severity using the CVSS system, versions 2 and 3.  CVSSv2 and CVSSv3 have different methods of calculating base scores, but both are designed to provide an indication of the level of risk that a vulnerability poses. The base score ranges from 0 to 10, with 10 being the most severe. Additionally, both CVSSv2 and CVSSv3 define severity levels, such as low, medium, high, and critical, based on the base score.||
 |[language](#propertylanguage-shortstringstring)|ShortStringString|The `language` field is used to specify the primary language of the affected system or the target of an attack. It can be used to provide additional context and information about the entity. The primary purpose of this field is to help analysts filter and prioritize entities based on their knowledge and expertise of different languages.  For example, if an incident involves an attack on a system in a country where a specific language is predominant, the `language` field can be used to indicate that language, which can help analysts to quickly identify and respond to incidents that may be geographically or culturally relevant. This information can be used to prioritize incidents based on their potential impact. The `language` field can also be used to help with correlation of incidents across different systems and regions, as well as to help with data analysis and reporting.||
 |[last_modified_date](#propertylast_modified_date-instdate)|Inst (Date)|Represents the date when the vulnerability metadata was last updated in the internal database. It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[published_date](#propertypublished_date-instdate)|Inst (Date)|Represents the date when a vulnerability was publicly disclosed or made available to the general public.   Important for tracking the age of a vulnerability, as well as for determining when a particular vulnerability was first introduced into a system. The published date can be used to identify the time window during which a system may have been vulnerable to a particular exploit.  For example, if an organization discovers that a vulnerability was published before their system's installation date, but they did not apply the necessary security updates in a timely manner, it can be concluded that their system was vulnerable for the period between the installation date and the date when the necessary security updates were applied.||
 |[revision](#propertyrevision-integer)|Integer|A monotonically increasing revision, incremented each time the object is changed.||
 |[short_description](#propertyshort_description-medstringstring)|MedStringString|A single line, short summary of the object.||
@@ -39,6 +41,16 @@ By tracking the affected software components and versions, defenders can identif
 <a id="map4-ref"></a>
 * *Configurations* Object Value
   * Details: [*Configurations* Object](#map4)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertycve-cveobject"></a>
 ## Property cve ∷ *CVE* Object
@@ -135,6 +147,16 @@ For example, if an incident involves an attack on a system in a country where a 
 
 Represents the date when the vulnerability metadata was last updated in the internal database.
 It can be used to track the freshness of the vulnerability information. If the `last_modified_date` is more recent than the `published_date`, it can indicate that there has been some new information or updates related to the vulnerability, such as new patch releases or changes in the severity or impact rating.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
 
 * This entry is optional
 

--- a/doc/structures/weakness.md
+++ b/doc/structures/weakness.md
@@ -15,6 +15,7 @@
 |[architectures](#propertyarchitectures-architectureobjectlist)|*Architecture* Object List|Applicable architectures.||
 |[background_details](#propertybackground_details-markdownstring)|MarkdownString|Information that is relevant but not related to the nature of the weakness itself.||
 |[common_consequences](#propertycommon_consequences-consequenceobjectlist)|*Consequence* Object List|Refers to the typical or expected negative effects that can result from exploiting the weakness. This could include anything from unauthorized access to data, denial of service, system crashes or other things.||
+|[created](#propertycreated-instdate)|Inst (Date)|The time this object was created at.||
 |[detection_methods](#propertydetection_methods-detectionmethodobjectlist)|*DetectionMethod* Object List|Identifies methods that may be employed to detect this weakness, including their strengths and limitations.||
 |[external_ids](#propertyexternal_ids-stringlist)|String List|It is used to store a list of external identifiers that can be linked to the incident, providing a reliable and manageable way to correlate and group related events across multiple data sources. It is especially useful in larger organizations that rely on multiple security information and event management (SIEM) systems to detect security incidents. For instance, it can be used to track events across different network sensors, intrusion detection and prevention systems (IDPS), or log management platforms.   The field can also be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems. It can be used to cross-reference with other external tools such as threat intelligence feeds and vulnerability scanners.||
 |[external_references](#propertyexternal_references-externalreferenceobjectlist)|*ExternalReference* Object List|Specifies a list of external references which refers to non-CTIM information.  Similar to `external_ids` field with major differences:  - `external_ids` field is used to store a list of external identifiers that can be used to link entities across different data sources. These identifiers are typically standardized and well-known, such as CVE IDs, US-CERT advisories, or other industry-standard threat intelligence feeds. The `external_ids` field can be used to facilitate automation and orchestration workflows, where additional information can be shared among incident management systems.   - `external_references` field, on the other hand, is used to provide a more general mechanism for linking entities to external sources of information. The `external_references` field can include references to blog posts, articles, external documents, threat intelligence reports, and other sources of information that may not have a standardized format or identifier.||
@@ -23,6 +24,7 @@
 |[languages](#propertylanguages-languageobjectlist)|*Language* Object List|Applicable Languages.||
 |[likelihood](#propertylikelihood-highmedlowstring)|HighMedLowString|Likelihood of exploit.||
 |[modes_of_introduction](#propertymodes_of_introduction-modeofintroductionobjectlist)|*ModeOfIntroduction* Object List|Information about how and when a given weakness may be introduced.||
+|[modified](#propertymodified-instdate)|Inst (Date)|The time this object was last modified.||
 |[notes](#propertynotes-noteobjectlist)|*Note* Object List|Provides any additional comments about the weakness.||
 |[operating_systems](#propertyoperating_systems-operatingsystemobjectlist)|*OperatingSystem* Object List|Applicable operating systems.||
 |[paradigms](#propertyparadigms-paradigmobjectlist)|*Paradigm* Object List|Applicable paradigms.||
@@ -131,6 +133,16 @@ Refers to the typical or expected negative effects that can result from exploiti
 <a id="map9-ref"></a>
 * *Consequence* Object Value
   * Details: [*Consequence* Object](#map9)
+
+<a id="propertycreated-instdate"></a>
+## Property created ∷ Inst (Date)
+
+The time this object was created at.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertydescription-markdownstring"></a>
 ## Property description ∷ MarkdownString
@@ -280,6 +292,16 @@ Information about how and when a given weakness may be introduced.
 <a id="map8-ref"></a>
 * *ModeOfIntroduction* Object Value
   * Details: [*ModeOfIntroduction* Object](#map8)
+
+<a id="propertymodified-instdate"></a>
+## Property modified ∷ Inst (Date)
+
+The time this object was last modified.
+
+* This entry is optional
+
+
+  * *ISO8601 Timestamp* Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.
 
 <a id="propertynotes-noteobjectlist"></a>
 ## Property notes ∷ *Note* Object List

--- a/src/ctim/examples/actors.cljc
+++ b/src/ctim/examples/actors.cljc
@@ -15,6 +15,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :actor_types ["Hacker"],
    :confidence "High",

--- a/src/ctim/examples/asset_mappings.cljc
+++ b/src/ctim/examples/asset_mappings.cljc
@@ -16,6 +16,8 @@
                           :hashes      ["#section1"]
                           :description "Description text"}]
    :timestamp           #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language            "language"
    :tlp                 "green"
 

--- a/src/ctim/examples/asset_properties.cljc
+++ b/src/ctim/examples/asset_properties.cljc
@@ -15,6 +15,8 @@
                           :hashes      ["#section1"]
                           :description "Description text"}]
    :timestamp           #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language            "language"
    :tlp                 "green"
 

--- a/src/ctim/examples/assets.cljc
+++ b/src/ctim/examples/assets.cljc
@@ -15,6 +15,8 @@
                           :hashes      ["#section1"]
                           :description "Description text"}]
    :timestamp           #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language            "language"
    :tlp                 "green"
    :source              "source"

--- a/src/ctim/examples/attack_patterns.cljc
+++ b/src/ctim/examples/attack_patterns.cljc
@@ -15,6 +15,8 @@
      :description "Description text"
      :hashes ["#section1"]}]
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/bundles.cljc
+++ b/src/ctim/examples/bundles.cljc
@@ -40,6 +40,8 @@
      :hashes      ["#section1"]
      :description "Description text"}]
    :timestamp               #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language                "language"
    :tlp                     "green"
    :description             "a sighting"

--- a/src/ctim/examples/campaigns.cljc
+++ b/src/ctim/examples/campaigns.cljc
@@ -16,6 +16,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :title "campaign"
    :description "description"

--- a/src/ctim/examples/casebooks.cljc
+++ b/src/ctim/examples/casebooks.cljc
@@ -25,6 +25,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-10-01T00:00:00.000-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :title "casebook"
    :description "description"

--- a/src/ctim/examples/coas.cljc
+++ b/src/ctim/examples/coas.cljc
@@ -49,6 +49,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-10-01T00:00:00.000-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :title "coa"
    :description "description"

--- a/src/ctim/examples/data_tables.cljc
+++ b/src/ctim/examples/data_tables.cljc
@@ -15,6 +15,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :title "title"
    :description "description"
    :short_description "short description"

--- a/src/ctim/examples/feedbacks.cljc
+++ b/src/ctim/examples/feedbacks.cljc
@@ -15,6 +15,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/identity_assertions.cljc
+++ b/src/ctim/examples/identity_assertions.cljc
@@ -15,6 +15,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -21,6 +21,8 @@
    :schema_version c/ctim-schema-version
    :revision 1
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :severity "High"
    :tactics ["TA0011"],

--- a/src/ctim/examples/indicators.cljc
+++ b/src/ctim/examples/indicators.cljc
@@ -23,6 +23,8 @@
    :source_uri "http://example.com"
    :revision 1
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :indicator_type ["C2" "IP Watchlist"]
    :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"

--- a/src/ctim/examples/investigations.cljc
+++ b/src/ctim/examples/investigations.cljc
@@ -16,6 +16,8 @@
                           :hashes ["#section1"]
                           :description "Description text"}]
    :timestamp #inst "2017-10-23T19:25:27.278-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :title "investigation-title"
    :description "description"

--- a/src/ctim/examples/judgements.cljc
+++ b/src/ctim/examples/judgements.cljc
@@ -14,6 +14,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/malwares.cljc
+++ b/src/ctim/examples/malwares.cljc
@@ -15,6 +15,8 @@
      :description "Cylance. (2014, December). Operation Cleaver. Retrieved December 4, 2014."
      :hashes ["#section1"]}]
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/notes.cljc
+++ b/src/ctim/examples/notes.cljc
@@ -26,7 +26,9 @@
                        :entity_id "https://ex.tld/ctia/incident/incident-0ecb71f3-6b04-4bbe-ba81-a0acf6f78395"}
                       {:entity_type "coa"
                        :entity_id "https://ex.tld/ctia/coa/coa-8703b709-e668-4461-bd3f-ef0cd2925fbd"}]
-   :timestamp #inst "2010-01-01T00:00:00.048-00:00"})
+   :timestamp #inst "2010-01-01T00:00:00.048-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"})
 
 (def note-minimal
   {:id "https://ex.tld/ctia/note/note-0ecb71f3-6b04-4bbe-ba81-a0acf6f78394"

--- a/src/ctim/examples/relationships.cljc
+++ b/src/ctim/examples/relationships.cljc
@@ -17,6 +17,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/sightings.cljc
+++ b/src/ctim/examples/sightings.cljc
@@ -12,6 +12,8 @@
      :hashes ["#section1"]
      :description "Description text"}]
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                    :end_time #inst "2016-02-11T00:40:48.212-00:00"}
    :description "a sighting"

--- a/src/ctim/examples/target_records.cljc
+++ b/src/ctim/examples/target_records.cljc
@@ -18,6 +18,8 @@
    :description         "description"
    :short_description   "short description"
    :timestamp           #inst "2016-02-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language            "language"
    :tlp                 "green"
    :targets             [{:type          "endpoint"

--- a/src/ctim/examples/tools.cljc
+++ b/src/ctim/examples/tools.cljc
@@ -15,6 +15,8 @@
      :description "Microsoft. (n.d.). Dir. Retrieved April 18, 2016."
      :hashes ["#section1"]}]
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/examples/vulnerabilities.cljc
+++ b/src/ctim/examples/vulnerabilities.cljc
@@ -112,6 +112,8 @@
    "http://ex.tld/ctia/vulnerability/vulnerability-6c5a8540-cec7-4647-abb6-84cd2d2fa544"
    :tlp "green"
    :timestamp #inst "2010-01-01T00:00:00.000-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :published_date #inst "2016-02-11T00:40:48.212-00:00"
    :last_modified_date #inst "2016-02-11T00:40:48.212-00:00"})
 

--- a/src/ctim/examples/weaknesses.cljc
+++ b/src/ctim/examples/weaknesses.cljc
@@ -15,6 +15,8 @@
      :description "Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
      :hashes ["#Common_Consequences"]}]
    :timestamp #inst "2016-05-11T00:40:48.212-00:00"
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :tlp "green"
    :source "source"

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -184,7 +184,7 @@
                     "material.")
   :reference "[External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)")
 
-(def base-entity-entries
+(def base-editable-entity-entries
   (concat
    (f/required-entries
     (f/entry :id ID
@@ -224,6 +224,8 @@
                                "information that may not have a standardized format or identifier."))
     (f/entry :timestamp Time
              :description "The time this object was created at, or last modified.")
+    (f/entry :timestamp Time
+             :description "The time this object was created at, or last modified.")
     (f/entry :language ShortString
              :description (str "The `language` field is used to specify the primary language of the affected "
                                "system or the target of an attack. It can be used to provide additional context "
@@ -255,10 +257,21 @@
                                "general information about security threats might be marked as `amber` or "
                                "`green`, indicating that it can be shared more broadly within an organization.")))))
 
+(def time-metas
+   (f/optional-entries
+    (f/entry :created Time
+             :description "The time this object was created at.")
+    (f/entry :modified Time
+             :description "The time this object was last modified.")))
+
+(def base-entity-entries
+  "Base for New Entities, optionalizes ID and type and schema_version"
+  (concat base-editable-entity-entries time-metas))
+
 (def base-new-entity-entries
   "Base for New Entities, optionalizes ID and type and schema_version"
   (concat
-   base-entity-entries
+   base-editable-entity-entries
    (f/optional-entries
     (f/entry :id ID)
     (f/entry :type f/any-str

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -185,6 +185,7 @@
   :reference "[External Reference](https://docs.google.com/document/d/1dIrh1Lp3KAjEMm8o2VzAmuV0Peu-jt9aAh1IHrjAroM/pub#h.72bcfr3t79jx)")
 
 (def base-editable-entity-entries
+  "Common base fields that can be provided by users."
   (concat
    (f/required-entries
     (f/entry :id ID
@@ -223,9 +224,12 @@
                                "external documents, threat intelligence reports, and other sources of "
                                "information that may not have a standardized format or identifier."))
     (f/entry :timestamp Time
-             :description "The time this object was created at, or last modified.")
-    (f/entry :timestamp Time
-             :description "The time this object was created at, or last modified.")
+             :description (str "The time this object was created at, or last modified by the source. "
+                               "This fields can be set by the source of the entity to represent "
+                               "the creation or modification time in a different application."
+                               "When not provided by the source at the creation of the document, "
+                               "it can be set to the created date. Depending on scenario of use, "
+                               "the application managing the document may also update it at each modification."))
     (f/entry :language ShortString
              :description (str "The `language` field is used to specify the primary language of the affected "
                                "system or the target of an attack. It can be used to provide additional context "
@@ -258,18 +262,26 @@
                                "`green`, indicating that it can be shared more broadly within an organization.")))))
 
 (def time-metas
-   (f/optional-entries
+  "Internal time metadata fields aimed to manage the lifecycle of the entities in an application."
+  (f/optional-entries
     (f/entry :created Time
-             :description "The time this object was created at.")
+             :description (str "The time this object was created at in the application that manages "
+                               "the submitted document representing the entity.\n\n"
+                               "This field should only be set at the creation of the document in a database and never modified. "
+                               "It must only be set by the application that manages the document. "))
     (f/entry :modified Time
-             :description "The time this object was last modified.")))
+             :description (str "The time this object was last created at or modified in the application that manages "
+                               "the submitted document representing the entity.\n\n"
+                               "This field should only be set during the creation or modification of the document in a database, "
+                               "and automatically updated by the application each time a modification happens on the document. "
+                               "Similarly to created, updated must only be set by the application that manages the document. "))))
 
 (def base-entity-entries
   "Base for New Entities, optionalizes ID and type and schema_version"
   (concat base-editable-entity-entries time-metas))
 
 (def base-new-entity-entries
-  "Base for New Entities, optionalizes ID and type and schema_version"
+  "Base for realized entities."
   (concat
    base-editable-entity-entries
    (f/optional-entries


### PR DESCRIPTION
> Related #advthreat/iroh/issues/8788

In order to (try to) end the confusion with timestamp in all documents that is dedicated to date control by sources and incident_time various fields like opened that represent status changes, we decided to expose the CTIA internal document time meta: `created` and `modified`.
This will clarify:
- what is displayed in the UI
- the understanding of the `[from, to[` filtering that is based on created
- ease the QA, that needs a DB access to see these fields.