### PR TITLE
Add process_uid to the observable type vocabulary.

### DIFF
--- a/doc/structures/asset_mapping.md
+++ b/doc/structures/asset_mapping.md
@@ -400,6 +400,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -1946,6 +1946,7 @@ For each asset, we allow for the assertion of time bound properties.This gives u
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -3972,6 +3973,7 @@ Observable types that can be acted upon.
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -6179,6 +6181,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -337,6 +337,7 @@ A URL reference to an external resource.
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -4280,6 +4281,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -5061,6 +5063,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -5519,6 +5522,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/coa.md
+++ b/doc/structures/coa.md
@@ -895,6 +895,7 @@ Observable types that can be acted upon.
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/judgement.md
+++ b/doc/structures/judgement.md
@@ -392,6 +392,7 @@ A URL reference to an external resource.
     * process_name
     * process_path
     * process_username
+    * process_uid
     * processor_id
     * registry_key
     * registry_name

--- a/doc/structures/sighting.md
+++ b/doc/structures/sighting.md
@@ -742,6 +742,7 @@ If `true`, the row entries for this column cannot contain `nulls`. Defaults to `
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -950,6 +951,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -1031,6 +1033,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -1318,6 +1321,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key
@@ -1399,6 +1403,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/target_record.md
+++ b/doc/structures/target_record.md
@@ -473,6 +473,7 @@ Time of the observation. If the observation was made over a period of time, than
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/doc/structures/verdict.md
+++ b/doc/structures/verdict.md
@@ -140,6 +140,7 @@ The disposition_name field is optional, but is intended to be shown to a user.  
     * process_hash
     * process_name
     * process_path
+    * process_uid
     * process_username
     * processor_id
     * registry_key

--- a/src/ctim/schemas/vocabularies.cljc
+++ b/src/ctim/schemas/vocabularies.cljc
@@ -315,6 +315,7 @@
     "process_args"
     "process_hash"
     "process_path"
+    "process_uid"           ;; used to correlate process_name to specific process attributes
     "process_username"
     "registry_key"
     "registry_name"


### PR DESCRIPTION
Sighting.relations fields often include self referential processes.

For example:

* cmd.exe `parent_of` cmd.exe
* args 1 `args_of` cmd.exe
* args 2 `args_of` cmd.exe
* cmd.exe `connected_to` hostname

This does not tell us a very clear picture because there is no way to determine which thing did what.

This will give us the option of having a unique id for a process which is a collection of the attributes of that process.