### PR TITLE
Add cisco:ctr:device:past_ids to the identity-assertion vocabulary (XDR-48383)

### DIFF
--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -11117,7 +11117,7 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is required
 
 
-  * *AssertionType* An open vocabulary containing well known assertion types. An Assertion :value is always a single string; a multi-valued assertion is expressed by repeating the entry once per value. For example, cisco:ctr:device:past_ids lists the device ids a device was previously known by - before duplicate posture endpoints were merged into one device - as one entry per past id.
+  * *AssertionType* An open vocabulary containing well known assertion types. This vocabulary is shared by IdentityAssertion assertions and AssetProperty properties; both are name/value pairs whose `value` is a single string. Plural-named entries (for example cisco:ctr:user:emails, cisco:ctr:user:groups, cisco:ctr:device:past_ids) carry a JSON-encoded array of strings in that single `value` and must be JSON-decoded by consumers; they are not repeated once per value. cisco:ctr:device:past_ids lists the ids a device was previously known by, after duplicate device records were merged into one.
   * Allowed Values:
     * cisco:ctr:ad:host_domain_name
     * cisco:ctr:ad:host_resolved_dns

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -11117,7 +11117,7 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is required
 
 
-  * *AssertionType* An open vocabulary containing well known assertion types
+  * *AssertionType* An open vocabulary containing well known assertion types. An Assertion :value is always a single string; a multi-valued assertion is expressed by repeating the entry once per value. For example, cisco:ctr:device:past_ids lists the device ids a device was previously known by - before duplicate posture endpoints were merged into one device - as one entry per past id.
   * Allowed Values:
     * cisco:ctr:ad:host_domain_name
     * cisco:ctr:ad:host_resolved_dns
@@ -11149,6 +11149,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * cisco:ctr:device:os_version
     * cisco:ctr:device:os_version_name
     * cisco:ctr:device:owner
+    * cisco:ctr:device:past_ids
     * cisco:ctr:device:posture
     * cisco:ctr:device:security_group
     * cisco:ctr:device:serial_number

