### PR TITLE
Add size constraints to CTIM collection fields (XDR-46972)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [com.google.protobuf/protobuf-java "4.32.1"] ;clj-momo > org.clojure/clojurescript
                  [threatgrid/clj-momo "0.4.1"]
                  [org.mozilla/rhino "1.8.0"] ;threatgrid/flanders > kovacnica/clojure.network.ip
-                 [threatgrid/flanders "1.1.0"]
+                 [threatgrid/flanders "1.1.1-SNAPSHOT"]
                  [metosin/ring-swagger "1.0.0"]
                  [org.clojure/test.check "1.1.1"]
                  [com.gfredericks/test.chuck "0.2.15"]

--- a/src/ctim/lib/predicates.cljc
+++ b/src/ctim/lib/predicates.cljc
@@ -1,8 +1,10 @@
 (ns ctim.lib.predicates)
 
 (defn max-len [len]
-  (fn [test]
-    (>= len (count test))))
+  (with-meta
+    (fn [test]
+      (>= len (count test)))
+    {:max-len len}))
 
 (defn max-non-neg-int [max-num]
   (fn [test]

--- a/src/ctim/schemas/asset_properties.cljc
+++ b/src/ctim/schemas/asset_properties.cljc
@@ -18,12 +18,12 @@
 (f/def-map-type AssetProperty
   (concat
    (f/required-entries
-    (f/entry :name f/any-str
+    (f/entry :name c/ShortString
              :description "The properties are an open vocabulary."
              :comment (str "The properties are an open vocabulary, meaning that there is "
                            "a defined set of values, but users may add their own values."
                            "See: https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/identity_assertion.cljc#L11"))
-    (f/entry :value f/any-str))))
+    (f/entry :value c/MedString))))
 
 (def-entity-type AssetProperties
   {:description properties-desc

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -35,6 +35,7 @@
             [ctim.schemas.verdict :refer [Verdict VerdictRef]]
             [ctim.schemas.weakness :refer [NewWeakness Weakness WeaknessRef]]
             [ctim.schemas.vulnerability :refer [NewVulnerability Vulnerability VulnerabilityRef]]
+            [ctim.lib.predicates :as pred]
             #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 

--- a/src/ctim/schemas/bundle.cljc
+++ b/src/ctim/schemas/bundle.cljc
@@ -35,7 +35,6 @@
             [ctim.schemas.verdict :refer [Verdict VerdictRef]]
             [ctim.schemas.weakness :refer [NewWeakness Weakness WeaknessRef]]
             [ctim.schemas.vulnerability :refer [NewVulnerability Vulnerability VulnerabilityRef]]
-            [ctim.lib.predicates :as pred]
             #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])))
 

--- a/src/ctim/schemas/casebook.cljc
+++ b/src/ctim/schemas/casebook.cljc
@@ -17,8 +17,8 @@
 
 (def-map-type Text
   (f/required-entries
-   (f/entry :type f/any-str)
-   (f/entry :text f/any-str)))
+   (f/entry :type c/ShortString)
+   (f/entry :text c/LongString)))
 
 (def-entity-type Casebook
   {:description casebook-desc

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -24,6 +24,9 @@
 
 (def ctim-schema-version (ctim-version))
 
+;; Default size limit for collection fields (strings, references, etc.)
+(def default-collection-max-len 500)
+
 (def-eq CTIMSchemaVersion ctim-schema-version)
 
 (cs/def ::ctim-schema-version
@@ -197,7 +200,8 @@
    (f/optional-entries
     (f/entry :revision PosInt
              :description "A monotonically increasing revision, incremented each time the object is changed.")
-    (f/entry :external_ids f/any-string-seq
+    (f/entry :external_ids (f/seq-of f/any-str
+                                     :spec (pred/max-len default-collection-max-len))
              :description (str "It is used to store a list of external identifiers that can be linked to the "
                                "incident, providing a reliable and manageable way to correlate and group related "
                                "events across multiple data sources. It is especially useful in larger "
@@ -209,7 +213,8 @@
                                "information can be shared among incident management systems. It can be used to "
                                "cross-reference with other external tools such as threat intelligence feeds and "
                                "vulnerability scanners."))
-    (f/entry :external_references [ExternalReference]
+    (f/entry :external_references (f/seq-of ExternalReference
+                                            :spec (pred/max-len default-collection-max-len))
              :description (str "Specifies a list of external references which refers to non-CTIM "
                                "information.\n\n"
                                "Similar to `external_ids` field with major differences:\n\n"

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -27,6 +27,9 @@
 ;; Default size limit for collection fields (strings, references, etc.)
 (def default-collection-max-len 500)
 
+;; Max number of actions allowed in a single relation's relation_info
+(def max-relation-actions 1000)
+
 (def-eq CTIMSchemaVersion ctim-schema-version)
 
 (cs/def ::ctim-schema-version
@@ -628,7 +631,12 @@
             :required? false)
    (f/entry :relation ObservableRelationType)
    (f/entry :relation_info (f/map
-                            [(f/entry f/any-keyword f/any)])
+                            [(f/entry f/any-keyword f/any)]
+                            :spec (fn [m]
+                                    (let [actions (:actions m)]
+                                      (or (nil? actions)
+                                          (not (sequential? actions))
+                                          ((pred/max-len max-relation-actions) actions)))))
             :required? false)
    (f/entry :source Observable)
    (f/entry :related Observable)]

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -178,9 +178,9 @@
     (f/entry :description Markdown)
     (f/entry :url URI
              :description "A URL reference to an external resource.")
-    (f/entry :hashes f/any-string-seq
+    (f/entry :hashes (f/seq-of ShortString)
              :description "Specifies a dictionary of hashes for the contents of the url.")
-    (f/entry :external_id f/any-str
+    (f/entry :external_id ShortString
              :description "An identifier for the external reference content.")))
   :description (str "External references are used to describe pointers to information "
                     "represented outside of CTIM. For example, a Malware object could "
@@ -194,13 +194,13 @@
    (f/required-entries
     (f/entry :id ID
              :description "Globally unique URI identifying this object.")
-    (f/entry :type f/any-str)
+    (f/entry :type ShortString)
     (f/entry :schema_version SchemaVersion
              :description "CTIM schema version for this entity."))
    (f/optional-entries
     (f/entry :revision PosInt
              :description "A monotonically increasing revision, incremented each time the object is changed.")
-    (f/entry :external_ids (f/seq-of f/any-str
+    (f/entry :external_ids (f/seq-of ShortString
                                      :spec (pred/max-len default-collection-max-len))
              :description (str "It is used to store a list of external identifiers that can be linked to the "
                                "incident, providing a reliable and manageable way to correlate and group related "
@@ -268,7 +268,7 @@
    base-entity-entries
    (f/optional-entries
     (f/entry :id ID)
-    (f/entry :type f/any-str
+    (f/entry :type ShortString
              :description "A valid entity type identifer")
     (f/entry :schema_version CTIMSchemaVersion
              :description "CTIM schema version for this entity."))))
@@ -327,20 +327,20 @@
 
 (def-map-type Contributor
   (f/optional-entries
-   (f/entry :role f/any-str
+   (f/entry :role ShortString
             :description "Role played by this contributor.")
-   (f/entry :name f/any-str
+   (f/entry :name ShortString
             :description "Name of this contributor.")
-   (f/entry :email f/any-str
+   (f/entry :email ShortString
             :description "Email of this contributor.")
-   (f/entry :phone f/any-str
+   (f/entry :phone ShortString
             :description "Telephone number of this contributor.")
-   (f/entry :organization f/any-str
+   (f/entry :organization ShortString
             :description "Organization name of this contributor.")
    (f/entry :date Time
             :description (str "Description (bounding) of the timing of this "
                               "contributor's involvement."))
-   (f/entry :contribution_location f/any-str
+   (f/entry :contribution_location ShortString
             :description (str "information describing the location at which the "
                               "contributory activity occured")))
   :description "Person who contributed cyber observation data."
@@ -355,10 +355,10 @@
     (f/entry :confidence v/HighMedLow
              :description (str "Specifies the level of confidence in the assertion "
                                "of the relationship between the two objects."))
-    (f/entry :information_source f/any-str
+    (f/entry :information_source ShortString
              :description (str "Specifies the source of the information about "
                                "the relationship between the two components."))
-    (f/entry :relationship f/any-str)))
+    (f/entry :relationship ShortString)))
   :description "Describes a related Identity"
   :reference "[RelatedIdentityType](http://stixproject.github.io/data-model/1.2/stixCommon/RelatedIdentityType/)")
 
@@ -623,7 +623,7 @@
   :gen (cs/gen relation-types))
 
 (def-map-type ObservedRelation
-  [(f/entry :origin f/any-str)
+  [(f/entry :origin ShortString)
    (f/entry :origin_uri URI
             :required? false)
    (f/entry :relation ObservableRelationType)
@@ -647,12 +647,12 @@
     (f/entry :observables [Observable])
     (f/entry :observed_time ObservedTime))
    (f/optional-entries
-    (f/entry :os f/any-str)))
+    (f/entry :os ShortString)))
   :description "Describes the target of the sighting and contains identifying observables for the target.")
 
 (def scalar
   (f/conditional
-   #(string? %) f/any-str
+   #(string? %) MedString
    #(number? %) f/any-num
    #(inst? %) f/any-inst
    #(keyword? %) f/any-keyword

--- a/src/ctim/schemas/data_table.cljc
+++ b/src/ctim/schemas/data_table.cljc
@@ -29,13 +29,13 @@
 (def-map-type ColumnDefinition
   (concat
    (f/required-entries
-    (f/entry :name f/any-str)
+    (f/entry :name c/ShortString)
     (f/entry :type ColumnType))
    (f/optional-entries
     (f/entry :description c/Markdown)
     (f/entry :required f/any-bool
              :description "If `true`, the row entries for this column cannot contain `nulls`. Defaults to `true`.")
-    (f/entry :short_description f/any-str))))
+    (f/entry :short_description c/ShortString))))
 
 (def Datum
   "A generic data object, this is really limited to the types

--- a/src/ctim/schemas/feedback.cljc
+++ b/src/ctim/schemas/feedback.cljc
@@ -16,7 +16,7 @@
    (f/entry :type FeedbackTypeIdentifier)
    (f/entry :entity_id c/Reference)
    (f/entry :feedback #{-1 0 1})
-   (f/entry :reason f/any-str)))
+   (f/entry :reason c/ShortString)))
 
 (def-entity-type NewFeedback
   "Schema for submitting new Feedback."

--- a/src/ctim/schemas/identity_assertion.cljc
+++ b/src/ctim/schemas/identity_assertion.cljc
@@ -71,7 +71,7 @@
 (def-map-type Assertion
   (f/required-entries
    (f/entry :name AssertionType)
-   (f/entry :value f/any-str)))
+   (f/entry :value c/ShortString)))
 
 (def-map-type IdentityCoordinates
   (f/required-entries

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -2,6 +2,7 @@
   (:require [ctim.schemas.common :as c]
             [ctim.schemas.relationship :as rel]
             [ctim.schemas.vocabularies :as v]
+            [ctim.lib.predicates :as pred]
             #?(:clj  [flanders.core :as f :refer [def-entity-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-entity-type def-map-type def-eq]])
             #?(:clj [clojure.test.check.generators :as gen])))
@@ -127,13 +128,15 @@
             :description "metadata associated to the incident.")
    (f/entry :scores IncidentScores
             :description "Used to indicate the severity or impact score of the threat represented by the incident.")
-   (f/entry :categories [v/IncidentCategory]
+   (f/entry :categories (f/seq-of v/IncidentCategory
+                                  :spec (pred/max-len c/default-collection-max-len))
             :description "A set of categories for this incident.")
    (f/entry :discovery_method v/DiscoveryMethod
             :description "Identifies how the incident was discovered.")
    (f/entry :intended_effect v/IntendedEffect
             :description "Specifies the suspected intended effect of this incident")
-   (f/entry :assignees [c/ShortString]
+   (f/entry :assignees (f/seq-of c/ShortString
+                                 :spec (pred/max-len c/default-collection-max-len))
             :description "A set of owners assigned to this incident.")
    (f/entry :detection_sources [c/MedString]
             :description "A set of sources that contributed threat detections to the incident.")
@@ -164,13 +167,15 @@
                               "interpreted differently by different organizations or analysts. Therefore, it "
                               "should be used in conjunction with other intelligence attributes, such as the "
                               "`confidence` field, to provide a more comprehensive view of the incident."))
-   (f/entry :tactics [c/ShortString]
+   (f/entry :tactics (f/seq-of c/ShortString
+                              :spec (pred/max-len c/default-collection-max-len))
             :description (str "Represents the offensive techniques, approaches, or procedures that an adversary "
                               "may use to achieve their objectives during an attack. It helps in understanding "
                               "the intent and capabilities of the adversary and can be used to identify "
                               "indicators of attack (IoAs) or indicators of compromise (IoCs) that are "
                               "associated with the adversary's tactics."))
-   (f/entry :techniques [c/ShortString]
+   (f/entry :techniques (f/seq-of c/ShortString
+                                  :spec (pred/max-len c/default-collection-max-len))
             :description (str "Represents the specific methods or actions used by an attacker "
                               "to carry out an offensive maneuver or achieve their goals."))
    (f/entry :short_id c/ShortString

--- a/src/ctim/schemas/indicator.cljc
+++ b/src/ctim/schemas/indicator.cljc
@@ -28,9 +28,9 @@
 
 (def-map-type ThreatBrainSpecification
   [(f/entry :type ThreatBrainSpecificationType)
-   (f/entry :query f/any-str
+   (f/entry :query c/MedString
             :required? false)
-   (f/entry :variables f/any-str-seq)]
+   (f/entry :variables (f/seq-of c/ShortString))]
   :description "An indicator which runs in threatbrain...")
 
 (def-eq SnortSpecificationType "Snort")
@@ -38,7 +38,7 @@
 (def-map-type SnortSpecification
   (f/required-entries
    (f/entry :type SnortSpecificationType)
-   (f/entry :snort_sig f/any-str))
+   (f/entry :snort_sig c/MedString))
   :description "An indicator which runs in snort...")
 
 (def-eq SIOCSpecificationType "SIOC")
@@ -46,7 +46,7 @@
 (def-map-type SIOCSpecification
   (f/required-entries
    (f/entry :type SIOCSpecificationType)
-   (f/entry :SIOC f/any-str))
+   (f/entry :SIOC c/MedString))
   :description "An indicator which runs in snort...")
 
 (def-eq OpenIOCSpecificationType "OpenIOC")
@@ -54,7 +54,7 @@
 (def-map-type OpenIOCSpecification
   (f/required-entries
    (f/entry :type OpenIOCSpecificationType)
-   (f/entry :open_IOC f/any-str))
+   (f/entry :open_IOC c/MedString))
   :description "An indicator which contains an XML blob of an openIOC indicator.")
 
 (def-enum-type BooleanOperator

--- a/src/ctim/schemas/note.cljc
+++ b/src/ctim/schemas/note.cljc
@@ -13,7 +13,7 @@
 
 (def-map-type NoteRelatedEntity
   (f/required-entries
-   (f/entry :entity_type f/any-str)
+   (f/entry :entity_type c/ShortString)
    (f/entry :entity_id c/Reference)))
 
 (def-entity-type Note
@@ -27,7 +27,7 @@ For example, an analyst may add a Note to a Campaign object created by another o
    (f/entry :content c/Markdown)
    (f/entry :related_entities (f/seq-of NoteRelatedEntity)))
   (f/optional-entries
-   (f/entry :author f/any-str)))
+   (f/entry :author c/ShortString)))
 
 (def-entity-type NewNote
   "Schema for submitting Notes"

--- a/src/ctim/schemas/openc2_network.cljc
+++ b/src/ctim/schemas/openc2_network.cljc
@@ -1,5 +1,6 @@
 (ns ctim.schemas.openc2-network
-  (:require [ctim.schemas.openc2vocabularies :as openc2v]
+  (:require [ctim.schemas.common :as c]
+            [ctim.schemas.openc2vocabularies :as openc2v]
             #?(:clj  [flanders.core :as f :refer [def-enum-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-enum-type def-map-type def-eq]])))
 
@@ -7,13 +8,13 @@
 
 (def-map-type BGPBlackhole
   [(f/entry :type BGPBlackholeTypeIdentifier)
-   (f/entry :host f/any-str)])
+   (f/entry :host c/ShortString)])
 
 (def-eq DNSSinkholeTypeIdentifier "DNSSinkhole")
 
 (def-map-type DNSSinkhole
   [(f/entry :type DNSSinkholeTypeIdentifier)
-   (f/entry :host f/any-str)])
+   (f/entry :host c/ShortString)])
 
 (def protocol
   #{"TCP"
@@ -35,10 +36,10 @@
 
 (def-map-type Traffic
   [(f/entry :protocol Protocol)
-   (f/entry :source_address f/any-str)
-   (f/entry :source_port f/any-str)
-   (f/entry :destination_address f/any-str)
-   (f/entry :destination_port f/any-str)])
+   (f/entry :source_address c/ShortString)
+   (f/entry :source_port c/ShortString)
+   (f/entry :destination_address c/ShortString)
+   (f/entry :destination_port c/ShortString)])
 
 (def-eq NetworkACLTypeIdentifier "NetworkACL")
 
@@ -48,17 +49,17 @@
    (f/entry :action ACLAction)])
 
 (def-map-type VLANProfile
-  [(f/entry :vlan_tag f/any-str)])
+  [(f/entry :vlan_tag c/ShortString)])
 
 (def-map-type SecGroupProfile
-  [(f/entry :sec_group_tag f/any-str)
-   (f/entry :sec_group_ACL f/any-str)])
+  [(f/entry :sec_group_tag c/ShortString)
+   (f/entry :sec_group_ACL c/ShortString)])
 
 (def-eq RemediationTypeIdentifier "Remediation")
 
 (def-map-type Remediation
   [(f/entry :type RemediationTypeIdentifier)
-   (f/entry :server f/any-str)
+   (f/entry :server c/ShortString)
    (f/entry :ACL NetworkACL)
    ;; (f/entry :containment_profile_VLAN VLANProfile
    ;;          :required? false)
@@ -70,19 +71,19 @@
 
 (def-map-type NonSensitive
   [(f/entry :type NonSensitiveTypeIdentifier)
-   (f/entry :permissible_IPs f/any-string-seq)
+   (f/entry :permissible_IPs (f/seq-of c/ShortString))
    (f/entry :ACL NetworkACL)])
 
 (def-map-type HoneyPotRoutes
-  [(f/entry :prefix f/any-str)
-   (f/entry :next_hop f/any-str)
-   (f/entry :next_hope_type f/any-str)])
+  [(f/entry :prefix c/ShortString)
+   (f/entry :next_hop c/ShortString)
+   (f/entry :next_hope_type c/ShortString)])
 
 (def-eq HoneyPotTypeIdentifier "Honeypot")
 
 (def-map-type HoneyPot
   [(f/entry :type HoneyPotTypeIdentifier)
-   (f/entry :permissible_IPs f/any-str-seq)
+   (f/entry :permissible_IPs (f/seq-of c/ShortString))
    (f/entry :ACL NetworkACL)
    (f/entry :routes HoneyPotRoutes)])
 
@@ -118,8 +119,8 @@
   (concat
    [(f/entry :type InspectModifierTypeIdentifier)]
    (f/optional-entries
-    (f/entry :profile f/any-str)
-    (f/entry :server f/any-str)
+    (f/entry :profile c/ShortString)
+    (f/entry :server c/ShortString)
     (f/entry :encapsulation Encapsulation))))
 
 (def-eq PacketCaptureModifierTypeIdentifier "PacketCapture")
@@ -128,5 +129,5 @@
   (concat
    [(f/entry :type PacketCaptureModifierTypeIdentifier)]
    (f/optional-entries
-    (f/entry :server f/any-str)
+    (f/entry :server c/ShortString)
     (f/entry :traffic Traffic))))

--- a/src/ctim/schemas/openc2_network_sdn.cljc
+++ b/src/ctim/schemas/openc2_network_sdn.cljc
@@ -1,5 +1,6 @@
 (ns ctim.schemas.openc2-network-sdn
-  (:require #?(:clj  [flanders.core :as f :refer [def-enum-type def-map-type def-eq]]
+  (:require [ctim.schemas.common :as c]
+            #?(:clj  [flanders.core :as f :refer [def-enum-type def-map-type def-eq]]
                :cljs [flanders.core :as f :refer-macros [def-enum-type def-map-type def-eq]])))
 
 
@@ -14,4 +15,4 @@
 (def-map-type Scan
   [(f/entry :type ScanTypeIdentifier)
    (f/entry :method ScanMethods)
-   (f/entry :search f/any-str)])
+   (f/entry :search c/ShortString)])

