### PR TITLE
Make incident short_id nullable

### DIFF
--- a/src/ctim/examples/incidents.cljc
+++ b/src/ctim/examples/incidents.cljc
@@ -61,6 +61,9 @@
    :schema_version c/ctim-schema-version
    :confidence "High"})
 
+(def incident-maximal-nil-short-id
+  (assoc incident-maximal :short_id nil))
+
 (def new-incident-maximal
   incident-maximal)
 

--- a/src/ctim/schemas/common.cljc
+++ b/src/ctim/schemas/common.cljc
@@ -140,6 +140,15 @@
          :name "Markdown"
          :description "Markdown string with at most 5000 characters."))
 
+(cs/def ::nullable-short-string
+  (cs/or :string (cs/and string? (pred/max-len 1024))
+         :nil nil?))
+
+(def NullableShortString
+  (f/anything :spec ::nullable-short-string
+              :description "String with at most 1024 characters, or null."
+              :name "NullableShortString"))
+
 (def OpenVocab
   (f/str :description (str "SHOULD be all lowercase (where lowercase is defined by the "
                            "locality conventions) and SHOULD use hyphens instead of "

--- a/src/ctim/schemas/incident.cljc
+++ b/src/ctim/schemas/incident.cljc
@@ -173,8 +173,8 @@
    (f/entry :techniques [c/ShortString]
             :description (str "Represents the specific methods or actions used by an attacker "
                               "to carry out an offensive maneuver or achieve their goals."))
-   (f/entry :short_id c/ShortString
-            :description "A human-readable, short identifier for the incident, unique within an organization.")))
+   (f/entry :short_id c/NullableShortString
+            :description "A human-readable, short identifier for the incident, unique within an organization. Can be null.")))
 
 (def-entity-type NewIncident
   "For submitting a new Incident."

--- a/test/ctim/schemas/entities_test.cljc
+++ b/test/ctim/schemas/entities_test.cljc
@@ -143,6 +143,7 @@
   (validate-entities
    [ice/incident-maximal ics/Incident]
    [ice/incident-minimal ics/Incident]
+   [ice/incident-maximal-nil-short-id ics/Incident]
    [ice/incident-maximal  (-> ics/Incident
                               fu/replace-either-with-any
                               fu/require-all)]


### PR DESCRIPTION
## Summary

- Add `NullableShortString` type to `ctim.schemas.common` that accepts a string (max 1024 chars) or null
- Uses `f/anything` with a registered nilable spec to work around Flanders lacking native nullable support
- Update incident schema `short_id` field to use `NullableShortString`
- Add nil short_id example and test coverage

## Test plan

- [x] `lein test :no-gen` passes (43 tests, 416 assertions, 0 failures)
- [ ] Verify CTIA integration handles nullable short_id correctly