--- a/doc/structures/bundle.md
+++ b/doc/structures/bundle.md
@@ -11108,7 +11108,7 @@ If not present, the valid time position of the indicator does not have an upper 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[name](#propertyname-assertiontypestring)|AssertionTypeString| |&#10003;|
-|[value](#propertyvalue-string)|String| |&#10003;|
+|[value](#propertyvalue-string)|String|The assertion value, always a single string. Plural-named entries (see AssertionType) carry a JSON-encoded array of strings in this single field and must be JSON-decoded by consumers.|&#10003;|
 
 
 <a id="propertyname-assertiontypestring"></a>
@@ -11174,6 +11174,8 @@ If not present, the valid time position of the indicator does not have an upper 
 
 <a id="propertyvalue-string"></a>
 ## Property value ∷ String
+
+The assertion value, always a single string. Plural-named entries (see AssertionType) carry a JSON-encoded array of strings in this single field and must be JSON-decoded by consumers.
 
 * This entry is required
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -5390,7 +5390,7 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is required
 
 
-  * *AssertionType* An open vocabulary containing well known assertion types
+  * *AssertionType* An open vocabulary containing well known assertion types. An Assertion :value is always a single string; a multi-valued assertion is expressed by repeating the entry once per value. For example, cisco:ctr:device:past_ids lists the device ids a device was previously known by - before duplicate posture endpoints were merged into one device - as one entry per past id.
   * Allowed Values:
     * cisco:ctr:ad:host_domain_name
     * cisco:ctr:ad:host_resolved_dns
@@ -5422,6 +5422,7 @@ If not present, the valid time position of the indicator does not have an upper 
     * cisco:ctr:device:os_version
     * cisco:ctr:device:os_version_name
     * cisco:ctr:device:owner
+    * cisco:ctr:device:past_ids
     * cisco:ctr:device:posture
     * cisco:ctr:device:security_group
     * cisco:ctr:device:serial_number

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -5381,7 +5381,7 @@ If not present, the valid time position of the indicator does not have an upper 
 | Property | Type | Description | Required? |
 | -------- | ---- | ----------- | --------- |
 |[name](#propertyname-assertiontypestring)|AssertionTypeString| |&#10003;|
-|[value](#propertyvalue-string)|String| |&#10003;|
+|[value](#propertyvalue-string)|String|The assertion value, always a single string. Plural-named entries (see AssertionType) carry a JSON-encoded array of strings in this single field and must be JSON-decoded by consumers.|&#10003;|
 
 
 <a id="propertyname-assertiontypestring"></a>
@@ -5447,6 +5447,8 @@ If not present, the valid time position of the indicator does not have an upper 
 
 <a id="propertyvalue-string"></a>
 ## Property value ∷ String
+
+The assertion value, always a single string. Plural-named entries (see AssertionType) carry a JSON-encoded array of strings in this single field and must be JSON-decoded by consumers.
 
 * This entry is required
 

--- a/doc/structures/casebook.md
+++ b/doc/structures/casebook.md
@@ -5390,7 +5390,7 @@ If not present, the valid time position of the indicator does not have an upper 
 * This entry is required
 
 
-  * *AssertionType* An open vocabulary containing well known assertion types. An Assertion :value is always a single string; a multi-valued assertion is expressed by repeating the entry once per value. For example, cisco:ctr:device:past_ids lists the device ids a device was previously known by - before duplicate posture endpoints were merged into one device - as one entry per past id.
+  * *AssertionType* An open vocabulary containing well known assertion types. This vocabulary is shared by IdentityAssertion assertions and AssetProperty properties; both are name/value pairs whose `value` is a single string. Plural-named entries (for example cisco:ctr:user:emails, cisco:ctr:user:groups, cisco:ctr:device:past_ids) carry a JSON-encoded array of strings in that single `value` and must be JSON-decoded by consumers; they are not repeated once per value. cisco:ctr:device:past_ids lists the ids a device was previously known by, after duplicate device records were merged into one.
   * Allowed Values:
     * cisco:ctr:ad:host_domain_name
     * cisco:ctr:ad:host_resolved_dns

--- a/src/ctim/examples/identity_assertions.cljc
+++ b/src/ctim/examples/identity_assertions.cljc
@@ -25,8 +25,8 @@
                             {:type "ip" :value "1.2.3.4"}]}
    :assertions [{:name "cisco:ctr:device:security_group" :value "employees"}
                 {:name "cisco:ctr:device:connector_version" :value "1.12.0 Mac Connector"}
-                {:name "cisco:ctr:device:past_ids" :value "00-00-00-01"}
-                {:name "cisco:ctr:device:past_ids" :value "00-00-00-02"}]
+                {:name "cisco:ctr:device:id" :value "00-00-00-01"}
+                {:name "cisco:ctr:device:past_ids" :value "[\"00-00-00-08\",\"00-00-00-09\"]"}]
    :valid_time {:start_time #inst "2020-01-11T00:40:48.212-00:00"
                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}})
 

--- a/src/ctim/examples/identity_assertions.cljc
+++ b/src/ctim/examples/identity_assertions.cljc
@@ -24,7 +24,9 @@
                             {:type "s1_agent_id" :value "897194377714833828"}
                             {:type "ip" :value "1.2.3.4"}]}
    :assertions [{:name "cisco:ctr:device:security_group" :value "employees"}
-                {:name "cisco:ctr:device:connector_version" :value "1.12.0 Mac Connector"}]
+                {:name "cisco:ctr:device:connector_version" :value "1.12.0 Mac Connector"}
+                {:name "cisco:ctr:device:past_ids" :value "00-00-00-01"}
+                {:name "cisco:ctr:device:past_ids" :value "00-00-00-02"}]
    :valid_time {:start_time #inst "2020-01-11T00:40:48.212-00:00"
                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}})
 