--- a/src/ctim/schemas/relationship.cljc
+++ b/src/ctim/schemas/relationship.cljc
@@ -53,8 +53,8 @@
 (def relationship-entries
   (f/optional-entries
    (f/entry :confidence v/HighMedLow)
-   (f/entry :source f/any-str)
-   (f/entry :relationship f/any-str)))
+   (f/entry :source c/ShortString)
+   (f/entry :relationship c/ShortString)))
 
 (def-map-type RelatedIndicator
   (concat

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -26,8 +26,8 @@
 
 (def max-data-table-columns 100)
 (def max-data-table-rows 10000)
-(def max-sighting-targets 1000)
-(def max-sighting-observables 2000)
+(def max-sighting-targets 2000)
+(def max-sighting-observables 5000)
 (def max-sighting-relations 10000)
 
 (def-map-type SensorCoordinates

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -7,6 +7,7 @@
       [ctim.schemas.sighting.context :as ctx]
       [ctim.schemas.vocabularies :as v]
       [ctim.schemas.data-table :as dt]
+      [ctim.lib.predicates :as pred]
       [flanders.core :as f :refer [def-entity-type def-eq def-map-type]])]
     :cljs
     [(:require
@@ -15,12 +16,19 @@
       [ctim.schemas.sighting.context :as ctx]
       [ctim.schemas.vocabularies :as v]
       [ctim.schemas.data-table :as dt]
+      [ctim.lib.predicates :as pred]
       [flanders.core
        :as
        f
        :refer-macros
        [def-entity-type def-eq def-map-type]])]))
 
+
+(def max-data-table-columns 100)
+(def max-data-table-rows 10000)
+(def max-sighting-targets 1000)
+(def max-sighting-observables 2000)
+(def max-sighting-relations 10000)
 
 (def-map-type SensorCoordinates
   (concat
@@ -36,9 +44,11 @@
 (def-map-type SightingDataTable
   (concat
    (f/required-entries
-    (f/entry :columns (f/seq-of dt/ColumnDefinition)
+    (f/entry :columns (f/seq-of dt/ColumnDefinition
+                                        :spec (pred/max-len max-data-table-columns))
              :description "an ordered list of column definitions")
-    (f/entry :rows (f/seq-of (f/seq-of dt/Datum))
+    (f/entry :rows (f/seq-of (f/seq-of dt/Datum)
+                              :spec (pred/max-len max-data-table-rows))
              :description "an ordered list of rows"))
    (f/optional-entries
     (f/entry :row_count f/any-int
@@ -101,7 +111,8 @@
                               "device that is creating this sighting (e.g. "
                               "network.firewall)"))
    (f/entry :sensor_coordinates SensorCoordinates)
-   (f/entry :targets (f/seq-of c/IdentitySpecification)
+   (f/entry :targets (f/seq-of c/IdentitySpecification
+                               :spec (pred/max-len max-sighting-targets))
             :description (str "May include one or more targets that observed the associated indicator. Targets "
                               "can include network devices, host devices, or other entities that are capable of "
                               "detecting indicators of compromise."
@@ -112,9 +123,11 @@
                               "different systems within an organization, the `targets` field may indicate which "
                               "systems are affected and which may need to be isolated or patched to prevent "
                               "further spread."))
-   (f/entry :observables [c/Observable]
+   (f/entry :observables (f/seq-of c/Observable
+                                   :spec (pred/max-len max-sighting-observables))
             :description "The object(s) of interest.")
-   (f/entry :relations [c/ObservedRelation]
+   (f/entry :relations (f/seq-of c/ObservedRelation
+                                 :spec (pred/max-len max-sighting-relations))
             :description (str "Provide any context we can about where the "
                               "observable came from."))
    (f/entry :context ctx/Context

--- a/src/ctim/schemas/sighting.cljc
+++ b/src/ctim/schemas/sighting.cljc
@@ -36,7 +36,7 @@
     (f/entry :type v/Sensor)
     (f/entry :observables [c/Observable]))
    (f/optional-entries
-    (f/entry :os f/any-str)))
+    (f/entry :os c/ShortString)))
   :description "Describes the device that made the sighting (sensor) and contains identifying observables for the sensor.")
 
 ;; A generic table of data, consisting of types and documented

--- a/src/ctim/schemas/sighting/context.cljc
+++ b/src/ctim/schemas/sighting/context.cljc
@@ -109,15 +109,15 @@
     (f/entry :protocol f/any-int
              :description
              "The IP [protocol id](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)")
-    (f/entry :source_ip f/any-str)
-    (f/entry :destination_ip f/any-str)
+    (f/entry :source_ip c/ShortString)
+    (f/entry :destination_ip c/ShortString)
     (f/entry :source_port f/any-int)
     (f/entry :destination_port f/any-int)
     (f/entry :direction TrafficDirection))
    (f/optional-entries
-    (f/entry :destination_host_name f/any-str)
-    (f/entry :source_subnet f/any-str)
-    (f/entry :destination_subnet f/any-str))))
+    (f/entry :destination_host_name c/ShortString)
+    (f/entry :source_subnet c/ShortString)
+    (f/entry :destination_subnet c/ShortString))))
 
 (def netflow-type-identifier "NetflowEvent")
 (def-eq NetflowTypeIdentifier netflow-type-identifier)