--- a/src/ctim/schemas/identity_assertion.cljc
+++ b/src/ctim/schemas/identity_assertion.cljc
@@ -68,13 +68,16 @@
   assertion
   :open? true
   :description (str "An open vocabulary containing well known assertion types. "
-                    "An Assertion :value is always a single string; a "
-                    "multi-valued assertion is expressed by repeating the "
-                    "entry once per value. For example, "
-                    "cisco:ctr:device:past_ids lists the device ids a device "
-                    "was previously known by - before duplicate posture "
-                    "endpoints were merged into one device - as one entry per "
-                    "past id."))
+                    "This vocabulary is shared by IdentityAssertion assertions "
+                    "and AssetProperty properties; both are name/value pairs "
+                    "whose `value` is a single string. Plural-named entries "
+                    "(for example cisco:ctr:user:emails, cisco:ctr:user:groups, "
+                    "cisco:ctr:device:past_ids) carry a JSON-encoded array of "
+                    "strings in that single `value` and must be JSON-decoded by "
+                    "consumers; they are not repeated once per value. "
+                    "cisco:ctr:device:past_ids lists the ids a device was "
+                    "previously known by, after duplicate device records were "
+                    "merged into one."))
 
 (def-map-type Assertion
   (f/required-entries

--- a/src/ctim/schemas/identity_assertion.cljc
+++ b/src/ctim/schemas/identity_assertion.cljc
@@ -82,7 +82,11 @@
 (def-map-type Assertion
   (f/required-entries
    (f/entry :name AssertionType)
-   (f/entry :value f/any-str)))
+   (f/entry :value f/any-str
+            :description (str "The assertion value, always a single string. "
+                              "Plural-named entries (see AssertionType) carry a "
+                              "JSON-encoded array of strings in this single "
+                              "field and must be JSON-decoded by consumers."))))
 
 (def-map-type IdentityCoordinates
   (f/required-entries

--- a/src/ctim/schemas/identity_assertion.cljc
+++ b/src/ctim/schemas/identity_assertion.cljc
@@ -9,6 +9,7 @@
 (def-eq IdentityAssertionTypeIdentifier type-identifier)
 
 (def assertion #{"cisco:ctr:device:id"
+                 "cisco:ctr:device:past_ids"
                  "cisco:ctr:device:name"
                  "cisco:ctr:device:type"
                  "cisco:ctr:device:owner"
@@ -66,7 +67,14 @@
 (def-enum-type AssertionType
   assertion
   :open? true
-  :description (str "An open vocabulary containing well known assertion types"))
+  :description (str "An open vocabulary containing well known assertion types. "
+                    "An Assertion :value is always a single string; a "
+                    "multi-valued assertion is expressed by repeating the "
+                    "entry once per value. For example, "
+                    "cisco:ctr:device:past_ids lists the device ids a device "
+                    "was previously known by - before duplicate posture "
+                    "endpoints were merged into one device - as one entry per "
+                    "past id."))
 
 (def-map-type Assertion
   (f/required-entries


### PR DESCRIPTION
**JIRA** https://cisco-sbg.atlassian.net/browse/XDR-48383

## Summary

Adds `cisco:ctr:device:past_ids` to the IdentityAssertion open vocabulary, so
providers can record the device ids a device was previously known by.

Device Insights merges duplicate device records into a single device. Before
XDR-48383 the merged-away id was lost, so "query asset by id" against the old id
failed even though the device still existed. This field publishes the past ids
for that lookup.

Requested by @zterlizz for Device ID Tracking in Assets.

## Changes

- `src/ctim/schemas/identity_assertion.cljc` -- adds `cisco:ctr:device:past_ids`
  to the `assertion` set; rewrites the `AssertionType` `:description` to document
  the multi-value encoding the producer actually emits (see below).
- `src/ctim/examples/identity_assertions.cljc` -- `identity-assertion-maximal`
  gains a `cisco:ctr:device:id` entry plus a `cisco:ctr:device:past_ids` entry
  carrying a JSON-encoded array, demonstrating the current-id / past-ids pairing.
- `doc/structures/bundle.md`, `doc/structures/casebook.md` -- regenerated with
  `lein doc`.

## Two things worth a reviewer's attention

**1. This changes no validation behavior.** `AssertionType` is `:open? true`,
which flanders compiles to plain `s/Str` -- the vocabulary set is erased at
compile time. An unlisted assertion name already validated before this change
(`s/check` on `{:name "cisco:ctr:device:past_ids" :value "x"}` returned `nil`
against `origin/master`). The value of this PR is discoverability and a
published contract, not enforcement.

**2. Multi-valued assertions are carried as a JSON-encoded array inside the
single `:value` string.** `Assertion` is `{:name Str, :value Str}` -- `:value`
is a single string. The Device Insights producer encodes any non-string value
as a JSON-encoded array of strings in that one `:value`, and this is its blanket
rule for every plural-named entry (`cisco:ctr:user:emails`, `:groups`,
`:phone_numbers`, `cisco:ctr:device:past_ids`); the acceptance test JSON-decodes
the value. The description now documents that shape:

```clojure
:assertions [{:name "cisco:ctr:device:id" :value "00-00-00-01"}
             {:name "cisco:ctr:device:past_ids" :value "[\"00-00-00-08\",\"00-00-00-09\"]"}]
```

This matches the 11 plural-named entries already in the vocabulary
(`cisco:ctr:user:emails`, `:phone_numbers`, `:roles`, `:groups`,
`:entitlements`, `cisco:ctr:device:administrators`, the four
`cisco:ctr:ad:*_resolved_*`, and `cisco:ctr:common:ir_attributes`), all of which
carry `:value Str`. Because `:value` is `s/Str`, a nested array is invisible to
schema validation -- consumers must JSON-decode it. A consumer that collapses
assertions with `(into {} (map (juxt :name :value)))` keeps the array string
intact under one key, which is the intended shape.

Alternatives considered and rejected:

- A singular `past_id` name would be the vocabulary's only singular-repeat
  entry, contradicting 11 plural siblings.
- Repeating the entry once per id -- the convention this PR originally
  documented -- is not what any producer emits (see @msprunck's review thread,
  which verified the producer directly). Documenting it would have marked the
  only producer non-conformant and prescribed a shape no consumer receives.
- Widening `Assertion :value` to accept arrays, or adding an optional `:values`
  entry, is forward-incompatible, not merely a contract change: flanders map
  types compile to closed maps, so any consumer validating against an older CTIM
  jar rejects the extra/retyped key as a disallowed-key error.

## Testing

- JVM: `lein with-profile -user test` -- 139 tests, 510 assertions, 0 failures.
- ClojureScript (the path CI actually gates on --
  `.github/workflows/build.yml:57` runs `lein do clean, compile :all, doo node
  node once`; there is no `lein test` step in CI):
  `lein with-profile -user do clean, doo node node once` -- 36 tests, 147
  assertions, 0 failures.
- `lein doc` regenerates `doc/structures/bundle.md` and `casebook.md` with the
  new description.
- Note on `doc/json`: `lein doc` on a `-SNAPSHOT` version also rewrites
  `schema_version` in 21 `doc/json/*.json` files (`1.3.30` -> `1.3.30-SNAPSHOT`);
  that churn is pre-existing and unrelated, so it is excluded here. This
  description edit does not rewrite `doc/json` on its own, but the earlier claim
  that `doc/json`'s example value is "vocabulary-independent" is not accurate:
  the flanders enum's `:default` is `(-> values sort first)` and `->json` does
  not null defaults, so `doc/json/bundle.json` and `casebook.json` escape churn
  here only because `cisco:ctr:ad:host_domain_name` still sorts first. A future
  vocabulary addition that sorts earlier (e.g. a `cisco:ctr:aa:*` name) WILL
  rewrite those files -- the next contributor adding such a name must regenerate.

## QA

1. Post a bundle containing an IdentityAssertion whose `:assertions` include a
   `cisco:ctr:device:past_ids` entry whose `:value` is a JSON-encoded array of
   ids (e.g. `"[\"00-00-00-08\",\"00-00-00-09\"]"`); confirm it round-trips and
   the value is preserved verbatim for consumers to JSON-decode.
2. Confirm `cisco:ctr:device:past_ids` appears in the AssertionType vocabulary
   in the generated docs (`doc/structures/bundle.md`, `casebook.md`).
3. Regression: confirm an assertion using an existing name
   (e.g. `cisco:ctr:device:id`) still validates unchanged.

## Out of scope (pre-existing, filed separately if wanted)

`doc/README.md:45,72` link to `structures/identity_assertion.md` and
`json/identity_assertion.json`, which have never been generated -- there are no
IdentityAssertion rows in `src/ctim/document.clj`. Dead since the entity was
added in 2019 (e5f4e62). Not touched here to keep this diff minimal.

## Rejected findings

- **Cross-reference the multiplicity convention on `:assertions` `:description` (L100-101)** (msprunck, 2026-08-12 approval) -- Declined. The convention now lives on the exact field it governs (`Assertion` `:value`, added in `7cd2fb4`) and on `AssertionType`. `:assertions` describes the collection at a higher level; duplicating the encoding rule a third time on the parent collection adds drift risk without giving a decoding consumer a new surface to read. The `:value` cross-reference from the same review was addressed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