--- a/src/ctim/schemas/target_record.cljc
+++ b/src/ctim/schemas/target_record.cljc
@@ -18,11 +18,11 @@
   "Schema for TargetRecord Targets"
   (:entries c/IdentitySpecification)
   (f/optional-entries
-   (f/entry :os f/any-str
+   (f/entry :os c/ShortString
             :description (str "Source Operating System where TargetRecord was originated."))
    (f/entry :internal (f/bool :default false)
             :description "Is it internal to our network?")
-   (f/entry :sensor f/any-str
+   (f/entry :sensor c/ShortString
             :description (str "The OpenC2 Actuator name that best fits the "
                               "device that is creating this TargetRecord (e.g.: "
                               "network.firewall, etc.)"))


### PR DESCRIPTION
> **Epic** [XDR-46972](https://cisco-sbg.atlassian.net/browse/XDR-46972)
> Related [flanders#58](https://github.com/threatgrid/flanders/pull/58)
> Related [ctia#1514](https://github.com/threatgrid/ctia/pull/1514)

Add `pred/max-len` constraints to collection fields in sighting, incident, and common schemas.

### Changes

- Bump flanders to `1.1.1-SNAPSHOT` (adds `:spec` support on `SequenceOfType`, `SetOfType`, and `MapType`)
- Add `default-collection-max-len` (500) constant in `common.cljc` for shared collection fields
- Constrain `external_ids` and `external_references` in base entity entries
- Add specific limits for sighting fields:
  - `columns`: 100, `rows`: 10,000
  - `targets`: 2,000, `observables`: 5,000, `relations`: 10,000
- Constrain incident fields (`categories`, `assignees`, `tactics`, `techniques`) to 500
- Add `relation_info.actions` limit of 1,000
- Add `{:max-len len}` metadata to `pred/max-len` for downstream 413 error reporting
- Replace unbounded `f/any-str` with typed string constraints (`ShortString`, `MedString`, `LongString`)

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed. All 139 existing tests (including generative tests) pass.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Add size constraints to CTIM collection fields.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

[XDR-46972]: https://cisco-sbg.atlassian.net/browse/XDR-46972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